### PR TITLE
Feature/improve subject revert

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2148,7 +2148,12 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                         assert it instanceof Map, "Error reverting ${fieldId} - expected object, got: ${it}"
                         if (uriTemplateBase) {
                             if (!it['@id'] || !it['@id'].startsWith(uriTemplateBase)) {
-                                return false
+                                boolean aliasMatchesBase = Util.asList(it['sameAs']).any {
+                                    it.get('@id')?.startsWith(uriTemplateBase)
+                                }
+                                if (!aliasMatchesBase) {
+                                    return false
+                                }
                             }
                         }
                         return isInstanceOf(it, useLink.resourceType)

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2801,30 +2801,30 @@ class MatchRule {
         if (onRevert == null) {
             return true
         } else {
-            matchObjectSpec(onRevert, entity)
+            objectContains(entity, onRevert)
         }
     }
 
     @CompileStatic(SKIP)
-    static boolean matchObjectSpec(spec, obj) {
-        if (spec instanceof List) {
-            return spec.every {
-                matchObjectSpec(it, obj)
+    static boolean objectContains(obj, pattern) {
+        if (pattern instanceof List) {
+            return pattern.every {
+                objectContains(obj, it)
             }
         }
-        if (spec instanceof Map) {
+        if (pattern instanceof Map) {
             if (!(obj instanceof Map)) {
                 return false
             }
             def map = (Map) obj
-            for (Map.Entry entry : ((Map) spec).entrySet()) {
+            for (Map.Entry entry : ((Map) pattern).entrySet()) {
                 if (!map.containsKey(entry.key)) {
                     return false
                 }
-                return matchObjectSpec(entry.value, map[entry.key])
+                return objectContains(map[entry.key], entry.value)
             }
         } else {
-            return obj.equals(spec)
+            return obj.equals(pattern)
         }
     }
 }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1143,14 +1143,9 @@
           "include": ["termbase_with_id"]
         },
         {
-          "when": "i2=7 & $2=kao",
-          "include": ["termbase"]
-        },
-        {
           "when": "i2=0",
           "include": ["termbase"],
-          "uriTemplate": "http://id.loc.gov/authorities/label/{prefLabel}",
-          "FIXME": "Match on uriTemplate on revert!"
+          "uriTemplate": "http://id.loc.gov/authorities/label/{prefLabel}"
         },
         {
           "when": "i2=1",
@@ -1159,24 +1154,40 @@
         },
 
         {
-          "when": null,
+          "when": {
+            "onRevert": {"inScheme": {"code": "lcsh"}},
+            "then": {"ind2": "0"}
+          },
+          "include": ["termbase"]
+        },
+        {
+          "when": {
+            "onRevert": {"inScheme": {"code": "mesh"}},
+            "then": {"ind2": "2"}
+          },
           "include": ["termbase"],
-          "TODO": "The uses of i2 below would be preferable before this, but the $2 are redunant (and don't work properly anyway). But matching just i2 actually sets its value..."
+          "TODO:uriTemplate": "https://id.nlm.nih.gov/mesh/{prefLabel}",
+          "NOTE": "beta sparql endpoint. Do not use yet (labels don't match)..."
         },
         {
-          "when": "i2=2 & $2=mesh",
+          "when": {
+            "onRevert": {"inScheme": {"code": "nal"}},
+            "then": {"ind2": "3"}
+          },
           "include": ["termbase"]
         },
         {
-          "when": "i2=3 & $2=nal",
+          "when": {
+            "onRevert": {"inScheme": {"code": "csh"}},
+            "then": {"ind2": "5"}
+          },
           "include": ["termbase"]
         },
         {
-          "when": "i2=5 & $2=csh",
-          "include": ["termbase"]
-        },
-        {
-          "when": "i2=6 & $2=rvm",
+          "when": {
+            "onRevert": {"inScheme": {"code": "rvm"}},
+            "then": {"ind2": "6"}
+          },
           "include": ["termbase"]
         },
         {
@@ -1186,13 +1197,6 @@
         {
           "when": null,
           "include": ["termbase"]
-        },
-
-        {
-          "TODO:when": "i2=2",
-          "include": ["termbase"],
-          "uriTemplate": "https://id.nlm.nih.gov/mesh/{prefLabel}",
-          "NOTE": "beta sparql endpoint. Do not use yet (labels don't match)..."
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -8155,6 +8155,7 @@
         }
       ],
       "addLink": "subject",
+      "resourceType": "Identity",
       "pendingResources": {
         "_:agent": {
           "addLink": "termComponentList",
@@ -8324,6 +8325,8 @@
     "611": {
       "aboutEntity": "?work",
       "i1": {"marcDefault": "2"},
+      "addLink": "subject",
+      "resourceType": "Identity",
       "match": [
         {
           "when": "$t",
@@ -8344,13 +8347,11 @@
             "_:agent": {"about": "_:contribution", "link": "agent", "resourceType": "Meeting", "required": true},
             "_:place": {"about": "_:agent", "addLink": "place", "resourceType": "Place"}
           },
-          "addLink": "subject",
           "$t": {"about": "_:title", "property": "mainTitle"}
         },
         {
           "when": null,
           "include": ["agentdataMeeting", "subjectbase"],
-          "addLink": "subject",
           "resourceType": "Meeting",
           "aboutAlias": "_:agent",
           "$n": {"addProperty": "marc:partNumber", "punctuationChars": ","},
@@ -8666,6 +8667,7 @@
       "include": ["subjectbase"],
       "aboutEntity": "?work",
       "addLink": "subject",
+      "resourceType": "Identity",
       "pendingResources": {
         "_:term": {
           "addLink": "termComponentList",

--- a/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
+++ b/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
@@ -211,6 +211,16 @@ class MarcFrameConverterUtilsSpec extends Specification {
         Util.getSortedPendingKeys(pendingResources) == ['a', 'b1', 'b2', 'd', 'c']
     }
 
+    def "should match object spec"() {
+        given:
+        def spec = [link: [key: "value"]]
+        def obj1 = [link: [key: "value"]]
+        def obj2 = [link: [key: "other"]]
+        expect:
+        MatchRule.matchObjectSpec(spec, obj1)
+        !MatchRule.matchObjectSpec(spec, obj2)
+    }
+
     def newMarcFieldHandler() {
         new MarcFieldHandler(new MarcRuleSet(new MarcConversion(null, [:], [:]), 'blip'), 'xxx', [:])
     }

--- a/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
+++ b/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
@@ -211,14 +211,14 @@ class MarcFrameConverterUtilsSpec extends Specification {
         Util.getSortedPendingKeys(pendingResources) == ['a', 'b1', 'b2', 'd', 'c']
     }
 
-    def "should match object spec"() {
+    def "should check if object contains pattern"() {
         given:
-        def spec = [link: [key: "value"]]
+        def pattern = [link: [key: "value"]]
         def obj1 = [link: [key: "value"]]
         def obj2 = [link: [key: "other"]]
         expect:
-        MatchRule.matchObjectSpec(spec, obj1)
-        !MatchRule.matchObjectSpec(spec, obj2)
+        MatchRule.objectContains(obj1, pattern)
+        !MatchRule.objectContains(obj2, pattern)
     }
 
     def newMarcFieldHandler() {

--- a/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
+++ b/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
@@ -133,7 +133,7 @@ class MarcFrameConverterUtilsSpec extends Specification {
         when:
         def subfields = MarcFieldHandler.orderAndGroupSubfields(
                 [
-                    'a': subHandler(field, 'a', [about: 'agent']),
+                    'a': subHandler(field, 'a', [aboutNew: 'agent']),
                     'd': subHandler(field, 'd', [about: 'agent']),
                     't': subHandler(field, 't', [about: 'title']),
                 ],
@@ -144,7 +144,7 @@ class MarcFrameConverterUtilsSpec extends Specification {
         and:
         def subfields2 = MarcFieldHandler.orderAndGroupSubfields(
                 [
-                    'a': subHandler(field, 'a', [about: 'agent']),
+                    'a': subHandler(field, 'a', [aboutNew: 'agent']),
                     'p': subHandler(field, 'p', [about: 'place']),
                     '4': subHandler(field, '4', [about: 'agent']),
                 ],
@@ -157,7 +157,7 @@ class MarcFrameConverterUtilsSpec extends Specification {
                 [
                     'a': subHandler(field, 'a', [about: 'title']),
                     'd': subHandler(field, 'd', [:]),
-                    'f': subHandler(field, 'f', [about: 'work']),
+                    'f': subHandler(field, 'f', [aboutNew: 'work']),
                     'q': subHandler(field, 'q', [:]),
                     'l': subHandler(field, 'l', [about: 'work']),
                 ],


### PR DESCRIPTION
Fix reverting of bib 6xx by adding onRevert-specific rules. These are needed to handle the interactions of i2 and $2 which are sometimes combined, and sometimes (desirably) leads to no $2 being produced. Some convert match rules (desirably) produce data for both, so which rule to be selected on revert collided with requirements.