### PR TITLE
Feature/fix ordered subfields bug

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2264,13 +2264,13 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                             vs = [vs]
                         }
                         for (v in vs.flatten()) {
+                            def sub = [(code): v]
                             if (subhandler.itemPos == 'rest') {
                                 if (firstRelPos == null)
                                     firstRelPos = pos
-                                sortedByItemPos[subhandler.code] = pos
+                                sortedByItemPos[System.identityHashCode(sub)] = pos
                             }
                             if (!usedMatchRules || usedMatchRules.every { it.matchValue(code, v) }) {
-                                def sub = [(code): v]
                                 subs << sub
                                 justAdded = [code, sub]
                             }
@@ -2303,9 +2303,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         if (!failedRequired && i1 != null && i2 != null && subs.size()) {
             if (sortedByItemPos.size()) {
                 subs.sort {
-                    def entry = it.entrySet()[0]
-                    def relPos = sortedByItemPos[entry.key]
-                    [relPos ? firstRelPos : subs.indexOf(it), relPos]
+                    def relPos = sortedByItemPos[System.identityHashCode(it)]
+                    [relPos != null ? firstRelPos : subs.indexOf(it), relPos]
                 }
             }
             def field = [ind1: i1, ind2: i2, subfields: subs]

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2196,7 +2196,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         def prevAdded = null
 
         // NOTE: Within a field, only *one* positioned term is supported.
-        def firstRelPos = null
+        Integer firstRelPos = null
         Map sortedByItemPos = [:]
 
         orderedAndGroupedSubfields.each { subhandlers ->
@@ -2264,16 +2264,20 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                             vs = [vs]
                         }
                         for (v in vs.flatten()) {
-                            def sub = [(code): v]
+                            if (usedMatchRules?.any { !it.matchValue(code, v) }) {
+                                continue
+                            }
+                            Map sub = [(code): v]
+
                             if (subhandler.itemPos == 'rest') {
-                                if (firstRelPos == null)
+                                if (firstRelPos == null) {
                                     firstRelPos = pos
+                                }
                                 sortedByItemPos[System.identityHashCode(sub)] = pos
                             }
-                            if (!usedMatchRules || usedMatchRules.every { it.matchValue(code, v) }) {
-                                subs << sub
-                                justAdded = [code, sub]
-                            }
+
+                            subs << sub
+                            justAdded = [code, sub]
                         }
                     }
                     if (subhandler.required && !justAdded) {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9136,6 +9136,65 @@
               ]
             }
           }}
+        },
+        {
+          "source": {
+            "650": {
+              "ind1": " ",
+              "ind2": "7",
+              "subfields": [
+                {"a": "1"},
+                {"x": "A"},
+                {"x": "B"},
+                {"y": "C"},
+                {"x": "A"},
+                {"x": "C"},
+                {"2": "BNB"}
+              ]
+            }
+          },
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [
+                {
+                  "@type": "ComplexSubject",
+                  "termComponentList": [
+                    {
+                      "@type": "Topic",
+                      "prefLabel": "1"
+                    },
+                    {
+                      "@type": "TopicSubdivision",
+                      "prefLabel": "A"
+                    },
+                    {
+                      "@type": "TopicSubdivision",
+                      "prefLabel": "B"
+                    },
+                    {
+                      "@type": "Temporal",
+                      "prefLabel": "C"
+                    },
+                    {
+                      "@type": "TopicSubdivision",
+                      "prefLabel": "A"
+                    },
+                    {
+                      "@type": "TopicSubdivision",
+                      "prefLabel": "C"
+                    }
+                  ],
+                  "inScheme": {
+                    "@type": "ConceptScheme",
+                    "@id": "https://id.kb.se/term/BNB",
+                    "code": "BNB"
+                  },
+                  "prefLabel": "1--A--B--C--A--C"
+                }
+              ]
+            }}
+          }
         }
       ]
     },


### PR DESCRIPTION
Fix subfield order bug for itemPos-mapped subfields.

Now heralds subfieldOrder for subfields *after* the itemPos-preserved ones, and also preserves idiosyncratic combinations (e.g. "x y x").