### PR TITLE
Feature/fix ordered by itempos bug

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2204,7 +2204,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         def prevAdded = null
 
         // NOTE: Within a field, only *one* positioned term is supported.
-        Integer firstRelPos = null
+        Map firstRelPosSubfield = null
         Map sortedByItemPos = [:]
 
         orderedAndGroupedSubfields.each { subhandlers ->
@@ -2278,8 +2278,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                             Map sub = [(code): v]
 
                             if (subhandler.itemPos == 'rest') {
-                                if (firstRelPos == null) {
-                                    firstRelPos = pos
+                                if (firstRelPosSubfield == null) {
+                                    firstRelPosSubfield = sub
                                 }
                                 sortedByItemPos[System.identityHashCode(sub)] = pos
                             }
@@ -2314,9 +2314,10 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
 
         if (!failedRequired && i1 != null && i2 != null && subs.size()) {
             if (sortedByItemPos.size()) {
+                int relPosStart = subs.indexOf(firstRelPosSubfield)
                 subs.sort {
                     def relPos = sortedByItemPos[System.identityHashCode(it)]
-                    [relPos != null ? firstRelPos : subs.indexOf(it), relPos]
+                    [relPos != null ? relPosStart : subs.indexOf(it), relPos]
                 }
             }
             def field = [ind1: i1, ind2: i2, subfields: subs]

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -8277,7 +8277,7 @@
               {"y": "21st century."}]}},
           "normalized": {
             "600": {"ind1": "1", "ind2": "0", "subfields": [
-              {"a": "Scarlatti, Domenico,"},
+              {"a": "Scarlatti, Domenico"},
               {"d": "1685-1757"},
               {"t": "Sonatas,"},
               {"m": "harpsichord"},


### PR DESCRIPTION
Fix revert logic for re-ordering subfields based on itemPos. This is relevant for ComplexSubject mappings to order by termComponentList.

This fix ensures that the tail items are put in order starting with the *current* position of the first in the tail (and not its relative position + 1 among the itemComponentList itmes).