### PR TITLE
Feature/update with marc default

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17349,7 +17349,7 @@
     "010": {"ignored": true, "NOTE:record-count": 22, "NOTE:local": "ANVÄNDS NORMALT EJ"},
     "014": {
       "aboutEntity": "?record",
-      "i1": {"property": "marc:typeOfLinkageNumber"},
+      "i1": {"property": "marc:typeOfLinkageNumber", "marcDefault": "1"},
       "$a": {"addLink": "identifiedBy", "resourceType": "LibrisIIINumber", "property": "value", "NOTE:marc-repeatable": false}
     },
     "016": {"ignored": true, "NOTE:record-count": 0, "NOTE:local": "ANVÄNDS NORMALT EJ"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -16532,7 +16532,8 @@
       "resourceType": "marc:EstablishedHeadingLinkingEntryUniformTitle",
       "i2": {
         "property": "marc:thesaurus",
-        "tokenMap": "marcThesaurus"
+        "tokenMap": "marcThesaurus",
+        "marcDefault": "4"
       },
       "$a": {"property": "marc:uniformTitle"},
       "$d": {"addProperty": "marc:dateOfTreatySigning"},
@@ -16566,7 +16567,8 @@
       "resourceType": "marc:EstablishedHeadingLinkingEntryChronologicalTerm",
       "i2": {
         "property": "marc:thesaurus",
-        "tokenMap": "marcThesaurus"
+        "tokenMap": "marcThesaurus",
+        "marcDefault": "4"
       },
       "$a": {"property": "marc:chronologicalTerm"},
       "$i": {"ignored": true},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7855,9 +7855,26 @@
       "$a": {"property": "label"},
       "_spec": [
         {
-          "source": {"522": {"ind1": "1", "ind2": " ", "subfields": [
+          "source": {"522": {"ind1": "8", "ind2": " ", "subfields": [
             {"a": "foo"}
           ]}},
+          "normalized": {"522": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "geographicCoverage": [
+                {
+                  "@type": "GeographicCoverage",
+                  "label": "foo"
+                }
+              ]
+            }
+          }}
+        },
+        {
+          "source": {"522": {"subfields": [{"a": "foo"}]}},
           "normalized": {"522": {"ind1": " ", "ind2": " ", "subfields": [
             {"a": "foo"}
           ]}},
@@ -8368,6 +8385,18 @@
       "_spec": [
         {
           "source": [{"586": {"ind1": "0", "ind2": " ", "subfields": [{"a": "EBZ"}]}}],
+          "normalized": [{"586": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EBZ"}]}}],
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text"
+              },
+              "awardsNote":  "EBZ"
+            }
+          }
+        },
+        {
+          "source": [{"586": {"subfields": [{"a": "EBZ"}]}}],
           "normalized": [{"586": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EBZ"}]}}],
           "result": {
             "mainEntity": {
@@ -9180,6 +9209,34 @@
         },
         {
           "source": {
+            "611": {"ind1": "0", "ind2": "0", "subfields":[
+              {"a": "Rio (Conference)"}]
+            }
+          },
+          "normalized": {
+            "611": {"ind1": "2", "ind2": "0", "subfields":[
+              {"a": "Rio (Conference)"}]
+            }
+          },
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [
+                {
+                  "@type": "Meeting",
+                  "name": "Rio (Conference)",
+                  "inScheme": {
+                    "@id": "https://id.kb.se/term/lcsh",
+                    "@type": "ConceptScheme",
+                    "code": "lcsh"
+                  }
+                }
+              ]
+            }
+          }}
+        },
+        {
+          "source": {
             "611": {"ind1": "2", "ind2": "0", "subfields":[
               {"a": "Vatican Council"},
               {"n": "(2nd :"},
@@ -9964,6 +10021,20 @@
               "subject": [{
                 "@type": "Geographic",
                 "prefLabel": "Förenta staterna"
+              }]
+            }
+          }}
+        },
+        {
+          "name": "Convert without any ind1 defined",
+          "source": {"651": {"ind2": "4", "subfields":[{"a": "Sverige"}]}},
+          "normalized": {"651": {"ind1": " ", "ind2": "4", "subfields":[{"a": "Sverige"}]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [{
+                "@type": "Geographic",
+                "prefLabel": "Sverige"
               }]
             }
           }}
@@ -17624,7 +17695,51 @@
       "$8": {"property": "marc:groupid"},
       "$9": {"addProperty": "marc:organizationalUnit"},
       "repeatable": true,
-      "subfieldOrder": "8 a x z 2 9"
+      "subfieldOrder": "8 a x z 2 9",
+      "_spec": [
+        {
+          "name": "With indicator 1 set to 1",
+          "source": {"866": {"ind1": "1", "ind2": " ", "subfields": [
+            {"a": "Foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "marc:hasTextualHoldingsBasicBibliographicUnit": [
+              {
+                "@type": "marc:TextualHoldingsBasicBibliographicUnit",
+                "marc:textualString": "Foo",
+                "marc:holdingsLevel": "1"
+              }
+            ]
+          }}
+        },
+        {
+          "name": "With indicator 1 set to blank",
+          "source": {"866": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "Foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "marc:hasTextualHoldingsBasicBibliographicUnit": [
+              {
+                "@type": "marc:TextualHoldingsBasicBibliographicUnit",
+                "marc:textualString": "Foo"
+              }
+            ]
+          }}
+        },
+        {
+          "name": "With no indicators set at all",
+          "source": {"866": {"subfields": [{"a": "Foo"}]}},
+          "normalized": {"866": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Foo"}]}},
+          "result": {"mainEntity": {
+            "marc:hasTextualHoldingsBasicBibliographicUnit": [
+              {
+                "@type": "marc:TextualHoldingsBasicBibliographicUnit",
+                "marc:textualString": "Foo"
+              }
+            ]
+          }}
+        }
+      ]
     },
     "867": {
       "addLink": "marc:hasTextualHoldingsSupplementaryMaterial",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -10042,6 +10042,30 @@
               ]
             }
           }}
+        },
+        {
+          "name": "With blank indicator 2",
+          "source": {
+            "653": {"ind1": " ", "ind2": " ", "subfields":[
+              {"a": "Name of Topic"}]
+            }
+          },
+          "normalized": {
+            "653": {"ind1": " ", "ind2": "0", "subfields":[
+              {"a": "Name of Topic"}]
+            }
+          },
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [
+                {
+                  "@type": "Topic",
+                  "label": "Name of Topic"
+                }
+              ]
+            }
+          }}
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3861,9 +3861,8 @@
           "pendingResources": {"_:scale": {"link": "scale", "resourceType": "marc:OtherCartographicScale"}}
         }
       ],
-      "i1": {"ignored": "true", "marcDefault": "1"},
+      "i1": {"marcDefault": "1"},
       "i2": {
-        "ignored": "true",
         "property": "marc:ringType",
         "marcDefault": " ",
         "tokenMap": {"0": "marc:OuterRing", "1": "marc:ExcludingRing"}
@@ -3916,6 +3915,28 @@
                       "@type": "marc:LinearScale",
                       "marc:constantRatioLinearHorizontalScale": ["110000"]
                     }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "source": [
+            {"034": {"ind1": "1", "ind2": "0", "subfields": [{"b": "11"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "cartographicAttributes": [
+                  {
+                    "@type": "Cartographic",
+                    "scale": {
+                      "@type": "Scale",
+                      "marc:constantRatioLinearHorizontalScale": ["11"]
+                    },
+                    "marc:ringType": "marc:OuterRing"
                   }
                 ]
               }
@@ -4088,7 +4109,7 @@
     "037": {
       "addLink": "acquisitionSource",
       "resourceType": "AcquisitionSource",
-      "i1": {"ignored": true, "marcDefault": " "},
+      "i1": {"marcDefault": " "},
       "$a": {"addLink": "identifiedBy", "resourceType": "StockNumber", "property": "value", "NOTE:marc-repeatable": false},
       "$b": {"property": "label"},
       "$c": {"property": "acquisitionTerms", "NOTE:marc-repeatable": true},
@@ -7848,7 +7869,6 @@
       "addLink": "geographicCoverage",
       "resourceType": "GeographicCoverage",
       "i1": {
-        "ignored": true,
         "NOTE:LC": "nac",
         "marcDefault": " "
       },
@@ -7896,7 +7916,6 @@
       "aboutEntity": "?thing",
       "i1": {
         "marcDefault": "8",
-        "ignored": true,
         "NOTE:LC": "nac"
       },
       "$a": {"property": "preferredCitation"},
@@ -8378,7 +8397,7 @@
     "586": {
       "NOTE:local": "ANVÄNDS NORMALT EJ",
       "aboutEntity": "?thing",
-      "i1": {"ignored": true, "marcDefault": " "},
+      "i1": {"marcDefault": " "},
       "$a": {"property": "awardsNote"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
       "$6": {"property": "marc:fieldref"},
@@ -17438,7 +17457,7 @@
     "561": {
       "groupId": "?example-$seq",
       "NOTE:i1": "0 = Sekretessbelagd information. Används f.n. ej. = 8 poster. Remove i1 when revert",
-      "i1": {"ignored": true,"marcDefault": " "},
+      "i1": {"marcDefault": " "},
       "$a": {"property": "custodialHistory"},
       "$3": {
         "link": "marc:custodialHistory-appliesTo", "resourceType": "Resource", "property": "label",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4538,9 +4538,9 @@
         "property": "edition",
         "tokenMap": {
           "0": "full",
-          "1": "abridged",
-          " ": "No information provided"
-        }
+          "1": "abridged"
+        },
+        "marcDefault": " "
       },
       "$a": {"property": "code"},
       "$b": {"property": "marc:itemNumber"},
@@ -4556,7 +4556,22 @@
               "instanceOf": {
                 "@type": "Text",
                 "classification": [
-                  {"@type": "ClassificationUdc", "code": "030", "edition": "No information provided"}
+                  {"@type": "ClassificationUdc", "code": "030"}
+                ]
+              }
+            }
+          }
+        },
+        {
+          "source": {
+            "080": {"ind1": "0", "ind2": " ", "subfields": [{"a": "030"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "classification": [
+                  {"@type": "ClassificationUdc", "code": "030", "edition": "full"}
                 ]
               }
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4405,7 +4405,7 @@
       "addLink": "classification",
       "resourceType": "ClassificationLcc",
       "i1": {"property": "marc:existenceInLCCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
-      "i2": {"property": "marc:assignedByLC", "tokenMap": {"0": true, "4": false}},
+      "i2": {"property": "marc:assignedByLC", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "code", "TODO:repeatable": true},
       "$b": {"property": "itemPortion"},
       "$6": {"property": "marc:fieldref"}
@@ -4479,7 +4479,7 @@
       "addLink": "classification",
       "resourceType": "ClassificationNlm",
       "i1": {"property": "marc:existenceInNlmCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
-      "i2": {"property": "marc:assignedByNlm", "tokenMap": {"0": true, "4": false}},
+      "i2": {"property": "marc:assignedByNlm", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "code"},
       "$b": {"property": "itemPortion", "ignored": true}
     },
@@ -13591,7 +13591,7 @@
       "aboutEntity": "?thing",
       "addLink": "classification",
       "resourceType": "ClassificationLcc",
-      "i2": {"property": "marc:assignedByLC", "tokenMap": {"0": true, "4": false}},
+      "i2": {"property": "marc:assignedByLC", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "classificationPortion"},
       "$b": {"property": "spanEnd"},
       "$c": {"property": "marc:explanatoryTerm"}
@@ -14600,9 +14600,8 @@
     "377": {
       "i2": {
         "property": "marc:languageCode",
+        "marcDefault": " ",
         "tokenMap": {
-          "1": "marc:ISO-639-2B",
-          "2": "marc:SourceSpecifiedInSubfield2",
           "7": "marc:SourceSpecifiedInSubfield2"
         }
       },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -8261,10 +8261,24 @@
     "586": {
       "NOTE:local": "ANVÄNDS NORMALT EJ",
       "aboutEntity": "?thing",
-      "i1": {"ignored": true},
+      "i1": {"ignored": true, "marcDefault": " "},
       "$a": {"property": "awardsNote"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
-      "$6": {"property": "marc:fieldref"}
+      "$6": {"property": "marc:fieldref"},
+      "_spec": [
+        {
+          "source": [{"586": {"ind1": "0", "ind2": " ", "subfields": [{"a": "EBZ"}]}}],
+          "normalized": [{"586": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EBZ"}]}}],
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text"
+              },
+              "awardsNote":  "EBZ"
+            }
+          }
+        }
+      ]
     },
     "588": {
       "aboutEntity": "?record",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7803,7 +7803,44 @@
       "$a": {"property": "label"},
       "$b": {"link": "source", "resourceType": "Source","property": "label"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
-      "$6": {"property": "marc:fieldref"}
+      "$6": {"property": "marc:fieldref"},
+      "_spec": [
+        {
+          "name": "With blank indicator 1",
+          "source": {"521": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "foo bar"}
+          ]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text"
+            },
+            "intendedAudience": [
+              {
+                "@type": "IntendedAudience",
+                "label": "foo bar"
+              }
+            ]
+          }}
+        },
+        {
+          "name": "With indicator 1 set to 0",
+          "source": {"521": {"ind1": "0", "ind2": " ", "subfields": [
+            {"a": "Baz"}
+          ]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text"
+            },
+            "intendedAudience": [
+              {
+                "@type": "IntendedAudience",
+                "label": "Baz",
+                "marc:audienceType": "marc:ReadingGradeLevel"
+              }
+            ]
+          }}
+        }
+      ]
     },
     "522": {
       "aboutEntity": "?work",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -56,7 +56,6 @@
           "1": "marc:LcSubjectHeadingsForChildrensLiterature",
           "2": "marc:MedicalSubjectHeadingsNlmNameAuthorityFile",
           "3": "marc:NationalAgriculturalLibrarySubjectAuthorityFile",
-          "4": "marc:SourceNotSpecified",
           "5": "marc:CanadianSubjectHeadingsNlcNameAuthorityFile",
           "6": "marc:RepertoireDeVedettesMatiere",
           "7": "marc:SourceSpecifiedInSubfield2"
@@ -16456,7 +16455,8 @@
       },
       "i2": {
         "property": "marc:thesaurus",
-        "tokenMap": "marcThesaurus"
+        "tokenMap": "marcThesaurus",
+        "marcDefault": "4"
       },
       "$a": {"property": "marc:corporateNameOrJurisdictionNameAsEntryElement"},
       "$b": {"addProperty": "marc:subordinateUnit"},
@@ -16497,7 +16497,8 @@
       },
       "i2": {
         "property": "marc:thesaurus",
-        "tokenMap": "marcThesaurus"
+        "tokenMap": "marcThesaurus",
+        "marcDefault": "4"
       },
       "$a": {"property": "marc:meetingNameOrJurisdictionNameAsEntryElement"},
       "$c": {"addProperty": "marc:locationOfMeeting"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -16451,7 +16451,8 @@
       "resourceType": "marc:EstablishedHeadingLinkingEntryCorporateName",
       "i1": {
         "property": "marc:nameForm",
-        "tokenMap": "marcNameForm"
+        "tokenMap": "marcNameForm",
+        "marcDefault": "2"
       },
       "i2": {
         "property": "marc:thesaurus",
@@ -16491,7 +16492,8 @@
       "resourceType": "marc:EstablishedHeadingLinkingEntryMeetingName",
       "i1": {
         "property": "marc:nameForm",
-        "tokenMap": "marcNameForm"
+        "tokenMap": "marcNameForm",
+        "marcDefault": "2"
       },
       "i2": {
         "property": "marc:thesaurus",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -5986,7 +5986,7 @@
       "addLink": "marc:hasBib249",
       "resourceType": "marc:Bib249",
       "i1": {"property": "marc:sequenceOfWork", "marcDefault": " "},
-      "i2": {"property": "marc:nonfilingChars"},
+      "i2": {"property": "marc:nonfilingChars", "marcDefault": "0"},
       "$a": {"property": "marc:originalTitle"},
       "$b": {"property": "marc:titleRemainder"},
       "$n": {"addProperty": "marc:titleNumber"},
@@ -8067,6 +8067,7 @@
       "resourceType": "marc:ImmediateSourceOfAcquisitionNote",
       "i1": {
         "property": "marc:isPrivate",
+        "marcDefault": " ",
         "tokenMap": {
           "0": true,
           "1": false
@@ -8082,7 +8083,38 @@
       "$n": {"addProperty": "marc:extent"},
       "$o": {"addProperty": "unit"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
-      "$5": {"link": "applicableInstitution", "resourceType": "Agent", "property": "code", "NOTE:local": "Används ej"}
+      "$5": {"link": "applicableInstitution", "resourceType": "Agent", "property": "code", "NOTE:local": "Används ej"},
+      "_spec": [
+        {
+          "name": "With indicator 1 set to 0",
+          "source": {"541": {"ind1": "0", "ind2": " ", "subfields": [
+            {"a": "Foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "marc:hasImmediateSourceOfAcquisitionNote": [
+              {
+                "@type": "marc:ImmediateSourceOfAcquisitionNote",
+                "label": "Foo",
+                "marc:isPrivate": true
+              }
+            ]
+          }}
+        },
+        {
+          "name": "With indicator 1 set to blank",
+          "source": {"541": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "Foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "marc:hasImmediateSourceOfAcquisitionNote": [
+              {
+                "@type": "marc:ImmediateSourceOfAcquisitionNote",
+                "label": "Foo"
+              }
+            ]
+          }}
+        }
+      ]
     },
     "542": {"ignored": true, "NOTE:record-count": 0, "NOTE:LC": "nac"},
     "544": {
@@ -8276,6 +8308,7 @@
       "i1": {
         "NOTE": "0 = Sekretessbelagd information. filtrera bort GDPR",
         "property": "marc:isPrivate",
+        "marcDefault": " ",
         "tokenMap": {
           "0": true,
           "1": false
@@ -8284,7 +8317,37 @@
       "$a": {"property": "label"},
       "$b": {"addProperty": "marc:actionIdentification"},
       "$x": {"addProperty": "marc:cataloguersNote", "TODO": "ignore?"},
-      "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"}
+      "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
+      "_spec": [
+        {
+          "name": "With indicator 1 set to 1",
+          "source": {"583": {"ind1": "1", "ind2": " ", "subfields": [
+            {"a": "Foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "hasNote": [
+              {
+                "@type": "marc:ActionNote",
+                "label": "Foo",
+                "marc:isPrivate": false
+              }
+            ]
+          }}
+        },
+        {
+          "name": "With no indicator set at all",
+          "source": {"583": {"subfields": [{"a": "Foo"}]}},
+          "normalized": {"583": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Foo"}]}},
+          "result": {"mainEntity": {
+            "hasNote": [
+              {
+                "@type": "marc:ActionNote",
+                "label": "Foo"
+              }
+            ]
+          }}
+        }
+      ]
     },
     "584": {"ignored": true, "NOTE:record-count": 0, "NOTE:LC": "nac"},
     "585": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3521,7 +3521,8 @@
       "resourceType": "ISSN",
       "i1": {
         "property": "marc:internationalInterest",
-        "tokenMap": {"0": true, "1": false}, "marcDefault": " "
+        "tokenMap": {"0": true, "1": false},
+        "marcDefault": " "
       },
       "$a": {"property": "value"},
       "$l": {"property": "marc:issnL"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9855,6 +9855,19 @@
           }}
         },
         {
+          "source": {"651": {"ind1": "1", "ind2": "4", "subfields":[{"a": "Förenta staterna"}]}},
+          "normalized": {"651": {"ind1": " ", "ind2": "4", "subfields":[{"a": "Förenta staterna"}]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [{
+                "@type": "Geographic",
+                "prefLabel": "Förenta staterna"
+              }]
+            }
+          }}
+        },
+        {
           "source": {
             "651": {"ind1": " ", "ind2": "7", "subfields":[
               {"a": "Sydafrika"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4527,9 +4527,22 @@
     "071": {"ignored": true, "NOTE:record-count": 0, "NOTE:LC": "nac", "NOTE:local": "ANVÄNDS NORMALT EJ"},
 
     "072": {
+      "onRevertPrefer": ["653"],
       "aboutEntity": "?work",
       "addLink": "subject",
       "resourceType": "Concept",
+      "match": [
+        {
+          "when": {
+            "NOTE": "stops here to get i2=0 without $2",
+            "onRevert": {"inScheme": {"code": "NAL"}}
+          }
+        },
+        {
+          "when": "i2=7 & $2",
+          "$2": {"requires-i2": "7", "link": "inScheme", "resourceType": "ConceptScheme", "property": "code"}
+        }
+      ],
       "i2": {
         "link": "inScheme",
         "resourceType": "ConceptScheme",
@@ -4537,11 +4550,74 @@
         "tokenMap": {
           "0": "NAL"
         },
-        "definedElsewhereToken": "7"
+        "definedElsewhereToken": "7",
+        "marcDefault": "7"
       },
       "$a": {"property": "label", "required": true},
       "$x": {"link": "inCollection", "property": "label"},
-      "$2": {"requires-i2": "7", "link": "inScheme", "resourceType": "ConceptScheme", "property": "code"}
+      "_spec": [
+        {
+          "source": {
+            "072": {"ind1": " ", "ind2": "0", "subfields": [
+              {"a": "Token"}
+            ]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "subject": [ {
+                  "@type": "Concept",
+                  "label": "Token",
+                  "inScheme": {
+                    "@type": "ConceptScheme",
+                    "code": "NAL"
+                  }
+                } ]
+              }
+            }
+          }
+        },
+        {
+          "source": {
+            "072": {"ind1": " ", "ind2": "7", "subfields": [
+              {"a": "Token"},
+              {"2": "G"}
+            ]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "subject": [ {
+                  "@type": "Concept",
+                  "label": "Token",
+                  "inScheme": {
+                    "@type": "ConceptScheme",
+                    "code": "G"
+                  }
+                } ]
+              }
+            }
+          }
+        },
+        {
+          "name": "i2=7 without $2",
+          "source": {
+            "072": {"ind1": " ", "ind2": "7", "subfields": [
+              {"a": "Token"}
+            ]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "subject": [ {"@type": "Concept", "label": "Token"} ]
+              }
+            }
+          }
+        }
+      ]
     },
 
     "074": {
@@ -5533,6 +5609,18 @@
       "resourceType": "AbbreviatedTitle",
       "aboutAlias": "_:title",
       "embedded": true,
+      "match": [
+        {
+          "when": {
+            "NOTE": "stops here to get i2=_ without $2",
+            "onRevert": {"source": {"code": "issnkey"}}
+          }
+        },
+        {
+          "when": "i2=0 & $2",
+          "$2": {"requires-i2": "0", "link": "source", "resourceType": "Source", "property": "code"}
+        }
+      ],
       "i2": {
         "link": "source",
         "resourceType": "Source",
@@ -5540,13 +5628,8 @@
         "tokenMap": {
           " ": "issnkey"
         },
+        "marcDefault": "0",
         "definedElsewhereToken": "0"
-      },
-      "$2": {
-        "requires-i2": "0",
-        "link": "source",
-        "resourceType": "Source",
-        "property": "code"
       },
       "$a": {"property": "mainTitle"},
       "$b": {"addProperty": "qualifier", "NOTE:marc-repeatable": false},
@@ -5585,6 +5668,19 @@
                 "@type" : "Source",
                 "code" : "issnkey"
               }
+            }]
+          }}
+        },
+        {
+          "name": "i2=0 without $2",
+          "source": {
+            "210": {"ind1": "1", "ind2": "0", "subfields": [
+              {"a": "No source"}
+            ]}},
+          "result": {"mainEntity": {
+            "hasTitle": [{
+              "@type": "AbbreviatedTitle",
+              "mainTitle":  "No source"
             }]
           }}
         }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9537,7 +9537,11 @@
         {
           "source": {
             "650": {"ind1": "2", "ind2": " ",
-              "subfields": [{"a": "Health services for the aged", "v": "periodicals"}]}
+              "subfields": [{"a": "Health services for the aged"}, {"v": "periodicals"}]}
+          },
+          "normalized": {
+            "650": {"ind1": "2", "ind2": "4",
+              "subfields": [{"a": "Health services for the aged"}, {"v": "periodicals"}]}
           },
           "result": {"mainEntity": {
             "instanceOf": {
@@ -9560,6 +9564,10 @@
         {
           "source": {
             "650": {"ind1": "0", "ind2": " ",
+              "subfields": [{"a": "Geriatrics"}]}
+          },
+          "normalized": {
+            "650": {"ind1": "0", "ind2": "4",
               "subfields": [{"a": "Geriatrics"}]}
           },
           "result": {"mainEntity": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3783,11 +3783,11 @@
         "TODO": "align with subfieldproperty instead of separate list, also make sure repeatable.",
         "property": "marc:typeOfDate",
         "tokenMap": {
-          " ": "marc:NoDateInformation",
           "0": "marc:SingleDate",
           "1": "marc:MultipleSingleDates",
           "2": "marc:RangeOfDates"
-        }
+        },
+        "marcDefault": " "
       },
       "i2": {
         "property": "@type",
@@ -4313,11 +4313,47 @@
           "0": "marc:SingleDateTime",
           "1": "marc:MultipleSingleDatesTimes",
           "2": "marc:RangeOfDatesTimes"
-        }
+        },
+        "marcDefault": " "
       },
       "$a": {"addProperty": "marc:timePeriodCode"},
       "$b": {"addProperty": "marc:formatted9999BCThroughCETimePeriod"},
-      "$c": {"addProperty": "marc:formattedPre9999BCTimePeriod"}
+      "$c": {"addProperty": "marc:formattedPre9999BCTimePeriod"},
+      "_spec": [
+        {
+          "source": {
+            "045": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Foo Bar"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "marc:hasTimePeriodOfContent": {
+                  "@type": "marc:TimePeriodOfContent",
+                  "marc:timePeriodCode": ["Foo Bar"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "source": {
+            "045": {"ind1": "0", "ind2": " ", "subfields": [{"a": "Foo Bar"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "marc:hasTimePeriodOfContent": {
+                  "@type": "marc:TimePeriodOfContent",
+                  "marc:timePeriodCode": ["Foo Bar"],
+                  "marc:typeOfTimePeriod": "marc:SingleDateTime"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "046": {
       "addLink": "marc:hasSpecialCodedDates",
@@ -4431,7 +4467,8 @@
           "7": "marc:OtherClassNumberAssignedByLac",
           "8": "marc:OtherCallNumberAssignedByTheContributingLibrary",
           "9": "marc:OtherClassNumberAssignedByTheContributingLibrary"
-        }
+        },
+        "marcDefault": " "
       },
       "$a": {"property": "marc:classificationNumber"},
       "$b": {"property": "marc:itemNumber"},
@@ -4856,7 +4893,8 @@
           " ": "marc:SourceSpecifiedInSubfield2",
           "0": "marc:SuperintendentOfDocumentsClassificationSystem",
           "1": "marc:GovernmentOfCanadaPublicationsOutlineOfClassification"
-        }
+        },
+        "marcDefault": " "
       },
       "$a": {"property": "marc:classificationNumber"},
       "$z": {"addProperty": "marc:canceledInvalidClassificationNumber"},
@@ -5932,7 +5970,7 @@
       "NOTE:Local": "LIBRIS-definierat fält, OBSOLET",
       "addLink": "marc:hasBib249",
       "resourceType": "marc:Bib249",
-      "i1": {"property": "marc:sequenceOfWork"},
+      "i1": {"property": "marc:sequenceOfWork", "marcDefault": " "},
       "i2": {"property": "marc:nonfilingChars"},
       "$a": {"property": "marc:originalTitle"},
       "$b": {"property": "marc:titleRemainder"},
@@ -7759,9 +7797,31 @@
       "resourceType": "GeographicCoverage",
       "i1": {
         "ignored": true,
-        "NOTE:LC": "nac"
+        "NOTE:LC": "nac",
+        "marcDefault": " "
       },
-      "$a": {"property": "label"}
+      "$a": {"property": "label"},
+      "_spec": [
+        {
+          "source": {"522": {"ind1": "1", "ind2": " ", "subfields": [
+            {"a": "foo"}
+          ]}},
+          "normalized": {"522": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "foo"}
+          ]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "geographicCoverage": [
+                {
+                  "@type": "GeographicCoverage",
+                  "label": "foo"
+                }
+              ]
+            }
+          }}
+        }
+      ]
     },
     "524": {
       "aboutEntity": "?thing",
@@ -13127,7 +13187,7 @@
       "aboutEntity": "?work",
       "addLink": "marc:hasBib976",
       "resourceType": "marc:Bib976",
-      "i2": {"property": "marc:bib976-i2"},
+      "i2": {"property": "marc:bib976-i2", "marcDefault": " "},
       "$a": {"property": "marc:bib976-a"},
       "$b": {"property": "marc:bib976-b"}
     }
@@ -17347,8 +17407,8 @@
       "addLink": "marc:hasEnumerationAndChronologyBasicBibliographicUnit",
       "resourceType": "marc:EnumerationAndChronologyBasicBibliographicUnit",
       "embedded": true,
-      "i1": {"property": "marc:holdingsLevel"},
-      "i2": {"property": "marc:formOfHoldings"},
+      "i1": {"property": "marc:holdingsLevel", "marcDefault": " "},
+      "i2": {"property": "marc:formOfHoldings", "marcDefault": " "},
       "$a": {"property": "marc:firstLevelOfEnumeration"},
       "$b": {"property": "marc:secondLevelOfEnumeration"},
       "$c": {"property": "marc:thirdLevelOfEnumeration"},
@@ -17369,8 +17429,8 @@
       "addLink": "marc:hasTextualHoldingsBasicBibliographicUnit",
       "resourceType": "marc:TextualHoldingsBasicBibliographicUnit",
       "embedded": true,
-      "i1": {"property": "marc:holdingsLevel"},
-      "i2": {"property": "marc:typeOfNotation"},
+      "i1": {"property": "marc:holdingsLevel", "marcDefault": " "},
+      "i2": {"property": "marc:typeOfNotation", "marcDefault": " "},
       "$a": {"property": "marc:textualString"},
       "$x": {"addProperty": "marc:cataloguersNote"},
       "$z": {"addProperty": "marc:publicNote"},
@@ -17385,8 +17445,8 @@
       "addLink": "marc:hasTextualHoldingsSupplementaryMaterial",
       "resourceType": "marc:TextualHoldingsSupplementaryMaterial",
       "embedded": true,
-      "i1": {"property": "marc:holdingsLevel"},
-      "i2": {"property": "marc:typeOfNotation"},
+      "i1": {"property": "marc:holdingsLevel", "marcDefault": " "},
+      "i2": {"property": "marc:typeOfNotation", "marcDefault": " "},
       "$a": {"property": "marc:textualString"},
       "$x": {"addProperty": "marc:cataloguersNote"},
       "$z": {"addProperty": "marc:publicNote"},
@@ -17396,8 +17456,8 @@
       "addLink": "marc:hasTextualHoldingsIndexes",
       "resourceType": "marc:TextualHoldingsIndexes",
       "embedded": true,
-      "i1": {"property": "marc:holdingsLevel"},
-      "i2": {"property": "marc:typeOfNotation"},
+      "i1": {"property": "marc:holdingsLevel", "marcDefault": " "},
+      "i2": {"property": "marc:typeOfNotation", "marcDefault": " "},
       "$a": {"property": "marc:textualString"},
       "$x": {"addProperty": "marc:cataloguersNote"},
       "$z": {"addProperty": "marc:publicNote"},
@@ -17514,8 +17574,8 @@
     "949": {
       "addLink": "marc:hasHold949",
       "resourceType": "marc:Hold949",
-      "i1": {"property": "marc:hasHold949-i1"},
-      "i2": {"property": "marc:hasHold949-i2"},
+      "i1": {"property": "marc:hasHold949-i1", "marcDefault": " "},
+      "i2": {"property": "marc:hasHold949-i2", "marcDefault": " "},
       "$a": {"addProperty": "marc:hasHold949-a"},
       "$b": {"addProperty": "marc:hasHold949-b"},
       "$c": {"addProperty": "marc:hasHold949-c"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9539,16 +9539,21 @@
             "650": {"ind1": "2", "ind2": " ",
               "subfields": [{"a": "Health services for the aged", "v": "periodicals"}]}
           },
-          "TODO:result": {"mainEntity": {
+          "result": {"mainEntity": {
             "instanceOf": {
               "@type": "Text",
-              "subject": [
-                {
+              "subject": [{
+                "@type": "ComplexSubject",
+                "marc:subjectLevel": "marc:Secondary",
+                "prefLabel": "Health services for the aged--periodicals",
+                "termComponentList": [{
                   "@type": "Topic",
-                  "marc:subjectLevel": "marc:Secondary",
                   "prefLabel": "Health services for the aged"
-                }
-              ]
+                }, {
+                  "@type": "GenreForm",
+                  "prefLabel": "periodicals"
+                }]
+              }]
             }
           }}
         },
@@ -9557,13 +9562,14 @@
             "650": {"ind1": "0", "ind2": " ",
               "subfields": [{"a": "Geriatrics"}]}
           },
-          "TODO:result": {"mainEntity": {
+          "result": {"mainEntity": {
             "instanceOf": {
               "@type": "Text",
               "subject": [
                 {
                   "@type": "Topic",
-                  "prefLabel": "Geriatrics"
+                  "prefLabel": "Geriatrics",
+                  "marc:subjectLevel": "marc:Unspecified"
                 }
               ]
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17378,6 +17378,7 @@
       "i1": {
         "NOTE": "0 = Sekretessbelagd information. Används f.n. ej. = ca 5000 poster",
         "property": "marc:isPrivate",
+        "marcDefault": " ",
         "tokenMap": {
           "0": true,
           "1": false
@@ -17441,6 +17442,7 @@
       "i1": {
         "NOTE": "0 = Sekretessbelagd information. Används f.n. ej. = 1 post",
         "property": "marc:isPrivate",
+        "marcDefault": " ",
         "tokenMap": {
           "0": true,
           "1": false
@@ -17805,8 +17807,8 @@
     "948": {
       "addLink": "marc:hasHold948",
       "resourceType": "marc:Hold948",
-      "i1": {"property": "marc:hasHold948-i1"},
-      "i2": {"property": "marc:hasHold948-i2"},
+      "i1": {"property": "marc:hasHold948-i1", "marcDefault": " "},
+      "i2": {"property": "marc:hasHold948-i2", "marcDefault": " "},
       "$a": {"addProperty": "marc:hasHold948-a"},
       "$b": {"addProperty": "marc:hasHold948-b"},
       "$c": {"addProperty": "marc:hasHold948-c"},


### PR DESCRIPTION
Add default value of indicators where it is needed. 

When adding a new field in the viewer the field is not possible to convert to MARC21 when no values in the indicators are set. The value of the indicator will become null which does not give a match on revert. To solve this we have needed to add default values of indicators (where it is missing).