### PR TITLE
Avoid adding bracket if it exists within the value

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2614,15 +2614,21 @@ class MarcSubFieldHandler extends ConversionPart {
 
         // Rudimentary mending of broken '[...]' expressions:
         if (balanceBrackets) {
-            if (val.startsWith('[')) {
-                if (!val.endsWith(']')) {
-                    val += ']'
-                }
-            } else if (val.endsWith(']')) {
-                val = '[' + val
-            }
+            val = toBalancedBrackets(val)
         }
 
+        return val
+    }
+
+    static String toBalancedBrackets(String val) {
+        if (val.startsWith('[')) {
+            if (val.indexOf(']') == -1) {
+                val += ']'
+            }
+        } else if (val.endsWith(']') &&
+                    val.indexOf('[') == -1) {
+            val = '[' + val
+        }
         return val
     }
 

--- a/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
+++ b/whelk-core/src/test/groovy/MarcFrameConverterUtilsSpec.groovy
@@ -221,6 +221,25 @@ class MarcFrameConverterUtilsSpec extends Specification {
         !MatchRule.objectContains(obj2, pattern)
     }
 
+    def "should balance brackets"() {
+        expect:
+        MarcSubFieldHandler.toBalancedBrackets(value) == result
+        where:
+        value       | result
+        '[a'        | '[a]'
+        '[a b'      | '[a b]'
+        '[a] b'     | '[a] b'
+        'a]'        | '[a]'
+        'a b]'      | '[a b]'
+        'a [b]'     | 'a [b]'
+        'a]'        | '[a]'
+        '[a] [b]'   | '[a] [b]'
+        'a [b] c'   | 'a [b] c'
+        // TODO: Do we have to support embedded half brackets?
+        //'a [b c'    | 'a [b c]'
+        //'a b] c'    | '[a b] c'
+    }
+
     def newMarcFieldHandler() {
         new MarcFieldHandler(new MarcRuleSet(new MarcConversion(null, [:], [:]), 'blip'), 'xxx', [:])
     }


### PR DESCRIPTION
Currently this fixes a glaring deficiency.

If we need to support more intelligent bracket fixing, we need to count brackets. This wasn't meant to handle more than rudimentary cases (since brackets are somewhat controversial anyway), so such decision should be formally made.