### PR TITLE
Feature/complete series on revert

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -200,6 +200,10 @@ class MarcConversion {
             procStep = new MappedPropertyStep(props); break
             case 'VerboseRevertData':
             procStep = new VerboseRevertDataStep(props); break
+            case 'ProduceIfMissing':
+            procStep = new ProduceIfMissingStep(props); break
+            case 'SetFlagsByPatterns':
+            procStep = new SetFlagsByPatternsStep(props); break
             default:
             return null
         }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1774,6 +1774,31 @@
                 ]
               }
             }
+          },
+          {
+            "name":  "Skip entirely if there is any one item with the expected property (regardless of value)",
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "Some Publications"
+                  },
+                  {
+                    "@type": "SeriesMembership",
+                    "inSeries": {
+                      "@type": "Instance",
+                      "instanceOf": {
+                        "@type": "Work",
+                        "hasTitle": [ {"@type": "Title", "mainTitle": "Other Publications"} ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": "source"
           }
         ]
       },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1708,6 +1708,183 @@
             "back": "both"
           }
         ]
+      },
+      {
+        "type": "ProduceIfMissing",
+        "select": "seriesMembership",
+        "produceMissing": {
+          "property": "seriesStatement",
+          "sourcePath": ["inSeries", "instanceOf", "hasTitle", "mainTitle"]
+        },
+        "_spec": [
+          {
+            "name":  "NOOP",
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "seriesStatement": "CNI Publications",
+                    "@type": "SeriesMembership",
+                    "inSeries": {
+                      "@type": "Instance",
+                      "instanceOf": {
+                        "@type": "Work",
+                        "hasTitle": [ {"@type": "Title", "mainTitle": "CNI Publications"} ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": "source"
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "inSeries": {
+                      "@type": "Instance",
+                      "instanceOf": {
+                        "@type": "Work",
+                        "hasTitle": [ {"@type": "Title", "mainTitle": "CNI Publications"} ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "CNI Publications",
+                    "inSeries": {
+                      "@type": "Instance",
+                      "instanceOf": {
+                        "@type": "Work",
+                        "hasTitle": [ {"@type": "Title", "mainTitle": "CNI Publications"} ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "SetFlagsByPatterns",
+        "select": "seriesMembership",
+        "match": [
+          {
+            "exists": ["seriesStatement", "inSeries"],
+            "setFlags": {
+              "marc:seriesTracingPolicy": "1"
+            }
+          },
+          {
+            "exists": ["seriesStatement"],
+            "setFlags": {
+              "marc:seriesTracingPolicy": "0"
+            }
+          }
+        ],
+        "_spec": [
+          {
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "...",
+                    "marc:seriesTracingPolicy": "0",
+                    "inSeries": {"...": "..."}
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": "source"
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "...",
+                    "inSeries": {"...": "..."}
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "...",
+                    "marc:seriesTracingPolicy": "1",
+                    "inSeries": {"...": "..."}
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "..."
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "seriesStatement": "...",
+                    "marc:seriesTracingPolicy": "0"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "inSeries": {"...": "..."}
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "seriesMembership": [
+                  {
+                    "@type": "SeriesMembership",
+                    "inSeries": {"...": "..."}
+                  }
+                ]
+              }
+            }
+          }
+        ]
       }
     ],
 
@@ -7790,7 +7967,7 @@
     "490": {
       "include": ["inseries"],
       "groupId": "#seriesmember-$seq",
-      "i1": {"property": "marc:seriesTracingPolicy", "TODO:marcDefault": 0, "TODO": {"when: 8xx[$t] | 830": "1", "else": "0"}},
+      "i1": {"property": "marc:seriesTracingPolicy", "NOTE:marcDefault": 0, "NOTE:postProcessing ": "SetFlagsByPatterns"},
       "i2": null,
       "$a": {"addProperty": "seriesStatement"},
       "NOTE:remove?$l": {"link": "callno", "resourceType": "Concept", "property": "code"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1319,7 +1319,7 @@
       "FIXME:embedded:whenGroupIdsAreStrippedFromEmbedded": true,
       "pendingResources": {
         "_:seriesinstance": {
-          "TODO:whenSoftMergeWorks:groupId": "#seriesinstance-$seq",
+          "groupId": "#seriesinstance-$seq",
           "link": "inSeries",
           "resourceType": "Instance"
         },
@@ -7789,10 +7789,9 @@
     },
     "490": {
       "include": ["inseries"],
-      "TODO:whenSoftMergeWorks:groupId": "#seriesmember-$seq",
+      "groupId": "#seriesmember-$seq",
       "i1": {"property": "marc:seriesTracingPolicy", "TODO:marcDefault": 0, "TODO": {"when: 8xx[$t] | 830": "1", "else": "0"}},
       "i2": null,
-      "TODO:allowSpillOverOnRevert": "800-830 (solved by groupId?)",
       "$a": {"addProperty": "seriesStatement"},
       "NOTE:remove?$l": {"link": "callno", "resourceType": "Concept", "property": "code"},
       "$0": {"about": "_:seriesinstance", "addProperty": "marc:uri"},
@@ -12892,7 +12891,7 @@
     },
     "800": {
       "include": ["hasSeriesInstance", "titledetails", "contributionRole_4_e"],
-      "TODO:whenSoftMergeWorks:groupId": "#seriesmember-$seq",
+      "groupId": "#seriesmember-$seq",
       "pendingResources": {
         "_:agent": {
           "about": "_:contribution",
@@ -13069,7 +13068,7 @@
     },
     "810": {
       "include": ["hasSeriesInstance", "agentdataOrganization", "titledetails", "contributionRole_4_e"],
-      "TODO:whenSoftMergeWorks:groupId": "#seriesmember-$seq",
+      "groupId": "#seriesmember-$seq",
       "pendingResources": {
         "_:agent": {
           "about": "_:contribution",
@@ -13264,7 +13263,7 @@
     },
     "811": {
       "include": ["hasSeriesInstance", "agentdataOrganization", "titledetails", "contributionRole_4"],
-      "TODO:whenSoftMergeWorks:groupId": "#seriesmember-$seq",
+      "groupId": "#seriesmember-$seq",
       "i1": {"marcDefault": "2"},
       "pendingResources": {
         "_:agent": {
@@ -13354,7 +13353,7 @@
     "830": {
       "onRevertPrefer": ["800", "810", "811"],
       "include": ["inseries_with_w", "titledetails", "i2-nonfiling"],
-      "TODO:whenSoftMergeWorks:groupId": "#seriesmember-$seq",
+      "groupId": "#seriesmember-$seq",
       "$a": {"about": "_:title", "property": "mainTitle", "punctuationChars": ".,=;", "required": true},
       "$d": {"about": "_:work", "addProperty": "legalDate"},
       "$0": {"about": "_:work", "addProperty": "marc:uri"},


### PR DESCRIPTION
## Add ProduceIfMissing and SetFlagsByPatterns post-processing steps

These are used to create the necessary data for a bib 490 to be produced
from a SeriesMembership node, which currently only yields a bib 830. The
added data is only added if there is no such data present, to avoid
intentional differences and eliminate duplicates. See specs for details.

## Re-enable groupId for inseries-related data

This is necessary in order for both bib 490 and 8xx to be produced on
revert from a single SeriesRelationship-node containing both a
seriesStatement and an inSeries relation.

We held off doing this kind of merge of 440+490+8xx-data during the
initial conversion, since records were discovered for which more
intelligent merging appeared necessary.

This re-enabled "dumb" merge logic is deemed OK now in production since
the data continuously imported doesn't have those irregularities.