### PR TITLE
When the batchimport is set to replace a record, any existing SystemN…

### DIFF
--- a/batchimport/integtest/batch0.xml
+++ b/batchimport/integtest/batch0.xml
@@ -11,7 +11,7 @@
       <subfield code="q">inbunden</subfield>
     </datafield>
     <datafield tag="035" ind1=" " ind2=" ">
-      <subfield code="a">(BOKR)9789150222319</subfield>
+      <subfield code="a">(BOKR)9789150222319_OLD</subfield>
     </datafield>
     <datafield tag="040" ind1=" " ind2=" ">
       <subfield code="a">BOKR</subfield>

--- a/batchimport/integtest/batch1.xml
+++ b/batchimport/integtest/batch1.xml
@@ -11,7 +11,7 @@
       <subfield code="q">inbunden</subfield>
     </datafield>
     <datafield tag="035" ind1=" " ind2=" ">
-      <subfield code="a">(BOKR)9789150222319</subfield>
+      <subfield code="a">(BOKR)9789150222319_NEW</subfield>
     </datafield>
     <datafield tag="040" ind1=" " ind2=" ">
       <subfield code="a">BOKR</subfield>

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -1,5 +1,6 @@
 package whelk.importer;
 
+import groovy.lang.Tuple;
 import io.prometheus.client.Counter;
 import se.kb.libris.util.marc.Datafield;
 import se.kb.libris.util.marc.Field;
@@ -189,6 +190,11 @@ class XL
                         List<String> recordIDs = doc.getRecordIdentifiers();
                         List<String> thingIDs = doc.getThingIdentifiers();
                         String controlNumber = doc.getControlNumber();
+                        List<Tuple> typedIDs = doc.getTypedRecordIdentifiers();
+                        List<String> systemNumbers = new ArrayList<>();
+                        for (Tuple tuple : typedIDs)
+                            if (tuple.get(0).equals("SystemNumber"))
+                                systemNumbers.add( (String) tuple.get(1) );
 
                         doc.data = rdfDoc.data;
 
@@ -199,6 +205,8 @@ class XL
                             doc.addRecordIdentifier(recordID);
                         for (String thingID : thingIDs)
                             doc.addThingIdentifier(thingID);
+                        for (String systemNumber : systemNumbers)
+                            doc.addTypedRecordIdentifier("SystemNumber", systemNumber);
                         if (controlNumber != null)
                             doc.setControlNumber(controlNumber);
                     });

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -383,6 +383,40 @@ class Document {
         }
     }
 
+    void addTypedRecordIdentifier(String type, String identifier) {
+        if (identifier == null)
+            throw new NullPointerException("Attempted to add typed null-identifier.")
+
+        if (preparePath(recordTypedIDsPath)) {
+            Object typedIDList = get(recordTypedIDsPath)
+            if (typedIDList == null || !(typedIDList instanceof List)) {
+                set(recordTypedIDsPath, [])
+                typedIDList = get(recordTypedIDsPath)
+            }
+
+            def idObject = ["value": identifier, "@type": type]
+            if (typedIDList.every { it -> it != idObject })
+                typedIDList.add(idObject)
+        }
+    }
+
+    void addTypedThingIdentifier(String type, String identifier) {
+        if (identifier == null)
+            throw new NullPointerException("Attempted to add typed null-identifier.")
+
+        if (preparePath(thingTypedIDsPath)) {
+            Object typedIDList = get(thingTypedIDsPath)
+            if (typedIDList == null || !(typedIDList instanceof List)) {
+                set(thingTypedIDsPath, [])
+                typedIDList = get(thingTypedIDsPath)
+            }
+
+            def idObject = ["value": identifier, "@type": type]
+            if (typedIDList.every { it -> it != idObject })
+                typedIDList.add(idObject)
+        }
+    }
+
     /**
      * Return a list of external references in the doc.
      *


### PR DESCRIPTION
…umbers

(035$A) is kept, alongside various other IDs.