### PR TITLE
Export all affected bib records when a holding record is relinked mul…

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -138,6 +138,12 @@ public class ProfileExport
         {
             List<Document> versions = m_whelk.getStorage().loadAllVersions(id);
 
+            // The 'versions' list is sorted, with the most recent version first.
+            // 1. We iterate through the list, skipping (continue) until we've found a
+            // version inside the update interval.
+            // 2. We keep iterating over versions and check if we're still inside the
+            // interval _after_ each iteration, which means we will pass (export) all
+            // versions inside the interval and exactly one version "before" the interval.
             for (Document version : versions)
             {
                 String itemOf = version.getHoldingFor();
@@ -154,7 +160,7 @@ public class ProfileExport
 
                 boolean insideInterval = from.toInstant().isBefore(modified) && until.toInstant().isAfter(modified);
                 if ( !insideInterval )
-                    break; // Only one more once outside the interval, then stop.
+                    break;
             }
         }
 

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -141,7 +141,7 @@ public class ProfileExport
             for (Document version : versions)
             {
                 String itemOf = version.getHoldingFor();
-                Instant modified =  ZonedDateTime.parse(version.getModified()).toInstant();
+                Instant modified = ZonedDateTime.parse(version.getModified()).toInstant();
 
                 if (modified.isAfter(until.toInstant()))
                     continue;


### PR DESCRIPTION
…tiple times.

When a holding record is relinked multiple times within an export-interval
we would previously only export the newly linked bib and the previously linked
bib. That is not enough, since a holding may have been relinked (to different
bibs) more than once during an interval.

The new approach is to export all bibs to which the holding _has_ been linked
within the update interval (including the bib it was linked to before the inteval).

As an implementation detail the initial scan for changes is now done on the
versions table instead of lddb, which means that exporting from time A to B
will always produce the same result, regardless of whether or not the records
that changed within that interval are changed again after the interval.