### PR TITLE
Feature/whelktool improvements

### DIFF
--- a/whelktool/scripts/2018/09/fix-rda-links.groovy
+++ b/whelktool/scripts/2018/09/fix-rda-links.groovy
@@ -47,7 +47,7 @@ selectByCollection('bib') { data ->
         it.each {
             if (fixRdaLink(it)) {
                 // TODO: when correct, eliminate possible duplicate in List
-                data.scheduleSave()
+                data.scheduleSave(loud: false)
             }
         }
     }

--- a/whelktool/scripts/2018/10/fix-unbalanced-brackets.groovy
+++ b/whelktool/scripts/2018/10/fix-unbalanced-brackets.groovy
@@ -46,7 +46,7 @@ void fixValueInData(data, container, key, value) {
         def fixed = fixBalancedBrackets(value)
         if (fixed != value) {
             container[key] = fixed
-            data.scheduleSave(false)
+            data.scheduleSave(loud: false)
         }
     } else {
         findAndFixValuesInData(data, value)

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -531,7 +531,6 @@ class DocumentItem {
     }
 
     void scheduleSave(Map params=[:]) {
-        assert params.containsKey('loud') : "Please state if change is loud or not"
         needsSaving = true
         set(params)
     }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -489,13 +489,13 @@ class WhelkTool {
 
     static void main(String[] args) {
         def cli = new CliBuilder(usage:'whelktool [options] <SCRIPT>')
-        cli.h(longOpt: 'help', 'Print this help message')
-        cli.r(longOpt:'report', args:1, argName:'REPORT-DIR', 'Directory where reports are written (defaults to "reports")')
-        cli.d(longOpt:'dry-run', 'Do not save any modifications')
-        cli.T(longOpt:'no-threads', 'Do not use threads to parallellize batch processing')
-        cli.s(longOpt:'step', 'Change one document at a time, prompting to continue')
+        cli.h(longOpt: 'help', 'Print this help message and exit.')
+        cli.r(longOpt:'report', args:1, argName:'REPORT-DIR', 'Directory where reports are written (defaults to "reports").')
+        cli.d(longOpt:'dry-run', 'Do not save any modifications.')
+        cli.T(longOpt:'no-threads', 'Do not use threads to parallellize batch processing.')
+        cli.s(longOpt:'step', 'Change one document at a time, prompting to continue.')
         cli.l(longOpt:'limit', args:1, argName:'LIMIT', 'Amount of documents to process.')
-        cli.a(longOpt:'allow-loud', 'Allow scripts do do loud modifications')
+        cli.a(longOpt:'allow-loud', 'Allow scripts to do loud modifications.')
 
         def options = cli.parse(args)
         if (options.h) {

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -47,6 +47,8 @@ class WhelkTool {
     boolean stepWise
     int limit = -1
 
+    boolean allowLoud
+
     private boolean errorDetected
 
     private def jsonWriter = new ObjectMapper().writerWithDefaultPrettyPrinter()
@@ -345,6 +347,9 @@ class WhelkTool {
 
     private void doModification(DocumentItem item) {
         Document doc = item.doc
+        if (item.loud) {
+            assert allowLoud : "Loud changes need to be explicitly allowed"
+        }
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
@@ -432,6 +437,7 @@ class WhelkTool {
         if (stepWise) log "  stepWise"
         if (noThreads) log "  noThreads"
         if (limit > -1) log "  limit: $limit"
+        if (allowLoud) log "  allowLoud"
         log()
         Bindings bindings = createMainBindings()
         script.eval(bindings)
@@ -482,6 +488,7 @@ class WhelkTool {
         cli.T(longOpt:'no-threads', 'Do not use threads to parallellize batch processing')
         cli.s(longOpt:'step', 'Change one document at a time, prompting to continue')
         cli.l(longOpt:'limit', args:1, argName:'LIMIT', 'Amount of documents to process.')
+        cli.a(longOpt:'allow-loud', 'Allow scripts do do loud modifications')
 
         def options = cli.parse(args)
         if (options.h) {
@@ -496,6 +503,7 @@ class WhelkTool {
         tool.stepWise = options.s
         tool.noThreads = options.T
         tool.limit = options.l ? Integer.parseInt(options.l) : -1
+        tool.allowLoud = options.a
         tool.run()
     }
 

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -508,34 +508,29 @@ class DocumentItem {
     private Whelk whelk
     private boolean needsSaving = false
     private boolean doDelete = false
-    private boolean loud = true
+    private boolean loud = false
     Closure onError = null
 
     def List getGraph() {
         return doc.data['@graph']
     }
 
-    void scheduleSave(boolean loud=true) {
-        scheduleSave(loud: loud)
-    }
-
-    void scheduleSave(Map params) {
+    void scheduleSave(Map params=[:]) {
+        assert params.containsKey('loud') : "Please state if change is loud or not"
         needsSaving = true
         set(params)
     }
 
-    void scheduleDelete(boolean loud=true) {
-        scheduleDelete(loud: true)
-    }
-
-    void scheduleDelete(Map params) {
+    void scheduleDelete(Map params=[:]) {
         needsSaving = true
         doDelete = true
         set(params)
     }
 
     private void set(Map params) {
-        this.loud = params.get('loud', true)
+        if (params.containsKey('loud')) {
+            this.loud = params.loud
+        }
         this.onError = params.onError
     }
 

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -430,8 +430,15 @@ class WhelkTool {
 
     private void run() {
         log "Running Whelk against:"
-        log "  PostgreSQL: ${whelk.storage.connectionPool.url}"
-        log "  ElasticSearch: ${whelk.elastic?.elasticHosts}"
+        log "  PostgreSQL:"
+        log "    url:     ${whelk.storage.connectionPool.url}"
+        log "    table:   ${whelk.storage.mainTableName}"
+        if (whelk.elastic) {
+            log "  ElasticSearch:"
+            log "    hosts:   ${whelk.elastic.elasticHosts}"
+            log "    cluster: ${whelk.elastic.elasticCluster}"
+            log "    index:   ${whelk.elastic.defaultIndex}"
+        }
         log "Using script: $scriptFile"
         if (dryRun) log "  dryRun"
         if (stepWise) log "  stepWise"


### PR DESCRIPTION
This mainly changes `loud` to false by default, requiring an explicit keyword to set it, and adds a cmdline flag (`--allow-loud`) as a safety measure when running scripts using loud changes.