### PR TITLE
Make batch import default: Only new records

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Parameters.java
+++ b/batchimport/src/main/java/whelk/importer/Parameters.java
@@ -23,6 +23,8 @@ class Parameters
     private boolean verbose = false;
     private boolean replaceHold = false;
     private boolean replaceBib = false;
+    private boolean mergeHold = false;
+    private boolean mergeBib = false;
     private String changedBy = null;
     private String changedIn = null;
 
@@ -37,6 +39,8 @@ class Parameters
     boolean getVerbose() { return verbose; }
     boolean getReplaceHold() { return replaceHold; }
     boolean getReplaceBib() { return replaceBib; }
+    boolean getMergeHold() { return mergeHold; }
+    boolean getMergeBib() { return mergeBib; }
     String getChangedBy() { return changedBy; }
     String getChangedIn() { return changedIn; }
 
@@ -78,6 +82,18 @@ class Parameters
         if (format == null)
         {
             printUsage();
+            System.exit(-1);
+        }
+
+        if (replaceBib && mergeBib)
+        {
+            System.err.println("Cannot both replace and merge bib.");
+            System.exit(-1);
+        }
+
+        if (replaceHold && mergeHold)
+        {
+            System.err.println("Cannot both replace and merge hold.");
             System.exit(-1);
         }
     }
@@ -151,9 +167,17 @@ class Parameters
         System.err.println("");
         System.err.println("--verbose     Verbose logging.");
         System.err.println("");
-        System.err.println("--replaceBib  If this flag is set, bibliographic records will be replaced instead of merged.");
+        System.err.println("--replaceBib  If this flag is set, matching bibliographic records will be replaced.");
+        System.err.println("              Mutually exclusive with --mergeBib");
         System.err.println("");
-        System.err.println("--replaceHold If this flag is set, holding records will be replaced instead of merged.");
+        System.err.println("--replaceHold If this flag is set, matching holding records will be replaced.");
+        System.err.println("              Mutually exclusive with --mergeHold");
+        System.err.println("");
+        System.err.println("--mergeBib    If this flag is set, matching bibliographic records will be merged.");
+        System.err.println("              Mutually exclusive with --replaceBib");
+        System.err.println("");
+        System.err.println("--mergeHold   If this flag is set, matching holding records will be merged.");
+        System.err.println("              Mutually exclusive with --replaceHold");
         System.err.println("");
         System.err.println("--changedBy   A string to use as descriptionCreator (MARC 040) for imported records.");
         System.err.println("--changedIn   A string to use for the changedIn column, defaults to \"batch import\".");
@@ -250,6 +274,12 @@ class Parameters
                 break;
             case "--replaceBib":
                 replaceBib = true;
+                break;
+            case "--mergeHold":
+                mergeHold = true;
+                break;
+            case "--mergeBib":
+                mergeBib = true;
                 break;
             default:
                 throw new IllegalArgumentException(parameter);

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -102,35 +102,30 @@ class XL
             else
                 importedHoldRecords.inc();
         }
-        else if (duplicateIDs.size() == 1) // Enrich ("merge") or replace
+        else if (duplicateIDs.size() == 1) // merge, keep or replace
         {
-            if (collection.equals("bib"))
+            // replace
+            if ((m_parameters.getReplaceBib() && collection.equals("bib")) ||
+                    m_parameters.getReplaceHold() && collection.equals("hold"))
             {
-                if ( m_parameters.getReplaceBib() )
-                {
-                    String idToReplace = duplicateIDs.iterator().next();
-                    resultingResourceId = importNewRecord(incomingMarcRecord, collection, relatedWithBibResourceId, idToReplace);
-                    importedBibRecords.inc();
-                }
-                else // Merge bib
-                {
-                    resultingResourceId = enrichRecord((String) duplicateIDs.toArray()[0], incomingMarcRecord, collection, relatedWithBibResourceId);
-                    enrichedBibRecords.inc();
-                }
+                String idToReplace = duplicateIDs.iterator().next();
+                resultingResourceId = importNewRecord(incomingMarcRecord, collection, relatedWithBibResourceId, idToReplace);
             }
-            else // collection = hold
+
+            // merge
+            else if ((m_parameters.getMergeBib() && collection.equals("bib")) ||
+                    m_parameters.getMergeHold() && collection.equals("hold"))
             {
-                if ( m_parameters.getReplaceHold() ) // Replace hold
-                {
-                    String idToReplace = duplicateIDs.iterator().next();
-                    resultingResourceId = importNewRecord(incomingMarcRecord, collection, relatedWithBibResourceId, idToReplace);
-                    importedHoldRecords.inc();
-                }
-                else // Merge hold
-                {
-                    resultingResourceId = enrichRecord((String) duplicateIDs.toArray()[0], incomingMarcRecord, collection, relatedWithBibResourceId);
-                    enrichedHoldRecords.inc();
-                }
+                resultingResourceId = enrichRecord((String) duplicateIDs.toArray()[0], incomingMarcRecord, collection, relatedWithBibResourceId);
+            }
+
+            // Keep existing
+            else
+            {
+                if (collection.equals("bib"))
+                    resultingResourceId = m_whelk.getStorage().getThingId((String) duplicateIDs.toArray()[0]);
+                else
+                    resultingResourceId = null;
             }
         }
         else


### PR DESCRIPTION
Before this, the default behvaiour was to merge matching exsting
records with new incoming ones (or optionally replace them).

Whith this change, the default will be to not touch matching existing
records, but rather just add new bibs and holds (possibly on pre-existing bibs).

The previous default moves out into two parameters:
--mergeHold and --mergeBib respectively.

THIS IS A PULL REQUEST INTO A HOTFIX BRANCH!