### PR TITLE
Handle unresolvable facets

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -418,7 +418,17 @@ class SearchUtils {
         if (termKey in ld.vocabIndex) {
             return ld.vocabIndex[termKey]
         }
-        String fullId = vocabUri ? vocabUri.resolve(id).toString() : id
+        String fullId
+        try {
+            if (vocabUri) {
+                fullId = vocabUri.resolve(id).toString()
+            }
+        }
+        catch (java.lang.IllegalArgumentException e) {
+            // Couldn't resolve, which means id isn't a valid IRI.
+            // No need to check the db.
+            return null
+        }
         Document doc = whelk.storage.getDocumentByIri(fullId)
 
         if (doc) {


### PR DESCRIPTION
The facet '210 ' would previously crash in the call to `resolve`, so we
catch it instead.