### PR TITLE
Fix two import bugs.

### DIFF
--- a/batchimport/integtest/batch10.xml
+++ b/batchimport/integtest/batch10.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record type="Bibliographic">
+    <leader>02625cam a22007458i 4500</leader>
+    <controlfield tag="001">1390474</controlfield>
+    <controlfield tag="003">SE-LIBR</controlfield>
+    <controlfield tag="005">20170713141440.0</controlfield>
+    <controlfield tag="008">170327s2017    sw ||||j     |00| 0|swe d</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">978-91-502-2231-9</subfield>
+      <subfield code="q">inbunden</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(BOKR)9789150222319_OLD</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">BOKR</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">Bently, Peter</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Polisbilen får ett larm</subfield>
+    </datafield>
+    <datafield tag="263" ind1=" " ind2=" ">
+      <subfield code="a">201709</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="1">
+      <subfield code="b">Berghs,</subfield>
+      <subfield code="c">2017</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">32 sidor :</subfield>
+      <subfield code="b">illustrationer</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="599" ind1=" " ind2=" ">
+      <subfield code="a">Maskinellt genererad post. Ändra kod för fullständighetsnivå (leader/17), annars kommer manuellt gjorda ändringar att försvinna.</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Lightfoot, Marta</subfield>
+      <subfield code="4">ill</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Vidén, Eva</subfield>
+      <subfield code="4">trl</subfield>
+    </datafield>
+  </record>
+  <record type="Holdings">
+    <leader>XXXXXax  a22XXXXX1n 4500</leader>
+    <controlfield tag="008">170714||0000|||||000||||||000000</controlfield>
+    <datafield tag="852" ind1="" ind2="">
+      <subfield code="b">Sods</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/batchimport/integtest/test.sh
+++ b/batchimport/integtest/test.sh
@@ -170,6 +170,18 @@ if (( $rowCount != 1 )) ; then
     fail "Expected single hold record (after IBSN$z 10/13 test)"
 fi
 
+cleanup
+# Should match an existing example record (on Voyager-style LIBRIS-ID), and only add the holding
+java -jar build/libs/batchimport.jar --path=./integtest/batch10.xml --format=xml --dupType=LIBRIS-ID --live --changedIn=importtest
+rowCount=$(psql -qAt whelk_dev <<< "select count(*) from lddb where changedIn = 'importtest' and collection = 'bib'")
+if (( $rowCount != 0 )) ; then
+    fail "Expected no bib record"
+fi
+rowCount=$(psql -qAt whelk_dev <<< "select count(*) from lddb where changedIn = 'importtest' and collection = 'hold'")
+if (( $rowCount != 1 )) ; then
+    fail "Expected single hold record"
+fi
+
 
 cleanup
 popd

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1176,10 +1176,10 @@ class PostgreSQLComponent {
     }
 
     /**
-     * Get the corresponding record main ID for supplied identifier
+     * Get the corresponding record main URI for supplied identifier
      *
-     * Supplied identifier can be either the document ID, the thing ID, or a
-     * sameAs ID.
+     * Supplied identifier can be either the document URI, the thing URI, or a
+     * sameAs URI, BUT NOT A SYSTEM ID.
      *
      */
     String getRecordId(String id) {
@@ -1199,8 +1199,8 @@ class PostgreSQLComponent {
     /**
      * Get the corresponding thing main ID for supplied identifier
      *
-     * Supplied identifier can be either the document ID, the thing ID, or a
-     * sameAs ID.
+     * Supplied identifier can be either the document URI, the thing URI, or a
+     * sameAs URI, BUT NOT A SYSTEM ID.
      *
      */
     String getThingId(String id) {


### PR DESCRIPTION
1. When the bib action was (default) to leave records alone,
the holds following would fall away and not reference the left alone
record.

2. Matching on LIBRIS-ID did not work because the MarcRecord
from which a 001 search candidate was obtained was ruined by an
earlier convertToRdf call (that call is now no longer destructive).