### PR TITLE
Feature/merge publication on fuzzy dates

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
@@ -249,8 +249,7 @@ class RestructPropertyValuesAndFlagStep extends MarcFramePostProcStepBase {
                 if ((!flagRule.revertRequiresNo ||
                         !target.containsKey(flagRule.revertRequiresNo)) &&
                     (targetContainsSomeRemapped ||
-                     (!fuzzyMergeProperty || onlyExpectedValuesInFuzzyProperty)
-                    )
+                     onlyExpectedValuesInFuzzyProperty)
                    ) {
                     mergeOk = ld.softMerge(obj, target)
                 }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
@@ -274,7 +274,6 @@ class RestructPropertyValuesAndFlagStep extends MarcFramePostProcStepBase {
         if (fuzzyMergeProperty) {
             String fuzzyValue = target[fuzzyMergeProperty]
             if (fuzzyValue) {
-                fuzzyValue = fuzzPattern.matcher(fuzzyValue).replaceAll('')
                 strictProperties.each {
                     String v = obj[it]
                     if (v) {
@@ -288,6 +287,7 @@ class RestructPropertyValuesAndFlagStep extends MarcFramePostProcStepBase {
                         fuzzyValue = fuzzyValue.replaceFirst(vPattern, '')
                     }
                 }
+                fuzzyValue = fuzzPattern.matcher(fuzzyValue).replaceAll('')
                 return fuzzyValue.trim() == ''
             }
         }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -6847,7 +6847,7 @@
         "splitValueProperties": ["startYear", "endYear"],
         "allowEmpty": true,
         "rejoin": "-",
-        "leadingPunctuation": ",", "punctuationChars": ",;"
+        "leadingPunctuation": ",", "punctuationChars": ".,;"
       },
       "$e": {"aboutNew": "_:manufacture", "link": "place", "resourceType": "Place", "property": "label", "punctuationChars": ",:;", "surroundingChars" : "()"},
       "$f": {"about": "_:manufacture", "link": "agent", "resourceType": "Agent", "property": "label", "leadingPunctuation": " :", "punctuationChars": ",:;)"},
@@ -7346,7 +7346,7 @@
         "splitValueProperties": ["startYear", "endYear"],
         "allowEmpty": true,
         "rejoin": "-",
-        "leadingPunctuation": ","
+        "leadingPunctuation": ",", "punctuationChars": ".,;"
       },
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label", "trailingPunctuation": ":"},
       "$6": {"property": "marc:fieldref"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1410,8 +1410,8 @@
         "flagProperty": "marc:publicationStatus",
         "matchValuePattern": "^[0-9u]{4}$",
         "fuzzyMergeProperty": "date",
-        "fuzzPattern": "[^0-9u]+",
-        "magicValueParts": {"u+": "\\d+"},
+        "fuzzPattern": "[^0-9]+",
+        "magicValueParts": {"u": "[0-9uxUX?-]"},
         "flagMatch": {
           "marc:PublicationDateAndCopyrightDate": {
             "mergeFirstLink": "publication",
@@ -1729,6 +1729,45 @@
               ]
             },
             "back": "both"
+          },
+          {
+            "name":  "Treating fuzzy date like startYear plus endYear with magic 'u'",
+            "source": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:ContinuingResourceCeasedPublication",
+                "year": "197u",
+                "otherYear": "202u"
+              },
+              "publication": [ {"@type": "Publication", "date": "[ca 197?-202-]"} ]
+            },
+            "result": {
+              "publication": [
+                {
+                  "@type": "PrimaryPublication",
+                  "startYear": "197u",
+                  "endYear": "202u",
+                  "date": "[ca 197?-202-]"
+                }
+              ]
+            },
+            "back": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:ContinuingResourceCeasedPublication",
+                "year": "197u",
+                "otherYear": "202u",
+                "date": "[ca 197?-202-]"
+              },
+              "publication": [
+                {
+                  "@type": "PrimaryPublication",
+                  "startYear": "197u",
+                  "endYear": "202u",
+                  "date": "[ca 197?-202-]"
+                }
+              ]
+            }
           },
           {
             "source": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1410,7 +1410,8 @@
         "flagProperty": "marc:publicationStatus",
         "matchValuePattern": "^[0-9u]{4}$",
         "fuzzyMergeProperty": "date",
-        "fuzzPattern": "[^0-9u]{1,3}",
+        "fuzzPattern": "[^0-9u]+",
+        "magicValueParts": {"u+": "\\d+"},
         "flagMatch": {
           "marc:PublicationDateAndCopyrightDate": {
             "mergeFirstLink": "publication",
@@ -1517,6 +1518,7 @@
             "back": "both"
           },
           {
+            "name":  "Treating date as 'fuzzy like' year",
             "source": {
               "marc:primaryProvisionActivity": {
                 "@type": "PrimaryProvisionActivity",
@@ -1539,6 +1541,33 @@
               },
               "publication": [
                 {"@type": "PrimaryPublication", "year": "1977", "date": "ca 1977"}
+              ]
+            }
+          },
+          {
+            "name":  "Treating fuzzy date like year with magic 'u'",
+            "source": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:SingleKnownDateProbableDate",
+                "year": "197u"
+              },
+              "publication": [ {"@type": "Publication", "date": "likely 1977?"} ]
+            },
+            "result": {
+              "publication": [
+                {"@type": "PrimaryPublication", "year": "197u", "date": "likely 1977?"}
+              ]
+            },
+            "back": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:SingleKnownDateProbableDate",
+                "year": "197u",
+                "date": "likely 1977?"
+              },
+              "publication": [
+                {"@type": "PrimaryPublication", "year": "197u", "date": "likely 1977?"}
               ]
             }
           },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1411,7 +1411,7 @@
         "matchValuePattern": "^[0-9u]{4}$",
         "fuzzyMergeProperty": "date",
         "fuzzPattern": "[^0-9]+",
-        "magicValueParts": {"u": "[0-9uxUX?-]"},
+        "magicValueParts": {"u": "[0-9nuxNUX?-]"},
         "flagMatch": {
           "marc:PublicationDateAndCopyrightDate": {
             "mergeFirstLink": "publication",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1409,6 +1409,8 @@
         "overwriteType": "PrimaryProvisionActivity",
         "flagProperty": "marc:publicationStatus",
         "matchValuePattern": "^[0-9u]{4}$",
+        "fuzzyMergeProperty": "date",
+        "fuzzPattern": "[^0-9u]{1,3}",
         "flagMatch": {
           "marc:PublicationDateAndCopyrightDate": {
             "mergeFirstLink": "publication",
@@ -1525,16 +1527,20 @@
             },
             "result": {
               "publication": [
-                {"@type": "PrimaryPublication", "year": "1977"},
-                {"@type": "Publication", "date": "ca 1977"}
-              ]
-            },
-            "TODO:desired": {
-              "publication": [
                 {"@type": "PrimaryPublication", "year": "1977", "date": "ca 1977"}
               ]
             },
-            "back": "both"
+            "back": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:SingleKnownDateProbableDate",
+                "year": "1977",
+                "date": "ca 1977"
+              },
+              "publication": [
+                {"@type": "PrimaryPublication", "year": "1977", "date": "ca 1977"}
+              ]
+            }
           },
           {
             "source": {
@@ -1650,15 +1656,20 @@
                 {
                   "@type": "PrimaryPublication",
                   "startYear": "1977",
+                  "date": "[1977-]",
                   "country": [ {"@id": "https://id.kb.se/country/sw"} ]
-                },
-                {
-                  "@type": "Publication",
-                  "date": "[1977-]"
                 }
               ]
             },
-            "TODO:desired": {
+            "back": {
+              "marc:primaryProvisionActivity": {
+                "@type": "PrimaryProvisionActivity",
+                "marc:publicationStatus": "marc:ContinuingResourceCurrentlyPublished",
+                "year": "1977",
+                "otherYear": "9999",
+                "date": "[1977-]",
+                "country": [ {"@id": "https://id.kb.se/country/sw"} ]
+              },
               "publication": [
                 {
                   "@type": "PrimaryPublication",
@@ -1667,8 +1678,7 @@
                   "country": [ {"@id": "https://id.kb.se/country/sw"} ]
                 }
               ]
-            },
-            "back": "both"
+            }
           },
           {
             "source": {

--- a/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
+++ b/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
@@ -32,6 +32,11 @@ selectBySqlWhere('''
             if (data.whelk.jsonld.softMerge(obj, it)) {
                 data.scheduleSave(loud: false)
                 removeFirst = true
+                if (it.date instanceof String &&
+                    it.date.endsWith('.') &&
+                    it.date[0..-2] == it.year) {
+                    it.remove('date')
+                }
             }
         }
     }

--- a/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
+++ b/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
@@ -14,6 +14,8 @@ boolean checkFuzzyDate(obj, target) {
 
 selectBySqlWhere('''
     data#>>'{@graph,1,publication}' LIKE '%"PrimaryPublication"%"Publication"%'
+    OR
+    data#>>'{@graph,1,publication}' LIKE '%"PrimaryPublication"%"PrimaryPublication"%'
 ''') { data ->
     def (record, instance, work) = data.graph
 
@@ -25,6 +27,13 @@ selectBySqlWhere('''
 
     if (!(publications instanceof List) || publications.size() < 2) {
         return
+    }
+
+    // Remove trivial duplicates
+    Set seenPublications = new HashSet()
+    publications.removeAll {
+        boolean justAdded = seenPublications.add(it)
+        return !justAdded
     }
 
     // Merge PrimaryPublication into first fuzzy-date-matching Publication.

--- a/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
+++ b/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
@@ -8,7 +8,7 @@ merger = new RestructPropertyValuesAndFlagStep(
 )
 
 boolean checkFuzzyDate(obj, target) {
-    def props = ['year'] // TODO: or startYear, endYear
+    def props =  'startYear' in obj ? ['startYear', 'endYear'] : ['year']
     return merger.checkOnlyExpectedValuesInFuzzyProperty(target, obj, props)
 }
 

--- a/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
+++ b/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
@@ -47,6 +47,10 @@ selectBySqlWhere('''
                 if (data.whelk.jsonld.softMerge(primary, it)) {
                     data.scheduleSave(loud: false)
                     removeFirst = true
+                    if (it.date instanceof List &&
+                        it.date.size() == 1) {
+                        it.date = it.date[0]
+                    }
                     if (it.date instanceof String &&
                         it.date.endsWith('.') &&
                         it.date[0..-2] == it.year) {

--- a/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
+++ b/whelktool/scripts/2018/11/cleanup-publication-duplicates.groovy
@@ -1,0 +1,43 @@
+import whelk.converter.marc.RestructPropertyValuesAndFlagStep
+
+merger = new RestructPropertyValuesAndFlagStep(
+    matchValuePattern: '^[0-9u]{4}$',
+    fuzzyMergeProperty: "date",
+    fuzzPattern: "[^0-9]+",
+    magicValueParts: ["u": "[0-9nuxNUX?-]"]
+)
+
+boolean checkFuzzyDate(obj, target) {
+    def props = ['year'] // TODO: or startYear, endYear
+    return merger.checkOnlyExpectedValuesInFuzzyProperty(target, obj, props)
+}
+
+selectBySqlWhere('''
+    data#>>'{@graph,1,publication}' LIKE '%"PrimaryPublication"%"Publication"%'
+''') { data ->
+    def (record, instance, work) = data.graph
+
+    if (!isInstanceOf(instance, 'Instance')) {
+        return
+    }
+
+    if (instance.publication.size() < 2) {
+        return
+    }
+
+    def obj = instance.publication[0]
+    boolean removeFirst = false
+    instance.publication[1].with {
+        if (checkFuzzyDate(obj, it)) {
+            if (data.whelk.jsonld.softMerge(obj, it)) {
+                data.scheduleSave(loud: false)
+                removeFirst = true
+            }
+        }
+    }
+    if (removeFirst) {
+        instance.publication.remove(0)
+    }
+
+
+}


### PR DESCRIPTION
This compares date (as well as startYear plus optional endYear) with year for fuzzy equivalence when merging a PrimaryPublication. We do so by removing defined "fuzz" from the fuzzy value, and then remove the stricter dates as well. If the result is empty, the fuzzy date is considered equivalent enough.

Feature includes:
* Updated marcframe logic
* A whelktool script (to change approx. 2.1 M descriptions)
