### PR TITLE
Only re-add fully uncompleted fields

### DIFF
--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -201,11 +201,17 @@ class MarcFrameConverterSpec extends Specification {
             controlNumber: "0000000",
             "mainEntity": [
                 "@type": "Instance",
-                "instanceOf": ["@type": "Text"]
+                "instanceOf": [
+                    "@type": "Text",
+                    "contribution": [
+                        ["@type": "PrimaryContribution",
+                         "agent": ["@type": "Person", "name": "X"]]
+                    ]
+                ]
             ],
             _marcUncompleted: [
                 ["008": "020409 | anznnbabn          |EEEEEEEEEEE"],
-                ["100": ["ind1": "0", "subfields": [["?": "?"]]], "_unhandled": ["?"]]
+                ["100": ["ind1": "0", "subfields": [["a": "X"]]], "_unhandled": ["?"]]
             ]
         ]
         when:
@@ -213,9 +219,10 @@ class MarcFrameConverterSpec extends Specification {
         then:
         result.fields == [
             ["001": "0000000"],
-            ["008": "020409 | anznnbabn          |EEEEEEEEEEE"],
-            ["100": ["ind1": "0", "subfields": [["?": "?"]]]]
+            ["100": ["ind1": "0", "ind2": " ", "subfields": [["a": "X"]]]],
+            ["008": "020409 | anznnbabn          |EEEEEEEEEEE"]
         ]
+
     }
 
     def "should accept sameAs-token-URIs on revert"() {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -448,11 +448,13 @@ class MarcConversion {
                 ? data._marcUncompleted
                 : [data._marcUncompleted]
 
-            // TODO: how to re-add only partially _unhandled?
             marcUncompleted.each {
-                def field = it.clone()
-                field.remove('_unhandled')
-                fields << field
+                // Only re-add *fully* uncompleted fields. (Saved failed fields
+                // with subfields in unhandled are now excluded to avoid field
+                // duplication).
+                if (!it.containsKey('_unhandled')) {
+                    fields << it.clone()
+                }
             }
         }
 


### PR DESCRIPTION
Saved failed fields with subfields in unhandled are now excluded to
avoid field duplication.