### PR TITLE
Remove mapping of 352q, add TODO

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -8174,11 +8174,8 @@
         "about": "_:cartographicobj",
         "property": "count"
       },
-      "$q": {
-        "addLink": "digitalCharacteristic",
-        "resourceType": "EncodingFormat",
-        "property": "label"
-      }
+      "$q": null,
+      "NOTE:$q": {"NOTE:record-count": 0, "TODO": "To enable future imports to EncodingFormat, we need something like onRevertPrefer 347$b to avoid collisions in export."}
     },
     "355": {"ignored": true, "NOTE:record-count": 0, "NOTE:LC": "nac"},
     "357": {"ignored": true, "NOTE:record-count": 0, "NOTE:LC": "nac"},


### PR DESCRIPTION
 digitalCharacteristic/EncodingFormat/label is now mapped only to 347#b in MARC21. Contains TODO about improved future handling.