### PR TITLE
Close *RecordWriter explicitly in LegacyMarcAPI

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
@@ -163,6 +163,7 @@ class LegacyMarcAPI extends HttpServlet {
             for (MarcRecord record : result) {
                 writer.writeRecord(record)
             }
+            writer.close()
             response.getOutputStream().close()
         } catch (Throwable e) {
             log.error("Failed handling _compilemarc request: ", e)


### PR DESCRIPTION
This is needed to ensure that we output the correct closing tags for
XML.