### PR TITLE
Add required to 866$a

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -19297,7 +19297,7 @@
       "embedded": true,
       "i1": {"property": "marc:holdingsLevel", "marcDefault": " "},
       "i2": {"property": "marc:typeOfNotation", "marcDefault": " "},
-      "$a": {"property": "marc:textualString"},
+      "$a": {"property": "marc:textualString", "required": true},
       "$x": {"addProperty": "marc:cataloguersNote"},
       "$z": {"addProperty": "marc:publicNote"},
       "$2": {"property": "marc:sourceOfNotation"},


### PR DESCRIPTION
To prevent fields in marc:hasTextualHoldingsBasicBibliographicUnit to convert into 866 MARC fields when $a is missing.

I could not get a test to validate because it was likely missing 866.