### PR TITLE
Add supplementary true to $0 in subjectbase

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1278,7 +1278,7 @@
 
     "subjectbase": {
       "include": ["subjectbaseSansUri"],
-      "$0": {"addProperty": "marc:uri"}
+      "$0": {"addProperty": "marc:uri", "supplementary": true}
     },
 
     "worksubjectData": {


### PR DESCRIPTION
Will make fields which includes subjectbase in Marcframe (mostly 6xx) filter out data in RDF to MARC21 conversion which only has a $0.