### PR TITLE
Use language container alias map and subproperties on revert

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -133,6 +133,7 @@ class MarcConversion {
     Map marcTypeMap = [:]
     Map tokenMaps
     Map defaultPunctuation
+    String locale
 
     private Set missingTerms = [] as Set
     private Set badRepeats = [] as Set
@@ -144,6 +145,7 @@ class MarcConversion {
         this.tokenMaps = tokenMaps
         this.converter = converter
         //this.baseUri = new URI(config.baseUri ?: '/')
+        this.locale = config.locale
         this.keepGroupIds = config.keepGroupIds == true
 
         this.sharedPostProcSteps = config.postProcessing.collect {
@@ -2441,6 +2443,7 @@ class MarcSubFieldHandler extends ConversionPart {
     String property
     boolean repeatProperty
     boolean overwrite
+    boolean infer
     String resourceType
     String subUriTemplate
     Pattern matchUriToken = null
@@ -2521,6 +2524,8 @@ class MarcSubFieldHandler extends ConversionPart {
         assert !required || !supplementary
 
         overwrite = subDfn.overwrite == true
+
+        infer = subDfn.infer == true
 
         if (subDfn.splitValuePattern) {
             /*TODO: assert subDfn.splitValuePattern=~ /^\^.+\$$/,
@@ -2725,9 +2730,18 @@ class MarcSubFieldHandler extends ConversionPart {
 
             String entityId = entity['@id']
 
-            def propertyValue = property ? entity[property] : null
+            def propertyValue = getPropertyValue(entity, property)
+
             if (propertyValue == null && castProperty)
                 propertyValue = entity[castProperty]
+
+            if (propertyValue == null && infer) {
+                for (subProp in ld.superPropertyOf[property]) {
+                    propertyValue = getPropertyValue(entity, subProp)
+                    if (propertyValue)
+                        break
+                }
+            }
 
             boolean checkResourceType = true
 
@@ -2817,6 +2831,17 @@ class MarcSubFieldHandler extends ConversionPart {
             return values
     }
 
+    def getPropertyValue(Map entity, String property) {
+        def propertyValue = property ? entity[property] : null
+        if (propertyValue == null) {
+            def alias = ld.langContainerAlias[property]
+            propertyValue = alias ? entity[alias] : null
+            if (propertyValue instanceof Map) {
+                propertyValue = propertyValue[ruleSet.conversion.locale]
+            }
+        }
+        return propertyValue
+    }
 }
 
 @CompileStatic

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2736,7 +2736,7 @@ class MarcSubFieldHandler extends ConversionPart {
                 propertyValue = entity[castProperty]
 
             if (propertyValue == null && infer) {
-                for (subProp in ld.superPropertyOf[property]) {
+                for (subProp in ld.getSubProperties(property)) {
                     propertyValue = getPropertyValue(entity, subProp)
                     if (propertyValue)
                         break

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1056,7 +1056,7 @@
     },
 
     "agentdataCollectiveDetails": {
-      "$c": {"about": "_:place", "property": "label"},
+      "$c": {"about": "_:place", "property": "label", "infer": true},
       "$d": {"about": "_:agent", "addProperty": "date", "TODO?:leadingPunctuation": ","}
     },
 
@@ -4471,7 +4471,7 @@
       },
       "$b": {"addProperty": "marc:geographicClassificationAreaCode"},
       "$c": {"addProperty": "marc:geographicClassificationSubareaCode"},
-      "$p": {"addLink": "place", "resourceType": "Place", "property": "label"},
+      "$p": {"addLink": "place", "resourceType": "Place", "property": "label", "infer": true},
       "$0": {"addProperty": "marc:recordControlNumber", "NOTE:local": "Används ej"},
       "$1": {"addProperty": "marc:rwoURI"},
       "$2": {"property": "marc:placeCodeSource"},
@@ -4810,7 +4810,7 @@
 
     "038": {
       "aboutEntity": "?record",
-      "$a": {"link": "metadataLicensor", "resourceType": "Organization", "property": "label"}
+      "$a": {"link": "metadataLicensor", "resourceType": "Organization", "property": "label", "infer": true}
     },
 
     "040": {
@@ -7446,8 +7446,8 @@
       "pendingResources": {
         "_:part": {"addLink": "hasPart", "resourceType": "ProvisionActivity", "absorbSingle": true}
       },
-      "$a": {"aboutNew": "_:part", "link": "place", "resourceType": "Place", "property": "label", "leadingPunctuation": " ;"},
-      "$b": {"aboutAltNew": "_:part", "link": "agent", "resourceType": "Agent", "property": "label", "leadingPunctuation": " :"},
+      "$a": {"aboutNew": "_:part", "link": "place", "resourceType": "Place", "property": "label", "infer": true, "leadingPunctuation": " ;"},
+      "$b": {"aboutAltNew": "_:part", "link": "agent", "resourceType": "Agent", "property": "label", "infer": true, "leadingPunctuation": " :"},
       "$c": {
         "property": "date",
         "castPattern": "^([0-9u]{4})$",
@@ -9080,7 +9080,7 @@
       "embedded": true,
       "$a": {"property": "label"},
       "$b": {"property": "degree"},
-      "$c": {"link": "grantingInstitution", "resourceType": "Agent", "property": "label"},
+      "$c": {"link": "grantingInstitution", "resourceType": "Agent", "property": "label", "infer": true},
       "$d": {"property": "date", "leadingPunctuation": ","},
       "$g": {"addProperty": "comment"},
       "$o": {"addLink": "identifiedBy", "resourceType": "DissertationIdentifier", "property": "value"},
@@ -9300,7 +9300,7 @@
       "$a": {"property": "label"},
       "$d": {"addProperty": "date"},
       "$o": {"addProperty": "marc:otherEventInformation"},
-      "$p": {"addLink": "place", "resourceType": "Place", "property": "label"},
+      "$p": {"addLink": "place", "resourceType": "Place", "property": "label", "infer": true},
       "$2": {"ignored": true, "NOTE:LC": "nac"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
       "$6": {"property": "marc:fieldref"}
@@ -9517,8 +9517,8 @@
         "_:event": {"addLink": "provisionActivity", "resourceType": "ProvisionActivity"}
       },
       "$a": {"property": "description", "punctuationChars": ":"},
-      "$b": {"about": "_:event", "addLink": "place", "resourceType": "Place", "property": "label", "punctuationChars": ":"},
-      "$c": {"about": "_:event", "addLink": "agent", "resourceType": "Agent", "property": "label", "punctuationChars": ","},
+      "$b": {"about": "_:event", "addLink": "place", "resourceType": "Place", "property": "label" , "punctuationChars": ":"},
+      "$c": {"about": "_:event", "addLink": "agent", "resourceType": "Agent", "property": "label" , "punctuationChars": ","},
       "$d": {"about": "_:event", "property": "date"},
       "$e": {"addLink": "extent", "resourceType": "Extent", "property": "label", "NOTE:marc-repeatable": false},
       "$f": {"addProperty": "seriesStatement"},
@@ -13455,7 +13455,7 @@
           }
         }
       ],
-      "$a": {"about": "_:agent", "property": "label", "required": true, "punctuationChars": ")"},
+      "$a": {"about": "_:agent", "property": "label", "infer": true, "required": true, "punctuationChars": ")"},
       "_spec": [
         {
           "source": {
@@ -13774,7 +13774,7 @@
       "i2": {
         "marcDefault": " "
       },
-      "$a": {"about": "_:instanceOfContribution", "link": "agent", "resourceType": "Agent", "property": "label", "TODO:targetMatch": "1xx"},
+      "$a": {"about": "_:instanceOfContribution", "link": "agent", "resourceType": "Agent", "property": "label", "infer": true, "TODO:targetMatch": "1xx"},
       "$b": {"property": "editionStatement", "TODO:targetMatch": "250"},
       "$c": {"about": "_:instanceTitle", "property": "qualifier", "NOTE:marc-repeatable": false},
       "$d": {"property": "provisionActivityStatement", "TODO:targetMatch": "260$c"},
@@ -14064,7 +14064,7 @@
       "i2": {
         "marcDefault": "0"
       },
-      "$a": {"about": "_:agent", "property": "label", "TODO:targetMatch": "1xx"},
+      "$a": {"about": "_:agent", "property": "label", "infer": true, "TODO:targetMatch": "1xx"},
       "$b": {"about": "_:hasInstance", "property": "editionStatement", "TODO:targetMatch": "250"},
       "$c": {"about": "_:title", "property": "qualifier", "NOTE:marc-repeatable": false},
       "$d": {"about": "_:hasInstance", "property": "provisionActivityStatement", "TODO:targetMatch": "260$c"},
@@ -16666,7 +16666,7 @@
     "375": {"ignored": true, "NOTE:local": "gender: Struket av MSS 2017-12-12 efter diskussion om persondata i biblioteksregister."},
     "376": {
       "$a": {"addLink": "hasTypeOfFamily", "resourceType": "TypeOfFamily", "property": "label"},
-      "$b": {"addLink": "hasProminentFamilyMember", "resourceType": "Person", "property": "prefLabel"},
+      "$b": {"addLink": "hasProminentFamilyMember", "resourceType": "Person", "property": "label", "infer": true},
     "_spec": [
       {
         "source": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -19618,7 +19618,7 @@
       "$i": {
         "addLink": "availability",
         "resourceType": "ItemAvailability",
-        "property": "label",
+        "property": "label", "infer": true,
         "NOTE": "deviates from standard (itemPart)?"
       },
       "$j": {"property": "shelfControlNumber"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4,6 +4,8 @@
 
   "keepGroupIds": false,
 
+  "locale": "sv",
+
   "TODO:s": [
     "addLink:identifiedBy (+ NOTE:marc-repeatable: false where link)"
   ],
@@ -317,7 +319,7 @@
       "$f": {"about": "_:work", "property": "originDate"},
       "$h": {"about": "_:work", "property": "marc:mediaTerm"},
 
-      "$l": {"about": "_:work", "link": "language", "resourceType": "Language", "property": "label"},
+      "$l": {"about": "_:work", "link": "language", "resourceType": "Language", "property": "label", "infer": true},
       "$m": {"about": "_:work", "addLink": "musicMedium", "resourceType": "MusicMedium", "property": "label", "leadingPunctuation": ","},
       "$o": {"about": "_:work", "property": "version"},
 

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -6463,6 +6463,30 @@
               "language": {"@type": "Language", "label": "Engelska."}
             }
           }}
+        },
+        {
+          "name": "Verify revert using infer for label from prefLabelByLang[locale]",
+          "normalized": [
+            {"008": "|     |        |  |||||||||||000 ||swe| "},
+            {"240": {"ind1": "1", "ind2": "0", "subfields": [
+              {"a": "En titel"},
+              {"l": "Svenska"}
+            ]}}
+          ],
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "hasTitle": [ {
+                "@type": "Title",
+                "mainTitle": "En titel"
+              } ],
+              "language": {
+                "@type": "Language",
+                "@id": "https://id.kb.se/language/swe",
+                "prefLabelByLang": {"sv": "Svenska"}
+              }
+            }
+          }}
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -402,7 +402,7 @@
       "include": ["agentpartnumber"],
       "$f": {"about": "_:agent", "property": "marc:originDate"},
       "$h": {"about": "_:agent", "property": "marc:mediaTerm"},
-      "$l": {"about": "_:agent", "link": "language", "resourceType": "Language", "property": "label"},
+      "$l": {"about": "_:agent", "link": "language", "resourceType": "Language", "property": "label", "infer": true},
       "$o": {"about": "_:agent", "property": "version"},
       "$r": {"about": "_:agent", "property": "marc:musicKey"},
       "$s": {"about": "_:agent", "property": "version"}
@@ -14228,7 +14228,7 @@
       "i2": {
         "marcDefault": " "
       },
-      "$e": {"addLink": "language", "NOTE:marc-repeatable": false, "resourceType": "Language", "property": "label", "TODO:inherit": "008:[35:38]"},
+      "$e": {"addLink": "language", "NOTE:marc-repeatable": false, "resourceType": "Language", "property": "label", "infer": true, "TODO:inherit": "008:[35:38]"},
       "$f": {"about": "_:provisionActivity", "link": "place", "resourceType": "Place", "property": "code", "NOTE:marc-repeatable": false, "TODO:inherit": "008:[15:18]"}
     },
     "776": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7644,7 +7644,7 @@
           "resourceType": "ContentType"
         }
       },
-      "$a": {"about": "_:contentType", "property": "label"},
+      "$a": {"about": "_:contentType", "property": "label", "infer": true},
       "$b": {"about": "_:contentType", "property": "code"},
       "$2": {"about": "_:contentType", "property": "termGroup", "marcDefault": "rdacontent", "supplementary": true},
       "TODO?:$2": {"about": "_:contentType", "addLink": "inCollection", "resourceType": "ConceptCollection", "property": "code"},
@@ -7796,7 +7796,7 @@
         }
       },
       "aboutEntity": "?thing",
-      "$a": {"about": "_:mediaType", "property": "label"},
+      "$a": {"about": "_:mediaType", "property": "label", "infer": true},
       "$b": {"about": "_:mediaType", "property": "code"},
       "$2": {"about": "_:mediaType", "property": "termGroup", "marcDefault": "rdamedia", "supplementary": true},
       "$8": {"about": "_:mediaType", "property": "marc:groupid", "supplementary": true},
@@ -7931,7 +7931,7 @@
           "resourceType": "CarrierType"
         }
       },
-      "$a": {"about": "_:carrierType", "property": "label"},
+      "$a": {"about": "_:carrierType", "property": "label", "infer": true},
       "$b": {"about": "_:carrierType", "property": "code"},
       "$2": {"about": "_:carrierType", "property": "termGroup", "marcDefault": "rdacarrier", "supplementary": true},
       "$8": {"about": "_:carrierType", "property": "marc:groupid", "supplementary": true},

--- a/whelk-core/src/test/groovy/JsonLdSpec.groovy
+++ b/whelk-core/src/test/groovy/JsonLdSpec.groovy
@@ -29,7 +29,15 @@ class JsonLdSpec extends Specification {
             ["@id": "http://example.org/ns/Publication",
              "subClassOf": ["@id": "http://example.org/ns/ProvisionActivity"]],
             ["@id": "http://example.org/pfx/SpecialPublication",
-             "subClassOf": ["@id": "http://example.org/ns/Publication"]]
+             "subClassOf": ["@id": "http://example.org/ns/Publication"]],
+
+            ["@id": "http://example.org/ns/label", "@type": ["@id": "DatatypeProperty" ]],
+            ["@id": "http://example.org/ns/prefLabel",
+             "subPropertyOf": [ ["@id": "http://example.org/ns/label"] ]],
+            ["@id": "http://example.org/ns/preferredLabel",
+             "subPropertyOf": ["@id": "http://example.org/ns/prefLabel"]],
+            ["@id": "http://example.org/ns/name",
+             "subPropertyOf": ["@id": "http://example.org/ns/label"]]
         ]
     ]
 
@@ -294,6 +302,20 @@ class JsonLdSpec extends Specification {
         term                        | uri
         'Publication'               | 'http://example.org/ns/Publication'
         'pfx:SpecialPublication'    | 'http://example.org/pfx/SpecialPublication'
+    }
+
+    def "use vocab to get subclasses of a base class"() {
+        given:
+        def ld = new JsonLd(CONTEXT_DATA, [:], VOCAB_DATA)
+        expect:
+        ld.getSubClasses('ProvisionActivity') == ['Publication', 'pfx:SpecialPublication'] as Set
+    }
+
+    def "use vocab to get subproperties of a base property"() {
+        given:
+        def ld = new JsonLd(CONTEXT_DATA, [:], VOCAB_DATA)
+        expect:
+        ld.getSubProperties('label') == ['prefLabel', 'preferredLabel', 'name'] as Set
     }
 
     def "use vocab to match a subclass to a base class"() {


### PR DESCRIPTION
Control language selection using a 'locale' setting, and subproperty
usage using an 'infer' flag.