### PR TITLE
Implement silentRevert and use for bib 041

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1780,6 +1780,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
     String aboutAlias
     List<String> onRevertPrefer
     Set<String> sharesGroupIdWith = new HashSet<String>()
+    boolean silentRevert
 
     static GENERIC_REL_URI_TEMPLATE = "generic:{_}"
 
@@ -1812,6 +1813,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         }
         onRevertPrefer = (List<String>) (fieldDfn.onRevertPrefer instanceof String ?
                 [fieldDfn.onRevertPrefer] : fieldDfn.onRevertPrefer)
+
+        silentRevert = fieldDfn.silentRevert == true
 
         computeLinks = (fieldDfn.computeLinks) ? new HashMap(fieldDfn.computeLinks) : [:]
         if (computeLinks) {
@@ -2401,7 +2404,11 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
             }
 
             // TODO: store reverted input refs instead of tagging input data
-            usedEntities.each { it._revertedBy = baseTag; it._groupId = groupId }
+            usedEntities.each {
+                def revertMark = silentRevert ? '_silentlyRevertedBy' : '_revertedBy'
+                it[revertMark] = baseTag
+                it._groupId = groupId
+            }
             //field._revertedBy = this.tag
             return field
         } else {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4864,6 +4864,7 @@
     },
     "041": {
       "aboutEntity": "?work",
+      "silentRevert": true,
       "linkSubsequentRepeated": {
         "addLink": "hasPart",
         "resourceType": "Work",
@@ -4948,7 +4949,68 @@
       },
       "$6": {"property": "marc:bib041-fieldref", "NOTE": "Qualified with field to avoid collision when put directly on top-level resource!", "NOTE:record-count": 2},
       "$8": {"property": "marc:bib041-groupid", "NOTE": "Qualified with field to avoid collision when put directly on top-level resource!", "NOTE:record-count": 0},
-      "TODO": "add _spec?"
+      "_spec": [
+        {
+          "source": [
+            {"008" : "|     |        |  |||||||||||000 ||swe| "},
+            {"041": { "ind1": " ", "ind2": " ", "subfields": [{"a": "swe"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "language": [{"@id": "https://id.kb.se/language/swe", "code": "swe"}]
+              }
+            }
+          }
+        },
+        {
+          "name": "Produce multiple 041 as well as 730 on revert",
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "language": [
+                  {
+                    "@id": "https://id.kb.se/language/swe",
+                    "@type": "Language",
+                    "code": "swe",
+                    "prefLabelByLang": {"sv": "Svenska"}
+                  }
+                ],
+                "hasPart": [
+                  {
+                    "@type": "Work",
+                    "hasTitle": [
+                      {"@type": "Title", "mainTitle": "A Part"}
+                    ],
+                    "language": [
+                      {
+                        "@id": "https://id.kb.se/language/eng",
+                        "@type": "Language",
+                        "code": "eng",
+                        "prefLabelByLang": {"sv": "English"}
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "normalized": [
+            {"008" : "|     |        |  |||||||||||000 ||swe| "},
+            {"041": { "ind1": " ", "ind2": " ", "subfields": [{"a": "swe"}]}},
+            {"041": {"ind1": " ", "ind2": " ", "subfields": [{"a": "eng"}]}},
+            {
+              "730": {
+                "ind1": "0",
+                "ind2": "2",
+                "subfields": [{"a": "A Part"}, {"l": "English"}]
+              }
+            }
+          ]
+        }
+      ]
     },
     "042": {
       "aboutEntity": "?record",


### PR DESCRIPTION
This lets a field revert entities without marking them as reverted. That
allows for other fields to revert from the same entity.

(This is akin to the groupId mechanism, but allows for other fields to
be more exclusive. (E.g. bib 700[t] and 730 are disjoint (the former is
preferred over the latter for the same entity), but a repeated 041 picks
language from either of them without marking as reverted).)