### PR TITLE
Add handling of silentRevert for fixed field columns

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1786,7 +1786,6 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
     Map uriTemplateDefaults
     Map<String, MarcSubFieldHandler> subfields = [:]
     List<List<MarcSubFieldHandler>> orderedAndGroupedSubfields
-    Set requiredCodes
     List<MatchRule> matchRules
     Map<String, Map> pendingResources
     List<String> pendingKeys
@@ -1842,8 +1841,6 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                 addSubfield(m.group(1), obj)
             }
         }
-
-        requiredCodes = subfields.values().findResult { if (it.required) it.code } as Set
 
         completePunctuationRules(subfields.values())
 
@@ -2281,6 +2278,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         // NOTE: Within a field, only *one* positioned term is supported.
         Map firstRelPosSubfield = null
         Map sortedByItemPos = [:]
+
+        Set requiredCodes = new HashSet()
         Set succeededCodes = new HashSet()
 
         orderedAndGroupedSubfields.each { subhandlers ->
@@ -2302,6 +2301,10 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                 def code = subhandler.code
                 if (failedRequired)
                     return
+
+                if (subhandler.required) {
+                    requiredCodes << code
+                }
 
                 if (subhandler.requiresI1) {
                     if (i1 == null) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1257,7 +1257,7 @@ class MarcFixedFieldHandler {
                 return
             def colNums = parseColumnNumbers(key)
             colNums.eachWithIndex { Tuple2<Integer, Integer> colNum, int i ->
-                columns << new Column(ruleSet, obj, colNum.first, colNum.second,
+                columns << new Column(this, obj, colNum.first, colNum.second,
                         obj['itemPos'] ?: colNums.size() > 1 ? i : null,
                         obj['fixedDefault'],
                         obj['matchAsDefault'])
@@ -1327,10 +1327,12 @@ class MarcFixedFieldHandler {
         Integer itemPos
         String fixedDefault
         Pattern matchAsDefault
+        MarcFixedFieldHandler fixedFieldHandler
 
-        Column(ruleSet, fieldDfn, int start, int end,
+        Column(MarcFixedFieldHandler fixedFieldHandler, fieldDfn, int start, int end,
                itemPos, fixedDefault, matchAsDefault = null) {
-            super(ruleSet, null, fieldDfn)
+            super(fixedFieldHandler.ruleSet, "$fixedFieldHandler.tag-$start-$end", fieldDfn)
+            this.fixedFieldHandler = fixedFieldHandler
             assert start > -1 && end >= start
             this.start = start
             this.end = end
@@ -1566,6 +1568,7 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
     LocalTime defaultTime
     boolean missingCentury = false
     boolean ignored = false
+    Boolean silentRevert = null
     // TODO: working, but not so useful until capable of merging entities..
     //MarcSimpleFieldHandler linkedHandler
 
@@ -1611,6 +1614,7 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
                 }
             }
         }
+        silentRevert = fieldDfn.silentRevert
         //if (fieldDfn.linkedEntity) {
         //    linkedHandler = new MarcSimpleFieldHandler(ruleSet,
         //            tag + ":linked", fieldDfn.linkedEntity)
@@ -1734,21 +1738,29 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
         } else {
             return (entity instanceof List ? entity : [entity]).collect {
                 if (uriTemplate) {
-                    def token = findTokenFromId(it, uriTemplate, matchUriToken)
+                    String token = findTokenFromId(it, uriTemplate, matchUriToken)
                     if (token) {
-                        return revertObject(token)
+                        return revertToken(it, token)
                     }
                     if (it instanceof Map) {
                         for (same in Util.asList(it['sameAs'])) {
                             token = findTokenFromId(same, uriTemplate, matchUriToken)
                             if (token) {
-                                return revertObject(token)
+                                return revertToken(it, token)
                             }
                         }
                     }
                 }
             }
         }
+    }
+
+    protected def revertToken(Map object, String token) {
+        def v = revertObject(token)
+        if (v && silentRevert == false) {
+            object._revertedBy = baseTag
+        }
+        return v
     }
 
     static ZonedDateTime parseDate(String s) {
@@ -1774,6 +1786,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
     Map uriTemplateDefaults
     Map<String, MarcSubFieldHandler> subfields = [:]
     List<List<MarcSubFieldHandler>> orderedAndGroupedSubfields
+    Set requiredCodes
     List<MatchRule> matchRules
     Map<String, Map> pendingResources
     List<String> pendingKeys
@@ -1829,6 +1842,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                 addSubfield(m.group(1), obj)
             }
         }
+
+        requiredCodes = subfields.values().findResult { if (it.required) it.code } as Set
 
         completePunctuationRules(subfields.values())
 
@@ -2266,6 +2281,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         // NOTE: Within a field, only *one* positioned term is supported.
         Map firstRelPosSubfield = null
         Map sortedByItemPos = [:]
+        Set succeededCodes = new HashSet()
 
         orderedAndGroupedSubfields.each { subhandlers ->
 
@@ -2316,7 +2332,6 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                          selectedEntity._revertedBy && (!groupId || selectedEntity._groupId != groupId)) ||
                         selectedEntity._revertedBy == baseTag ||
                         selectedEntity._revertedBy in sharesGroupIdWith) {
-                    failedRequired = true
                     return
                     //subs << ['DEBUG:blockedSinceRevertedBy': selectedEntity._revertedBy]
                 }
@@ -2358,16 +2373,21 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                             }
                         }
                     }
-                    if (subhandler.required && !justAdded) {
+                    if (subhandler.required && !justAdded
+                        && !(code in succeededCodes)) {
                         failedRequired = true
                     }
                 } else {
-                    if (subhandler.required || subhandler.requiresI1 || subhandler.requiresI2) {
+                    if ((subhandler.required || subhandler.requiresI1 ||
+                                subhandler.requiresI2)
+                        && !(code in succeededCodes)) {
                         failedRequired = true
                     }
                 }
                 if (!failedRequired && justAdded) {
                     usedEntities << selectedEntity
+                    succeededCodes << code
+
                     if (prevAdded && justAdded && subhandler.leadingPunctuation) {
                         def (prevCode, prevSub) = prevAdded
                         MarcSubFieldHandler prevSubHandler = subfields[prevCode]
@@ -2392,6 +2412,10 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                     prevAdded = justAdded
                 }
             }
+        }
+
+        if (requiredCodes && !requiredCodes.every { it in succeededCodes }) {
+            failedRequired = true
         }
 
         if (!failedRequired && i1 != null && i2 != null && subs.size() && !onlySupplementary) {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -2470,7 +2470,8 @@
           "TODO:about": "_:otherInstance",
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/ComputerItemType-{_}",
-          "matchUriToken": "^[oqs]$"
+          "matchUriToken": "^[oqs]$",
+          "silentRevert": false
         },
         "[9]": {
           "addLink": "genreForm",
@@ -2660,7 +2661,8 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/ComputerMaterialType-{_}",
-          "matchUriToken": "^[_abcdefhjkmor]$"
+          "matchUriToken": "^[_abcdefhjkmor]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "colorContent",
@@ -2776,7 +2778,8 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/ProjGraphMaterialType-{_}",
-          "matchUriToken": "^[_cdfost]$"
+          "matchUriToken": "^[_cdfost]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "colorContent",
@@ -2820,7 +2823,8 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/MicroformMaterialType-{_}",
-          "matchUriToken": "^[_abcdefghj]$"
+          "matchUriToken": "^[_abcdefghj]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "polarity",
@@ -2907,7 +2911,8 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/MotionPicMaterialType-{_}",
-          "matchUriToken": "^[_cfor]$"
+          "matchUriToken": "^[_cfor]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "colorContent",
@@ -2996,21 +3001,24 @@
       "KitInstance": {
         "[1]": {
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
+          "silentRevert": false
         }
       },
       "NotatedMusicInstance": {
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
-          "TODO:tokenMap? (empty, just as KitMaterialType)": "NotatedMusicMaterialType"
+          "TODO:tokenMap? (empty, just as KitMaterialType)": "NotatedMusicMaterialType",
+          "silentRevert": false
         }
       },
       "RemoteSensingImage": {
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
-          "TODO:tokenMap? (empty, just as KitMaterialType)": "RemoteSensingImageMaterialType"
+          "TODO:tokenMap? (empty, just as KitMaterialType)": "RemoteSensingImageMaterialType",
+          "silentRevert": false
         },
         "[3]": {
           "link": "marc:remoteSensImageAltitude",
@@ -3052,7 +3060,8 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/SoundMaterialType-{_}",
-          "matchUriToken": "^[_degiqstw]$"
+          "matchUriToken": "^[_degiqstw]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "soundCharacteristic",
@@ -3124,14 +3133,16 @@
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/TextMaterialType-{_}",
-          "matchUriToken": "^[_abcd]$"
+          "matchUriToken": "^[_abcd]$",
+          "silentRevert": false
         }
       },
       "VideoRecording": {
         "[1]": {
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/VideoMaterialType-{_}",
-          "matchUriToken": "^[_cdfr]$"
+          "matchUriToken": "^[_cdfr]$",
+          "silentRevert": false
         },
         "[3]": {
           "addLink": "colorContent",
@@ -3309,31 +3320,36 @@
         "[23]": {
           "TODO": "add spec to ensure this doesn't conflict with 007[1].carrierType",
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/BooksItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/BooksItemType-{_}",
+          "silentRevert": false
         },
         "[24] [25] [26] [27]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/BooksContentsType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/BooksContentsType-{_}",
+          "silentRevert": false
         },
         "[28]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         },
         "[29]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/ConferencePublicationType-{_}",
           "matchUriToken": "^[01]$",
-          "fixedDefault": "0"
+          "fixedDefault": "0",
+          "silentRevert": false
         },
         "[30]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/BooksFestschriftType-{_}",
           "matchUriToken": "^[01]$",
-          "fixedDefault": "0"
+          "fixedDefault": "0",
+          "silentRevert": false
         },
         "[31]": {
           "link": "supplementaryContent",
@@ -3345,13 +3361,15 @@
           "aboutEntity": "?work",
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/BooksLiteraryFormType-{_}",
-          "matchUriToken": "^[01cdefhijmps]$"
+          "matchUriToken": "^[01cdefhijmps]$",
+          "silentRevert": false
         },
         "[34]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/BooksBiographyType-{_}",
-          "matchUriToken": "^[abcd]$"
+          "matchUriToken": "^[abcd]$",
+          "silentRevert": false
         }
       },
       "Multimedia": {
@@ -3381,12 +3399,14 @@
         "[26]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/ComputerTypeOfFileType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ComputerTypeOfFileType-{_}",
+          "silentRevert": false
         },
         "[28]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         }
       },
       "Cartography": {
@@ -3408,16 +3428,19 @@
           "TODO": "Add condition to 'link' to MapsMaterialType: (a|b|c|f|g|z) should be issuance. (d|e) should be genreForm (see also 006)",
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/MapsMaterialType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MapsMaterialType-{_}",
+          "silentRevert": false
         },
         "[28]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         },
         "[29]": {
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}",
+          "silentRevert": false
         },
         "[31]": {
           "link": "supplementaryContent",
@@ -3428,7 +3451,8 @@
         "[33] [34]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/MapsFormatType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MapsFormatType-{_}",
+          "silentRevert": false
         }
       },
       "Mixed": {
@@ -3442,7 +3466,8 @@
         "[18:20]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/MusicCompositionType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MusicCompositionType-{_}",
+          "silentRevert": false
         },
         "[20]": {
           "aboutEntity": "?work",
@@ -3474,7 +3499,8 @@
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/MusicTextType-{_}",
           "matchUriToken": "^[_abcdefghijklmoprst]$",
-          "fixedDefault": " "
+          "fixedDefault": " ",
+          "silentRevert": false
         },
         "[33]": {
           "link": "marc:transposition",
@@ -3505,7 +3531,8 @@
           "aboutEntity": "?work",
           "TODO": "Decide if it should be Work or Instance",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/SerialsTypeOfSerialType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/SerialsTypeOfSerialType-{_}",
+          "silentRevert": false
         },
         "[22]": {
           "link": "marc:originalItem",
@@ -3518,24 +3545,28 @@
         "[24]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/SerialsNatureType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/SerialsNatureType-{_}",
+          "silentRevert": false
         },
         "[25] [26] [27]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/SerialsContentsType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/SerialsContentsType-{_}",
+          "silentRevert": false
         },
         "[28]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         },
         "[29]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/ConferencePublicationType-{_}",
           "matchUriToken": "^[01]$",
-          "fixedDefault": "0"
+          "fixedDefault": "0",
+          "silentRevert": false
         },
         "[33]": {
           "link": "marc:alphabet",
@@ -3560,16 +3591,19 @@
         "[28]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         },
         "[29]": {
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}",
+          "silentRevert": false
         },
         "[33]": {
           "aboutEntity": "?work",
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/VisualMaterialType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/VisualMaterialType-{_}",
+          "silentRevert": false
         },
         "[34]": {
           "link": "marc:technique",
@@ -3688,6 +3722,44 @@
               }
             }
           }
+        },
+        {
+          "name": "Revert genreForm either to 008 or to 655",
+          "result": {
+            "mainEntity": {
+              "instanceOf": {
+                "@type": "Text",
+                "genreForm": [
+                  {
+                    "@id": "https://id.kb.se/marc/GovernmentPublicationLevelUndetermined",
+                    "@type": "marc:GovernmentPublicationType",
+                    "code": "o",
+                    "prefLabelByLang": {
+                      "en": "Government publication--level undetermined",
+                      "sv": "Nivå ej specificerad"
+                    },
+                    "sameAs": [{"@id": "https://id.kb.se/marc/GovernmentPublicationType-o"}]
+                  },
+                  {
+                    "@type": "GenreForm",
+                    "inScheme": {
+                      "@id": "https://id.kb.se/term/marcgt",
+                      "@type": "ConceptScheme",
+                      "code": "marcgt"
+                    },
+                    "prefLabel": "government publication"
+                  }
+                ]
+              }
+            }
+          },
+          "normalized": [
+            {"008": "|     |        |  ||||||||||o000 ||   | "},
+            {"655": {"ind1": " ", "ind2": "7", "subfields": [
+              {"a": "government publication"},
+              {"2": "marcgt"}
+            ]}}
+          ]
         },
         {
           "name": "handle consecutive columns",
@@ -6312,7 +6384,7 @@
           "embedded": true
         }
       },
-      "$a": {"about": "_:title", "property": "mainTitle"},
+      "$a": {"about": "_:title", "property": "mainTitle", "required": true},
       "$d": {"property": "legalDate"},
       "$0": {"about": "_:work", "addProperty": "marc:uri"},
       "subfieldOrder": "a d m n r p k l s f o",
@@ -6473,7 +6545,7 @@
         }
       },
       "TODO": "[1]See also 100$t and 130. [2]Interpunction ; on $r needs to be analyzed",
-      "$a": {"about": "_:title", "property": "mainTitle"},
+      "$a": {"about": "_:title", "property": "mainTitle", "required": true},
       "$d": {"property": "legalDate"},
       "$0": {
         "aboutEntity": "?work",
@@ -11015,7 +11087,7 @@
           "embedded": true
         }
       },
-      "$a": {"about": "_:title", "property": "mainTitle"},
+      "$a": {"about": "_:title", "property": "mainTitle", "required": true},
       "$d": {"property": "date"},
       "$6": {"property": "marc:fieldref"},
       "$8": {"property": "marc:groupid"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -2476,11 +2476,13 @@
         "[9]": {
           "addLink": "genreForm",
           "uriTemplate": "https://id.kb.se/marc/ComputerTypeOfFileType-{_}",
-          "matchUriToken": "^[_abcdefghijm]$"
+          "matchUriToken": "^[_abcdefghijm]$",
+          "silentRevert": false
         },
         "[11]": {
           "addLink": "genreForm",
-          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/GovernmentPublicationType-{_}",
+          "silentRevert": false
         }
       },
       "Mixed": {
@@ -3394,7 +3396,8 @@
         "[23]": {
           "TODO": "add spec to ensure this doesn't conflict with 007[1].carrierType",
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ComputerItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ComputerItemType-{_}",
+          "silentRevert": false
         },
         "[26]": {
           "aboutEntity": "?work",
@@ -3459,7 +3462,8 @@
         "[23]": {
           "TODO": "add spec to ensure this doesn't conflict with 007[1].carrierType",
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}",
+          "silentRevert": false
         }
       },
       "Audio": {
@@ -3487,7 +3491,8 @@
         },
         "[23]": {
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}",
+          "silentRevert": false
         },
         "[24] [25] [26] [27] [28] [29]": {
           "TODO": "Decide if this should be Work or Instance. Compare with Text",
@@ -3540,7 +3545,8 @@
         },
         "[23]": {
           "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/ItemType-{_}",
+          "silentRevert": false
         },
         "[24]": {
           "aboutEntity": "?work",


### PR DESCRIPTION
Fixed columns by default do a silentRevert (i.e. do not mark entities
with _revertedBy). Now this can be controlled with a flag.

This flag is set to false for genreForm and carrierType. That avoids
values from them being simultaneously reverted to regular bib 655.

With this feature, some brittle handling cropped up regarding when a
field is considered to have failedRequired. This addresses that as well,
which in turn required adding required to some subfields in marcframe (a
seemingly sensible addition).

Two additional checks using the new succeededCodes introduced here have
also been added, to avoid a potential bug which can drop a field when a
second group of subfields (pertaining to the aboutNew mechanism) do not
produce a required field, even if it has already been produced in the
first group for the same field (hence passing the required rule).