### PR TITLE
Update fieldorder and specs for 505

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9357,7 +9357,7 @@
           }}
         },
         {
-          "name": "Enhanced - order g t",
+          "name": "Enhanced - order g t, creates faulty entities, because aboutNew on t",
           "source": {"505": {"ind1": "8", "ind2": "0", "subfields": [
             {"g": "Nr. 1."},
             {"t": "Region Neusiedlersee --"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9234,8 +9234,9 @@
       "$6": {"property": "marc:fieldref"}
     },
     "505": {
-      "i1": {"marcDefault": "8", "NOTE:LC": "nac"},
-      "i2": {"marcDefault": " ", "NOTE:LC": "ignore"},
+      "i1": {"marcDefault": "8", "NOTE:LC": "nac (Display constant controller)"},
+      "i2": {"marcDefault": " ", "NOTE:LC": "ignore (Level of content designation)"},
+      "TODO": "LC consider this a work entity in their 1.4 conversion. Interpunctuation:  -- .-- / ", 
       "aboutEntity": "?thing",
       "addLink": "tableOfContents",
       "resourceType": "TableOfContents",
@@ -9245,18 +9246,79 @@
           "resourceType": "ToCEntry"
         }
       },
-      "subfieldOrder": "a t r g u",
-      "TODO": "No $a if i2=0",
+      "subfieldOrder": "6 a g t r u",
+      "NOTE": "No $a if i2=0",
       "$a": {"property": "label"},
-      "$t": {"aboutNew": "_:tocEntry", "property": "label"},
-      "$r": {"about": "_:tocEntry", "property": "responsibilityStatement"},
       "$g": {"about": "_:tocEntry", "addProperty": "comment"},
+      "$r": {"about": "_:tocEntry", "property": "responsibilityStatement"},
+      "$t": {"aboutNew": "_:tocEntry", "property": "label"},
       "$u": {"about": "_:tocEntry", "addProperty": "uri"},
       "$6": {"property": "marc:fieldref"},
+      "$8": {"property": "marc:groupid"},
       "_spec": [
         {
-          "source": {"505": {"ind1": "8", "ind2": " ", "subfields": [
-            {"a": "Contents:"},
+          "name": "Enhanced - Data is encoded with repetitions of the defined subfields, other than subfield $a. TODO: When $g comes first, two ToCEntries has been created; one for comment and one for that which comes after $t",
+          "source": [
+            {"505": {"ind1": "1", "ind2": " ", "subfields": [
+              {"g": "Bd. 15"},
+              {"t": "Dissertatio de valore absoluto vis centripetae, tendentis ad ambilium ellipseos"},
+              {"r": "(def. Zach. Nordmark)"}
+            ]}},
+            {"505": {"ind1": "1", "ind2": " ", "subfields": [
+              {"g": "Bd. 16"},
+              {"t": "Dissertatio de constructione sectionis conicae vi centripeta tendente ad focum descriptae"},
+              {"r": "(def. Jac. Gust. Klingwall)"}
+            ]}}
+          ],
+          "normalized": [
+            {"505": {"ind1": "8", "ind2": " ", "subfields": [
+              {"g": "Bd. 15"},
+              {"t": "Dissertatio de valore absoluto vis centripetae, tendentis ad ambilium ellipseos"},
+              {"r": "(def. Zach. Nordmark)"}
+            ]}},
+            {"505": {"ind1": "8", "ind2": " ", "subfields": [
+              {"g": "Bd. 16"},
+              {"t": "Dissertatio de constructione sectionis conicae vi centripeta tendente ad focum descriptae"},
+              {"r": "(def. Jac. Gust. Klingwall)"}
+            ]}}
+          ],
+          "result": {"mainEntity": {
+            "tableOfContents": [
+              {
+                "@type": "TableOfContents",
+                "hasPart": [
+                  {
+                    "@type": "ToCEntry",
+                    "comment": ["Bd. 15"]
+                  },
+                  {
+                    "@type": "ToCEntry",
+                    "label": "Dissertatio de valore absoluto vis centripetae, tendentis ad ambilium ellipseos",
+                    "responsibilityStatement": "(def. Zach. Nordmark)"
+                  }
+                ]
+              },
+              {
+                "@type": "TableOfContents",
+                "hasPart": [
+                  {
+                    "@type": "ToCEntry",
+                    "comment": ["Bd. 16"]
+                  },
+                  {
+                    "@type": "ToCEntry",
+                    "label": "Dissertatio de constructione sectionis conicae vi centripeta tendente ad focum descriptae",
+                    "responsibilityStatement": "(def. Jac. Gust. Klingwall)"
+                  }
+                ]
+              }
+            ]
+            }
+          }
+        },
+        {
+          "name": "Enhanced - Reordered normalized subfields within a field",
+          "source": {"505": {"ind1": "8", "ind2": "0", "subfields": [
             {"t": "Enoralehu"},
             {"r": "(Gigi)"},
             {"g": "(3:52) --"},
@@ -9264,32 +9326,52 @@
             {"r": "(Tweak & Tony Allen)"},
             {"g": "(5:47) --"}
           ]}},
+          "normalized": {"505": {"ind1": "8", "ind2": " ", "subfields": [
+            {"g": "(3:52) --"},
+            {"t": "Enoralehu"},
+            {"r": "(Gigi)"},
+            {"g": "(5:47) --"},
+            {"t": "Leroy"},
+            {"r": "(Tweak & Tony Allen)"}
+          ]}},
           "result": {"mainEntity": {
             "tableOfContents": [
               {
                 "@type": "TableOfContents",
-                "label": "Contents:",
                 "hasPart": [
                   {
                     "@type": "ToCEntry",
+                    "comment": ["(3:52) --"],
                     "label": "Enoralehu",
-                    "responsibilityStatement": "(Gigi)",
-                    "comment": ["(3:52) --"]
+                    "responsibilityStatement": "(Gigi)"
                   },
                   {
                     "@type": "ToCEntry",
+                    "comment": ["(5:47) --"],
                     "label": "Leroy",
-                    "responsibilityStatement": "(Tweak & Tony Allen)",
-                    "comment": ["(5:47) --"]
+                    "responsibilityStatement": "(Tweak & Tony Allen)"
                   }
                 ]
+              }
+            ]
+          }}
+        },
+        {
+          "name": "Basic - All information is recorded in a single occurrence of subfield $a.",
+          "source": {"505": {"ind1": "8", "ind2": " ", "subfields": [
+            {"a": "pt. 1. Carbon -- pt. 2. Nitrogen -- pt. 3. Sulphur -- pt. 4. Metals."}
+          ]}},
+          "result": {"mainEntity": {
+            "tableOfContents": [
+              {
+                "@type": "TableOfContents",
+                "label": "pt. 1. Carbon -- pt. 2. Nitrogen -- pt. 3. Sulphur -- pt. 4. Metals."
               }
             ]
           }}
         }
       ]
     },
-
     "506": {
       "aboutEntity": "?thing",
       "NOTE:local": "ANVÄNDS NORMALT EJ",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9257,7 +9257,7 @@
       "$8": {"property": "marc:groupid"},
       "_spec": [
         {
-          "name": "Enhanced - Data is encoded with repetitions of the defined subfields, other than subfield $a. TODO: When $g comes first, two ToCEntries has been created; one for comment and one for that which comes after $t",
+          "name": "Enhanced - Data is encoded with repetitions of the defined subfields, other than subfield $a. TODO: When $g comes first, two ToCEntries has been created; one for comment and one for that which comes after $t. Hence revert order is only maintained in converted records with several 505 fields.",
           "source": [
             {"505": {"ind1": "1", "ind2": " ", "subfields": [
               {"g": "Bd. 15"},
@@ -9272,14 +9272,14 @@
           ],
           "normalized": [
             {"505": {"ind1": "8", "ind2": " ", "subfields": [
+              {"g": "Bd. 15"},
               {"t": "Dissertatio de valore absoluto vis centripetae, tendentis ad ambilium ellipseos"},
-              {"r": "(def. Zach. Nordmark)"},
-              {"g": "Bd. 15"}
+              {"r": "(def. Zach. Nordmark)"}
             ]}},
             {"505": {"ind1": "8", "ind2": " ", "subfields": [
+              {"g": "Bd. 16"},
               {"t": "Dissertatio de constructione sectionis conicae vi centripeta tendente ad focum descriptae"},
-              {"r": "(def. Jac. Gust. Klingwall)"},
-              {"g": "Bd. 16"}
+              {"r": "(def. Jac. Gust. Klingwall)"}
             ]}}
           ],
           "result": {"mainEntity": {
@@ -9317,7 +9317,7 @@
           }
         },
         {
-          "name": "Enhanced - Reordered normalized subfields within a field",
+          "name": "Enhanced - order t r g",
           "source": {"505": {"ind1": "8", "ind2": "0", "subfields": [
             {"t": "Enoralehu"},
             {"r": "(Gigi)"},
@@ -9327,7 +9327,6 @@
             {"g": "(5:47) --"}
           ]}},
           "normalized": {"505": {"ind1": "8", "ind2": " ", "subfields": [
-
             {"t": "Enoralehu"},
             {"r": "(Gigi)"},
             {"g": "(3:52) --"},
@@ -9351,6 +9350,52 @@
                     "label": "Leroy",
                     "responsibilityStatement": "(Tweak & Tony Allen)",
                     "comment": ["(5:47) --"]
+                  }
+                ]
+              }
+            ]
+          }}
+        },
+        {
+          "name": "Enhanced - order g t",
+          "source": {"505": {"ind1": "8", "ind2": "0", "subfields": [
+            {"g": "Nr. 1."},
+            {"t": "Region Neusiedlersee --"},
+            {"g": "Nr. 2."},
+            {"t": "Region Rosalia/Lithagebirge --"},
+            {"g": "Nr. 3."},
+            {"t": "Region Mettelburgenland --"}
+          ]}},
+          "normalized": {"505": {"ind1": "8", "ind2": " ", "subfields": [
+            {"g": "Nr. 1."},
+            {"t": "Region Neusiedlersee --"},
+            {"g": "Nr. 2."},
+            {"t": "Region Rosalia/Lithagebirge --"},
+            {"g": "Nr. 3."},
+            {"t": "Region Mettelburgenland --"}
+          ]}},
+          "result": {"mainEntity": {
+            "tableOfContents": [
+              {
+                "@type": "TableOfContents",
+                "hasPart": [
+                  {
+                    "@type": "ToCEntry",
+                    "comment": [ "Nr. 1." ]
+                  },
+                  {
+                    "@type": "ToCEntry",
+                    "label": "Region Neusiedlersee --",
+                    "comment": [ "Nr. 2." ]
+                  },
+                  {
+                    "@type": "ToCEntry",
+                    "label": "Region Rosalia/Lithagebirge --",
+                    "comment": [ "Nr. 3." ]
+                  },
+                  {
+                    "@type": "ToCEntry",
+                    "label": "Region Mettelburgenland --"
                   }
                 ]
               }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9246,7 +9246,7 @@
           "resourceType": "ToCEntry"
         }
       },
-      "subfieldOrder": "6 a g t r u",
+      "subfieldOrder": "6 a t r g u",
       "NOTE": "No $a if i2=0",
       "$a": {"property": "label"},
       "$g": {"about": "_:tocEntry", "addProperty": "comment"},
@@ -9272,14 +9272,14 @@
           ],
           "normalized": [
             {"505": {"ind1": "8", "ind2": " ", "subfields": [
-              {"g": "Bd. 15"},
               {"t": "Dissertatio de valore absoluto vis centripetae, tendentis ad ambilium ellipseos"},
-              {"r": "(def. Zach. Nordmark)"}
+              {"r": "(def. Zach. Nordmark)"},
+              {"g": "Bd. 15"}
             ]}},
             {"505": {"ind1": "8", "ind2": " ", "subfields": [
-              {"g": "Bd. 16"},
               {"t": "Dissertatio de constructione sectionis conicae vi centripeta tendente ad focum descriptae"},
-              {"r": "(def. Jac. Gust. Klingwall)"}
+              {"r": "(def. Jac. Gust. Klingwall)"},
+              {"g": "Bd. 16"}
             ]}}
           ],
           "result": {"mainEntity": {
@@ -9327,12 +9327,13 @@
             {"g": "(5:47) --"}
           ]}},
           "normalized": {"505": {"ind1": "8", "ind2": " ", "subfields": [
-            {"g": "(3:52) --"},
+
             {"t": "Enoralehu"},
             {"r": "(Gigi)"},
-            {"g": "(5:47) --"},
+            {"g": "(3:52) --"},
             {"t": "Leroy"},
-            {"r": "(Tweak & Tony Allen)"}
+            {"r": "(Tweak & Tony Allen)"},
+            {"g": "(5:47) --"}
           ]}},
           "result": {"mainEntity": {
             "tableOfContents": [
@@ -9341,15 +9342,15 @@
                 "hasPart": [
                   {
                     "@type": "ToCEntry",
-                    "comment": ["(3:52) --"],
                     "label": "Enoralehu",
-                    "responsibilityStatement": "(Gigi)"
+                    "responsibilityStatement": "(Gigi)",
+                    "comment": ["(3:52) --"]
                   },
                   {
                     "@type": "ToCEntry",
-                    "comment": ["(5:47) --"],
                     "label": "Leroy",
-                    "responsibilityStatement": "(Tweak & Tony Allen)"
+                    "responsibilityStatement": "(Tweak & Tony Allen)",
+                    "comment": ["(5:47) --"]
                   }
                 ]
               }


### PR DESCRIPTION
NOTE: Fieldorder NOT updated.

Because of problems in with varying forms of this field probably need some real overhaul before we start doing changes. When $g is present it is sometimes used as the first subfield (but not always).

Also add specs both basic and extended, these show what happens in cases where $g comes before a $t (which has aboutnew) in converted MARC data, more than one ToCEntry is created, (off by one!) For now I have left a TODO and the spec is the documentation of this behavior. 

See example https://libris-stg.kb.se/katalogisering/4mff52sg2vrr3ch#it
