### PR TITLE
Fix content-type parameter parsing in CrudUtils

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
@@ -128,8 +128,11 @@ class CrudUtils {
             if (tokens.size() == 1) {
                 result[tokens[0]] = 1.0
             } else if (tokens.size() == 2) {
-                Float quality = tokens[1].split("=")[1] as Float
-                result[tokens[0]] = quality
+                def (param, value) = tokens[1].split("=")
+                if (param == 'q' && value.isFloat()) {
+                    Float quality = value as Float
+                    result[tokens[0]] = quality
+                }
             }
         }
         String[] sorted = result.keySet() as String[]

--- a/rest/src/test/groovy/whelk/rest/api/CrudUtilsSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudUtilsSpec.groovy
@@ -47,6 +47,7 @@ class CrudUtilsSpec extends Specification {
         "text/turtle, application/json;q=0.8"               | null     | "text/turtle"
         "text/turtle;q=0.1, application/json;q=0.8"         | null     | "application/json"
         "*/*, text/turtle;q=0.1, application/json;q=0.8"    | null     | "application/ld+json"
+        "text/turtle, application/signed-exchange;v=b3"     | null     | "text/turtle"
     }
 
     def "Should convert suffix to MIME type"() {


### PR DESCRIPTION
Now checks that the parameter used actually is 'q', and that its value is a valid float.