### PR TITLE
Script that sets encodingLevel of auth records where missing or faulty value

### DIFF
--- a/whelktool/scripts/cleanups/2019/04/set-auth-encodingLevel/main.groovy
+++ b/whelktool/scripts/cleanups/2019/04/set-auth-encodingLevel/main.groovy
@@ -1,0 +1,27 @@
+/*
+ * This sets encodingLevel to marc:CompleteAuthorityRecord for all remaining auth
+ * records with no property encodingLevel, or property with non-valid structure or value.
+ *
+ * See LXL-2056 for more info.
+ *
+ */
+
+ENCODING_LEVEL = "encodingLevel"
+VALID_AUTH_LEVELS = ["marc:CompleteAuthorityRecord", "marc:IncompleteAuthorityRecord"]
+PrintWriter scheduledToSetEncodingLevel = getReportWriter("scheduled-to-set-encodingLevel")
+
+
+selectByCollection('auth') { data ->
+
+    def (record, authdata) = data.graph
+
+    if (!record) return
+
+    if (!record.encodingLevel ||
+            (record.encodingLevel instanceof Map && record.encodingLevel[ID]) ||
+            (!VALID_AUTH_LEVELS.contains(record.encodingLevel))) {
+        record[ENCODING_LEVEL] = VALID_AUTH_LEVELS[0]
+        scheduledToSetEncodingLevel.println("${record[ID]}")
+        data.scheduleSave()
+    }
+}

--- a/whelktool/scripts/cleanups/2019/04/set-auth-encodingLevel/main.groovy
+++ b/whelktool/scripts/cleanups/2019/04/set-auth-encodingLevel/main.groovy
@@ -6,7 +6,6 @@
  *
  */
 
-ENCODING_LEVEL = "encodingLevel"
 VALID_AUTH_LEVELS = ["marc:CompleteAuthorityRecord", "marc:IncompleteAuthorityRecord"]
 PrintWriter scheduledToSetEncodingLevel = getReportWriter("scheduled-to-set-encodingLevel")
 
@@ -15,12 +14,10 @@ selectByCollection('auth') { data ->
 
     def (record, authdata) = data.graph
 
-    if (!record) return
-
     if (!record.encodingLevel ||
             (record.encodingLevel instanceof Map && record.encodingLevel[ID]) ||
             (!VALID_AUTH_LEVELS.contains(record.encodingLevel))) {
-        record[ENCODING_LEVEL] = VALID_AUTH_LEVELS[0]
+        record.encodingLevel = VALID_AUTH_LEVELS[0]
         scheduledToSetEncodingLevel.println("${record[ID]}")
         data.scheduleSave()
     }


### PR DESCRIPTION
Sets encodingLevel to marc:CompleteAuthorityRecord when:
- There is no encodingLevel
- encodingLevel contains uri
- value of encodingLevel is set to bibliographic value

See LXL-2056 for more info