### PR TITLE
Feature/remove unused encoding level

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -921,6 +921,15 @@ class ConversionPart {
                     reverseTokenMap[v] = k
                 }
             }
+            if (dfn.reverseTokenMapOverrides) {
+                def revMap = dfn.reverseTokenMapOverrides
+                if (revMap instanceof String) {
+                    revMap = fieldHandler.tokenMaps[revMap]
+                }
+                if (revMap instanceof Map) {
+                    reverseTokenMap.putAll(revMap)
+                }
+            }
         }
     }
 

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -116,18 +116,18 @@
       "EncLevelType": {
         "1": "marc:FullLevelMaterialNotExamined",
         "2": "marc:LessThanFullLevelMaterialNotExamined",
-        "3": "marc:AbbreviatedLevel",
-        "4": "marc:CoreLevel",
+        "4": "marc:AbbreviatedLevel",
         "5": "marc:PartialPreliminaryLevel",
         "7": "marc:MinimalLevel",
         "8": "marc:PrepublicationLevel",
         " ": "marc:FullLevel",
         "e": "marc:SystemIdentifiedMarcErrorInABatchloadedRecordLocal",
-        "i": "marc:FullLevelInputByOclcParticipantsLocal",
-        "j": "marc:DeletedRecordLocal",
-        "k": "marc:LessThanFullLevelInputByOclcParticipantsLocal",
-        "l": "marc:FullLevelInputAddedFromABatchProcessLocal",
-        "m": "marc:LessThanFullLevelInputAddedFromABatchProcessLocal"
+        "i": "marc:AbbreviatedLevel",
+        "j": "marc:AbbreviatedLevel",
+        "k": "marc:AbbreviatedLevel",
+        "l": "marc:AbbreviatedLevel",
+        "m": "marc:AbbreviatedLevel",
+        "3": "marc:AbbreviatedLevel"
       },
       "AuthorityEncLevelType": {
         "n": "marc:CompleteAuthorityRecord",
@@ -2160,6 +2160,26 @@
             "descriptionConventions": [{"@id": "https://id.kb.se/marc/CatFormType-a"}],
             "controlNumber": "0000000",
             "encodingLevel": "marc:FullLevel",
+            "mainEntity": {
+              "@type": "Instance",
+              "issuanceType": "Monograph",
+              "@id": "http://libris.kb.se/resource/bib/0000000",
+              "instanceOf": {"@type": "Text"}
+            }
+          }
+        },
+        {
+          "name": "encodingLevel should revert to 3",
+          "originalLeader": "00887cam a2200277 a 4500",
+          "source": {"leader": "     cam a       4a 4500", "fields": [{"001": "0000000"}]},
+          "normalized": {"leader": "     cam a       3a 4500", "fields": [{"001": "0000000"}]},
+          "result": {
+            "@type": "Record",
+            "@id": "http://libris.kb.se/bib/0000000",
+            "recordStatus": "marc:CorrectedOrRevised",
+            "descriptionConventions": [{"@id": "https://id.kb.se/marc/CatFormType-a"}],
+            "controlNumber": "0000000",
+            "encodingLevel": "marc:AbbreviatedLevel",
             "mainEntity": {
               "@type": "Instance",
               "issuanceType": "Monograph",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -122,7 +122,7 @@
         "7": "marc:MinimalLevel",
         "8": "marc:PrepublicationLevel",
         " ": "marc:FullLevel",
-        "e": "marc:SystemIdentifiedMarcErrorInABatchloadedRecordLocal",
+        "e": "marc:AbbreviatedLevel",
         "i": "marc:AbbreviatedLevel",
         "j": "marc:AbbreviatedLevel",
         "k": "marc:AbbreviatedLevel",
@@ -132,6 +132,7 @@
       "EncLevelType-ReverseOverrides": {
         "marc:AbbreviatedLevel": "3",
         "marc:CoreLevel": "3",
+        "marc:SystemIdentifiedMarcErrorInABatchloadedRecordLocal": "3",
         "marc:FullLevelInputByOclcParticipantsLocal": "3",
         "marc:DeletedRecordLocal": "3",
         "marc:LessThanFullLevelInputByOclcParticipantsLocal": "3",
@@ -2179,7 +2180,7 @@
           }
         },
         {
-          "name": "encodingLevel should revert to 3",
+          "name": "encodingLevel marc:AbbreviatedLevel should revert to 3",
           "originalLeader": "00887cam a2200277 a 4500",
           "source": {"leader": "     cam a       4a 4500", "fields": [{"001": "0000000"}]},
           "normalized": {"leader": "     cam a       3a 4500", "fields": [{"001": "0000000"}]},
@@ -2190,6 +2191,25 @@
             "descriptionConventions": [{"@id": "https://id.kb.se/marc/CatFormType-a"}],
             "controlNumber": "0000000",
             "encodingLevel": "marc:AbbreviatedLevel",
+            "mainEntity": {
+              "@type": "Instance",
+              "issuanceType": "Monograph",
+              "@id": "http://libris.kb.se/resource/bib/0000000",
+              "instanceOf": {"@type": "Text"}
+            }
+          }
+        },
+        {
+          "name": "Obsolete encodingLevel should revert to 3 (marc:AbbreviatedLevel)",
+          "originalLeader": "00887cam a2200277 a 4500",
+          "normalized": {"leader": "     cam a       3a 4500", "fields": [{"001": "0000000"}]},
+          "result": {
+            "@type": "Record",
+            "@id": "http://libris.kb.se/bib/0000000",
+            "recordStatus": "marc:CorrectedOrRevised",
+            "descriptionConventions": [{"@id": "https://id.kb.se/marc/CatFormType-a"}],
+            "controlNumber": "0000000",
+            "encodingLevel": "marc:DeletedRecordLocal",
             "mainEntity": {
               "@type": "Instance",
               "issuanceType": "Monograph",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -116,6 +116,7 @@
       "EncLevelType": {
         "1": "marc:FullLevelMaterialNotExamined",
         "2": "marc:LessThanFullLevelMaterialNotExamined",
+        "3": "marc:AbbreviatedLevel",
         "4": "marc:AbbreviatedLevel",
         "5": "marc:PartialPreliminaryLevel",
         "7": "marc:MinimalLevel",
@@ -126,8 +127,16 @@
         "j": "marc:AbbreviatedLevel",
         "k": "marc:AbbreviatedLevel",
         "l": "marc:AbbreviatedLevel",
-        "m": "marc:AbbreviatedLevel",
-        "3": "marc:AbbreviatedLevel"
+        "m": "marc:AbbreviatedLevel"
+      },
+      "EncLevelType-ReverseOverrides": {
+        "marc:AbbreviatedLevel": "3",
+        "marc:CoreLevel": "3",
+        "marc:FullLevelInputByOclcParticipantsLocal": "3",
+        "marc:DeletedRecordLocal": "3",
+        "marc:LessThanFullLevelInputByOclcParticipantsLocal": "3",
+        "marc:FullLevelInputAddedFromABatchProcessLocal": "3",
+        "marc:LessThanFullLevelInputAddedFromABatchProcessLocal": "3"
       },
       "AuthorityEncLevelType": {
         "n": "marc:CompleteAuthorityRecord",
@@ -2125,7 +2134,8 @@
       "[17]": {
         "aboutEntity": "?record",
         "property": "encodingLevel",
-        "tokenMap": "EncLevelType"
+        "tokenMap": "EncLevelType",
+        "reverseTokenMapOverrides": "EncLevelType-ReverseOverrides"
       },
       "[18]": {
         "aboutEntity": "?record",

--- a/whelktool/scripts/2019/05/delete-unused-encodingLevel.groovy
+++ b/whelktool/scripts/2019/05/delete-unused-encodingLevel.groovy
@@ -1,0 +1,26 @@
+/*
+ * This script sets obsolete or OCLC specfic encodingLevels to marc:AbbreviatedLevel
+ *
+ * See LXL-2546 for more info.
+ *
+ */
+
+NEW_ENCODING_LEVEL_VALUE = "marc:AbbreviatedLevel"
+PrintWriter scheduledToUpdateEncodingLevel = getReportWriter("scheduled-to-update-encodingLevel")
+
+selectBySqlWhere("""
+        collection in ('bib') AND
+        data#>>'{@graph,0,encodingLevel}' = 'marc:FullLevelInputByOclcParticipantsLocal' OR
+        data#>>'{@graph,0,encodingLevel}' = 'marc:LessThanFullLevelInputAddedFromABatchProcessLocal' OR
+        data#>>'{@graph,0,encodingLevel}' = 'marc:FullLevelInputAddedFromABatchProcessLocal' OR
+        data#>>'{@graph,0,encodingLevel}' = 'marc:LessThanFullLevelInputByOclcParticipantsLocal' OR
+        data#>>'{@graph,0,encodingLevel}' = 'marc:DeletedRecordLocal' OR
+        data#>>'{@graph,0,encodingLevel}' = 'marc:CoreLevel'
+    """) { data ->
+
+    def (record, instance, work) = data.graph
+
+    record["encodingLevel"] = NEW_ENCODING_LEVEL_VALUE
+    scheduledToUpdateEncodingLevel.println("${record[ID]}")
+    data.scheduleSave()
+}

--- a/whelktool/scripts/2019/05/delete-unused-encodingLevel.groovy
+++ b/whelktool/scripts/2019/05/delete-unused-encodingLevel.groovy
@@ -15,7 +15,7 @@ selectBySqlWhere("""
         data#>>'{@graph,0,encodingLevel}' = 'marc:FullLevelInputAddedFromABatchProcessLocal' OR
         data#>>'{@graph,0,encodingLevel}' = 'marc:LessThanFullLevelInputByOclcParticipantsLocal' OR
         data#>>'{@graph,0,encodingLevel}' = 'marc:DeletedRecordLocal' OR
-        data#>>'{@graph,0,encodingLevel}' = 'marc:CoreLevel'
+        data#>>'{@graph,0,encodingLevel}' = 'marc:SystemIdentifiedMarcErrorInABatchloadedRecordLocal'
     """) { data ->
 
     def (record, instance, work) = data.graph


### PR DESCRIPTION
* Change mapping of bib encodingLevel. Set obsolete or OCLC specific encodingLevels to marc:AbbreviatedLevel.
* Update existing data according to the new mapping
* Align this PR with https://github.com/libris/definitions/pull/119
* See LXL-2545 and LXL-2546 for more info.