### PR TITLE
Feature/bfconversion2xx

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7414,7 +7414,8 @@
     },
     "258": {
       "ignored": true,
-      "NOTE:LC": "258 - PHILATELIC ISSUE DATE (R) nac"
+      "NOTE:LC": "258 - PHILATELIC ISSUE DATE (R) nac",
+      "NOTE:record-count": 0
     },
 
     "260": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7299,7 +7299,10 @@
         }
       ]
     },
-
+    "251": {
+      "ignored": true,
+      "NOTE:LC": "251 - VERSION INFORMATION (R) nac"
+    },
 
     "254": {
       "Link": "marc:hasMusicalPresentationStatement",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7305,7 +7305,7 @@
     },
 
     "254": {
-      "link": "marc:hasMusicalPresentationStatement",
+      "link": "hasNote",
       "resourceType": "marc:MusicalPresentationStatement",
       "$a": {"property": "label"},
       "$6": {"property": "marc:fieldref"},
@@ -7316,7 +7316,7 @@
             {"254": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Composer's facsimile study score."}]}}
           ],
           "result": {"mainEntity": {
-            "marc:hasMusicalPresentationStatement": 
+            "hasNote": 
               {
                 "@type": "marc:MusicalPresentationStatement",
                 "label": "Composer's facsimile study score."

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7356,10 +7356,40 @@
       ]
     },
     "257": {
-      "addLink": "marc:hasCountryOfProducingEntityForArchivalFilms",
-      "resourceType": "marc:CountryOfProducingEntityForArchivalFilms",
-      "$a": {"property": "marc:countryOfProducingEntity"},
-      "$2": {"property": null}
+      "aboutEntity": "?thing",
+      "onRevertPrefer": "264",
+      "addLink": "production",
+      "resourceType": "Production",
+      "$a": {"addLink": "place", "resourceType": "Place", "property": "label"},
+      "$0": {"addProperty": "marc:recordControlNumber"},
+      "$1": null,
+      "$2": {"link": "source", "resourceType": "Source", "property": "code"},
+      "$6": {"property": "marc:fieldref"},
+      "_spec": [
+        {
+          "source": [
+            {"257": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Sverige"}]}}
+          ],
+          "normalized": [
+            {"264": {"ind1": " ", "ind2": "0", "subfields": [{"a": "Sverige"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "production": [
+                {
+                  "@type": "Production",
+                  "place": [
+                    {
+                      "@type": "Place",
+                      "label": "Sverige"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "258": {
       "NOTE:LC": "nac",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7987,7 +7987,38 @@
       ]
     },
 
-    "270": { "ignored": true, "NOTE:LC": "ignore"},
+    "265": {
+      "addLink": "acquisitionSource",
+      "resourceType": "AcquisitionSource",
+      "onRevertPrefer": "037",
+      "$a": {"property": "label"},
+      "$6": null,
+      "_spec": [
+        {
+          "source": [
+            {"265": {"ind1": " ", "ind2": " ", "subfields": [{"a": "source"}]}}
+          ],
+          "normalized": [
+            {"037": {"ind1": " ", "ind2": " ", "subfields": [{"b": "source"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "acquisitionSource": [{
+                "@type": "AcquisitionSource",
+                "label": "source"
+              }],
+              "instanceOf": {
+                "@type": "Text"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "270": {
+      "ignored": true,
+      "NOTE:LC": "270 - ADDRESS (R) ignore"
+    },
 
     "300": {
       "aboutEntity": "?thing",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7305,9 +7305,26 @@
     },
 
     "254": {
-      "Link": "marc:hasMusicalPresentationStatement",
+      "link": "marc:hasMusicalPresentationStatement",
       "resourceType": "marc:MusicalPresentationStatement",
-      "$a": {"property": "marc:musicalPresentationStatement"}
+      "$a": {"property": "label"},
+      "$6": {"property": "marc:fieldref"},
+      "NOTE:LC": "I - note - Note",
+      "_spec": [
+        {
+          "source": [
+            {"254": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Composer's facsimile study score."}]}}
+          ],
+          "result": {"mainEntity": {
+            "marc:hasMusicalPresentationStatement": 
+              {
+                "@type": "marc:MusicalPresentationStatement",
+                "label": "Composer's facsimile study score."
+              }
+            }
+          }
+        }
+      ]
     },
     "255": {
       "NOTE:domainIncludes": "Cartography",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7872,7 +7872,94 @@
       ]
     },
 
-    "261": {},
+    "261": {
+      "onRevertPrefer": "264",
+      "aboutEntity": "?thing",
+      "NOTE:LC": "Also create statement: I - provisionActivityStatement - literal ($abd -- concatenate with blank -- add semicolon between subfields if no other punctuation -- keep order in field)",
+      "pendingResources": {
+        "_:production": {"addLink": "production", "resourceType": "Production", "embedded": true},
+        "_:prodPart": {"about": "_:production", "addLink": "hasPart", "resourceType": "Production", "absorbSingle": true},
+        "_:manufacture": {"addLink": "manufacture", "resourceType": "Manufacture", "embedded": true}
+      },
+      "$a": {"aboutNew": "_:prodPart", "addLink": "agent", "resourceType": "Agent", "property": "label", "leadingPunctuation": " :", "punctuationChars": ".,"},
+      "$b": {"aboutAltNew": "_:prodPart", "addLink": "agent", "resourceType": "Agent", "property": "label", "leadingPunctuation": " :"},
+      "$d": {"about": "_:production", "addProperty": "date", "leadingPunctuation": ",", "punctuationChars": ".,;"},
+      "$e": {"about": "_:manufacture", "addLink": "agent", "resourceType": "Agent", "property": "label", "punctuationChars": ".,;"},
+      "$f": {"about": "_:production", "addLink": "place", "resourceType": "Place", "property": "label","leadingPunctuation": " ;"},
+      "$6": {"property": "marc:fieldref"},
+      "_spec": [
+        {
+          "name": "Simple",
+          "source": [
+            {"261": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Coronet Films,"},{"d": "1967."}]}}
+          ],
+          "normalized": [
+            {"264": {"ind1": " ", "ind2": "0", "subfields": [{"b": "Coronet Films,"},{"c": "1967"}]}}
+
+          ],
+          "result": {
+            "mainEntity": {
+              "production": [
+                {
+                  "@type": "Production",
+                  "agent": [
+                    {
+                      "@type": "Agent",
+                      "label": "Coronet Films"
+                    }
+                  ],
+                  "date": ["1967"]
+
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "With manufacturer",
+          "source": [
+            {"261": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Boulton-Hawker Films"},{"f": "Hadley, Eng"},{"e": "Made by D.C. Chipperfield."},{"d": "1971"}]}}
+          ],
+          "normalized": [
+            {"264": {"ind1": " ", "ind2": "0", "subfields": [{"a": "Hadley, Eng :"}, {"b": "Boulton-Hawker Films,"}, {"c": "1971"}]}},
+            {"264": {"ind1": " ", "ind2": "3", "subfields": [{"b": "Made by D.C. Chipperfield"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "manufacture": [
+                {
+                  "@type": "Manufacture",
+                  "agent": [
+                    {
+                      "@type": "Agent",
+                      "label": "Made by D.C. Chipperfield"
+                    }
+                  ]
+                }
+              ],
+              "production": [
+                {
+                  "@type": "Production",
+                  "date": ["1971"],
+                  "agent": [
+                    {
+                      "@type": "Agent",
+                      "label": "Boulton-Hawker Films"
+                    }
+                  ],
+                  "place": [
+                    {
+                      "@type": "Place",
+                      "label": "Hadley, Eng"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
     "262": {
       "aboutEntity": "?thing",
       "onRevertPrefer": "264",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7335,7 +7335,7 @@
       "resourceType": "marc:ComputerFileCharacteristics",
       "repeatable": false,
       "$a": {"property": "label"},
-      "$6": null,
+      "$6": {"property": "marc:fieldref"},
       "$8": null,
       "_spec": [
         {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7392,11 +7392,8 @@
       ]
     },
     "258": {
-      "NOTE:LC": "nac",
-      "addLink": "marc:hasPhilatelicIssueDate",
-      "resourceType": "marc:PhilatelicIssueDate",
-      "$a": {"property": "marc:issuingJurisdiction"},
-      "$b": {"property": "marc:denomination"}
+      "ignored": true,
+      "NOTE:LC": "258 - PHILATELIC ISSUE DATE (R) nac"
     },
 
     "260": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7374,20 +7374,22 @@
     },
     "257": {
       "onRevertPrefer": "264",
+      "NOTE": "Removing subfields incompatible with 264.",
       "aboutEntity": "?thing",
+      "addLink": "production",
+      "resourceType": "Production", 
       "pendingResources": {
-        "_:production": {"addLink": "production", "resourceType": "Production", "embedded": true},
-        "_:prodPlace": {"about": "_:production", "addLink": "place", "resourceType": "Place", "embedded": true}
+        "_:part": {"addLink": "hasPart", "resourceType": "Production", "absorbSingle": true}
       },
-      "$a": {"about": "_:prodPlace", "property": "label"},
-      "$0": {"about": "_:prodPlace", "addProperty": "marc:recordControlNumber"},
+      "$a": {"about": "_:part", "addLink": "place", "resourceType": "Place","property": "label"},
+      "$0": null,
       "$1": null,
-      "$2": {"about": "_:prodPlace", "link": "source", "resourceType": "Source", "property": "code"},
-      "$6": {"about": "_:prodPlace", "property": "marc:fieldref"},
+      "$2": null,
+      "$6": {"about": "_:part", "property": "marc:fieldref", "supplementary": true},
       "_spec": [
         {
           "source": [
-            {"257": {"ind1": " ", "ind2": " ", "subfields": [{"0": "http://id.loc.gov/authorities/names/n79021184"},{"a": "Sweden"}]}}
+            {"257": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Sweden"}]}}
           ],
           "normalized": [
             {"264": {"ind1": " ", "ind2": "0", "subfields": [{"a": "Sweden"}]}}
@@ -7400,8 +7402,7 @@
                   "place": [
                     {
                       "@type": "Place",
-                      "label": "Sweden",
-                      "marc:recordControlNumber": ["http://id.loc.gov/authorities/names/n79021184"]
+                      "label": "Sweden"
                     }
                   ]
                 }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7635,19 +7635,19 @@
         {
           "name": "Upprepade utgivarbyten för fortlöpande resurser",
           "source": [
-            {"260": {"ind1": "_", "ind2": "_", "subfields":
+            {"260": {"ind1": " ", "ind2": " ", "subfields":
               [{"3": "Sammanfattad utgivningstid:"}, {"a": "Lund :"}, {"b": "Svenska Clartésektionen,"}, {"c": "1924-"}, {"e": "(Stockholm :"}, {"f": "Fram)"}]}},
-            {"260": {"ind1": "_", "ind2": "_", "subfields":
+            {"260": {"ind1": " ", "ind2": " ", "subfields":
               [{"a": "Lund :"}, {"b": "Svenska Clartésektionen,"}, {"c": "1924-1925"}]}},
-            {"260": {"ind1": "2", "ind2": "_", "subfields":
+            {"260": {"ind1": "2", "ind2": " ", "subfields":
               [{"a": "Lund :"}, {"b": "Svenska Clartéavdelningen,"}, {"c": "1926-1927"}]}},
-            {"260": {"ind1": "2", "ind2": "_", "subfields":
+            {"260": {"ind1": "2", "ind2": " ", "subfields":
               [{"a": "Stockholm :"}, {"b": "Svenska Clartéavdelningen,"}, {"c": "1928-1931"}]}},
-            {"260": {"ind1": "2", "ind2": "_", "subfields":
+            {"260": {"ind1": "2", "ind2": " ", "subfields":
               [{"a": "Stockholm :"}, {"b": "Svenska Clartéförbundet,"}, {"c": "1932-1953"}]}},
-            {"260": {"ind1": "2", "ind2": "_", "subfields":
+            {"260": {"ind1": "2", "ind2": " ", "subfields":
               [{"a": "Hägersten :"}, {"b": "Clarté,"}, {"c": "1991-1995"}]}},
-            {"260": {"ind1": "3", "ind2": "_", "subfields":
+            {"260": {"ind1": "3", "ind2": " ", "subfields":
               [{"a": "Stockholm :"}, {"b": "Clarté,"}, {"c": "1953-1991, 1995-"}]}}
           ] ,
           "normalized": [

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7855,7 +7855,56 @@
     },
 
     "261": {},
-    "262": {},
+    "262": {
+      "aboutEntity": "?thing",
+      "onRevertPrefer": "264",
+      "addLink": "publication",
+      "resourceType": "Publication",
+      "$a": {"addLink": "place", "resourceType": "Place", "property": "label","leadingPunctuation": " ;"},
+      "$b": {"addLink": "agent", "resourceType": "Agent", "property": "label", "leadingPunctuation": " :"},
+      "$c": {"addProperty": "date", "leadingPunctuation": ",", "punctuationChars": ".,;"},
+      "$k": null,
+      "$l": null,
+      "$6": null,
+      "_spec": [
+        {
+          "source": [
+            {"262": {"ind1": " ", "ind2": " ", "subfields": [{"a": "plats"},{"b": "agent"},{"c": "datum"}]}}
+          ],
+          "normalized": [
+            {"264": {"ind1": " ", "ind2": "1",
+              "subfields": [
+                {"a": "plats :"},
+                {"b": "agent,"},
+                {"c": "datum"}
+              ]
+            }}
+          ],
+          "result": {
+            "mainEntity": {
+              "publication": [
+                {
+                  "@type": "Publication",
+                  "place": [
+                    {
+                      "@type": "Place",
+                      "label": "plats"
+                    }
+                  ],
+                  "agent": [
+                    {
+                      "@type": "Agent",
+                      "label": "agent"
+                    }
+                  ],
+                  "date": ["datum"]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
     "263": {
       "aboutEntity": "?thing",
       "$a": {"property": "projectedProvisionDate"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7356,22 +7356,24 @@
       ]
     },
     "257": {
-      "aboutEntity": "?thing",
       "onRevertPrefer": "264",
-      "addLink": "production",
-      "resourceType": "Production",
-      "$a": {"addLink": "place", "resourceType": "Place", "property": "label"},
-      "$0": {"addProperty": "marc:recordControlNumber"},
+      "aboutEntity": "?thing",
+      "pendingResources": {
+        "_:production": {"addLink": "production", "resourceType": "Production", "embedded": true},
+        "_:prodPlace": {"about": "_:production", "addLink": "place", "resourceType": "Place", "embedded": true}
+      },
+      "$a": {"about": "_:prodPlace", "property": "label"},
+      "$0": {"about": "_:prodPlace", "addProperty": "marc:recordControlNumber"},
       "$1": null,
-      "$2": {"link": "source", "resourceType": "Source", "property": "code"},
-      "$6": {"property": "marc:fieldref"},
+      "$2": {"about": "_:prodPlace", "link": "source", "resourceType": "Source", "property": "code"},
+      "$6": {"about": "_:prodPlace", "property": "marc:fieldref"},
       "_spec": [
         {
           "source": [
-            {"257": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Sverige"}]}}
+            {"257": {"ind1": " ", "ind2": " ", "subfields": [{"0": "http://id.loc.gov/authorities/names/n79021184"},{"a": "Sweden"}]}}
           ],
           "normalized": [
-            {"264": {"ind1": " ", "ind2": "0", "subfields": [{"a": "Sverige"}]}}
+            {"264": {"ind1": " ", "ind2": "0", "subfields": [{"a": "Sweden"}]}}
           ],
           "result": {
             "mainEntity": {
@@ -7381,7 +7383,8 @@
                   "place": [
                     {
                       "@type": "Place",
-                      "label": "Sverige"
+                      "label": "Sweden",
+                      "marc:recordControlNumber": ["http://id.loc.gov/authorities/names/n79021184"]
                     }
                   ]
                 }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7316,13 +7316,15 @@
       "TODO:resourceType (to distinguish this 'free form' from 034)?": "marc:CartographicDescription",
       "resourceType": "Cartographic",
       "embedded": true,
+      "NOTE": "Scale sits directly on work in BF2 conversion",
       "$a": {"link": "scale", "resourceType": "Scale", "property": "label"},
       "$b": {"link": "projection", "resourceType": "Projection", "property": "label"},
       "$c": {"property": "coordinates"},
       "$d": {"property": "ascensionAndDeclination"},
       "$e": {"property": "equinox"},
       "$f": {"property": "outerGRing"},
-      "$g": {"property": "exclusionGRing"}
+      "$g": {"property": "exclusionGRing"},
+      "$6": {"property": "marc:fieldref"}
     },
 
     "256": {


### PR DESCRIPTION
Housekeeping update 2xx fields with some changes (except for titles) from MARC2BF2 conversion 1.5.

* Add bib 251 - Version Information, as ignored.
* Update bib 254 to hasNote correctly map field with link property. (These fields are completely dropped from conversion until this fix, ~800 records before XL launch.)
* Update bib 255 with a note on BF2 difference and mapping of $6 field.
* Update field 256 with mapping of $6.
* Change bib 257 to production place and revert to 264, dropping incompatible subfields (36 records need to be manually updated).
* Update bib 258 - Philatelic Issue Date, as ignored with expanded note (0 records in db).
* Some indicators in spec for 260 had underscore, these are changed to space.
* Add bib 261 and 262 with mapping to provisionActivities and revert to 264 (3 records unhandled).
* Add bib 265 -  acquisitionSource, with revert to 037 (1 record unhandled).
* Add expanded note for 270.
