### PR TITLE
Fix: handle records with missing recordStatus in OAI-PMH

### DIFF
--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -77,7 +77,7 @@ public class Helpers
     {
         // Construct the query
         String selectSQL = "WITH bib_with_heldby AS (" +
-                " SELECT lddb.id, lddb.data, lddb.collection, lddb.modified, lddb.deleted, lddb.changedBy, lddb.data#>>'{@graph,1,heldBy,@id}' AS sigel, lddb.data#>>'{@graph,1,itemOf,@id}' AS itemOf, lddb_attached_holdings.data#>>'{@graph,1,heldBy,@id}' as heldBy" +
+                " SELECT lddb.id, lddb.data, lddb.collection, lddb.created, lddb.modified, lddb.deleted, lddb.changedBy, lddb.data#>>'{@graph,1,heldBy,@id}' AS sigel, lddb.data#>>'{@graph,1,itemOf,@id}' AS itemOf, lddb_attached_holdings.data#>>'{@graph,1,heldBy,@id}' as heldBy" +
                 " FROM lddb ";
 
         selectSQL += " LEFT JOIN lddb lddb_attached_holdings ON lddb.data#>>'{@graph,1,@id}' = lddb_attached_holdings.data#>>'{@graph,1,itemOf,@id}' ";
@@ -120,7 +120,7 @@ public class Helpers
             throws SQLException
     {
         // Construct the query
-        String selectSQL = "SELECT lddb.id, lddb.data, lddb.collection, lddb.modified, lddb.deleted, lddb.changedBy, lddb.data#>>'{@graph,1,heldBy,@id}' AS sigel, lddb.data#>>'{@graph,1,itemOf,@id}' AS itemOf" +
+        String selectSQL = "SELECT lddb.id, lddb.data, lddb.collection, lddb.created, lddb.modified, lddb.deleted, lddb.changedBy, lddb.data#>>'{@graph,1,heldBy,@id}' AS sigel, lddb.data#>>'{@graph,1,itemOf,@id}' AS itemOf" +
                 " FROM lddb ";
 
         selectSQL += " WHERE lddb.collection <> 'definitions' ";

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -16,6 +16,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -154,6 +155,12 @@ public class ResponseCommon
         if (embellish)
         {
             document = OaiPmh.s_whelk.getStorage().loadEmbellished(document.getShortId(), OaiPmh.s_whelk.getJsonld());
+        }
+        else
+        {
+            document.setModified(new Date(resultSet.getTimestamp("modified").getTime()));
+            document.setDeleted(deleted);
+            document.setCreated(new Date(resultSet.getTimestamp("created").getTime()));
         }
 
         if (!onlyIdentifiers)


### PR DESCRIPTION
This makes OAI-PMH handle `recordStatus` the same way as CRUD API.
That is: it is set depending on the values of `created` and `modified`