### PR TITLE
Fix broken record mainEntity references when renaming the mainEntity

### DIFF
--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -104,6 +104,22 @@ class LinkFinder {
 
         clearReferenceAmbiguities(document)
         replaceSameAsLinksWithPrimaries(document.data, connection, cacheAuthForever)
+        // TODO: check what happens in the sameas table when id:s are changed and changed back!
+        restoreNewCanonicalMainEntityUri(document.data)
+    }
+
+    /**
+     * When {@link #replaceSameAsLinksWithPrimaries} is used, the mainEntity
+     * reference is replaced by any already existing primary id. This collides
+     * with purposefully changing the primary id, which is therefore restored
+     * here.
+     */
+    private void restoreNewCanonicalMainEntityUri(Map data) {
+        List items = data['@graph']
+        if (items.size() < 2) {
+            return
+        }
+        items[0][JsonLd.THING_KEY]['@id'] = items[1]['@id']
     }
 
     private void replaceSameAsLinksWithPrimaries(Map data, Connection connection, boolean cacheAuthForever = false) {


### PR DESCRIPTION
When LinkFinder.replaceSameAsLinksWithPrimaries is used, the mainEntity
reference is replaced by any already existing primary id. This collides
with purposefully changing the primary id, which is therefore restored
again by restoreNewCanonicalMainEntityUri.

(This is only relevant for the top entities of the graph, not any
eventually nested bnodes, which is why this restore is done instead of
conditionals within replaceSameAsLinksWithPrimaries.)