### PR TITLE
Add script for deleting electronic UR holdings for Z

### DIFF
--- a/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Z-electronic-UR/delete-holdings-for-Z-electronic-UR.groovy
+++ b/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Z-electronic-UR/delete-holdings-for-Z-electronic-UR.groovy
@@ -1,0 +1,35 @@
+/*
+ * This deletes holdings for sigel Z where bib is an electronic resource from UR
+ *
+ * See LXL-2652 for more info.
+ *
+ */
+
+PrintWriter failedHoldIDs = getReportWriter("failed-to-delete-holdIDs")
+PrintWriter scheduledForDeletion = getReportWriter("scheduled-for-deletion")
+
+where = """
+id in 
+(
+    select hold.id
+    from
+        lddb as hold,
+        lddb as bib,
+        lddb__identifiers
+    where hold.collection = 'hold'
+    and hold.data #>>'{@graph,1,heldBy,@id}' = 'https://libris.kb.se/library/Z'
+    and hold.deleted = false
+    and hold.data #>> '{@graph,1,itemOf,@id}' = lddb__identifiers.iri
+    and lddb__identifiers.id = bib.id
+    and bib.deleted = false
+    and bib.data #>>'{@graph,1,marc:mediaTerm}' = 'Elektronisk resurs'
+    and bib.data #>>'{@graph,0,bibliography,0,sigel}' = 'UR'
+)
+"""
+
+selectBySqlWhere(where, silent: false) { hold ->
+    scheduledForDeletion.println("${hold.doc.getURI()}")
+    hold.scheduleDelete(onError: { e ->
+        failedHoldIDs.println("Failed to delete ${hold.doc.shortId} due to: $e")
+    })
+}


### PR DESCRIPTION
Gives the same result (size) as the query in the JIRA issue:
http://libris.kb.se/hitlist?d=libris&q=bibl:(z)+mat:(eresurser)+Utbildningsradion&f=simp&spell=true&hist=true&p=1

```
whelk=> select count(hold.id)
whelk-> from
whelk->      lddb as hold,
whelk->      lddb as bib,
whelk->      lddb__identifiers
whelk-> where hold.collection = 'hold'
whelk->   and hold.data #>>'{@graph,1,heldBy,@id}' = 'https://libris.kb.se/library/Z'
whelk->   and hold.deleted = false
whelk->   and hold.data #>> '{@graph,1,itemOf,@id}' = lddb__identifiers.iri
whelk->   and lddb__identifiers.id = bib.id
whelk->   and bib.deleted = false
whelk->   and bib.data #>>'{@graph,1,marc:mediaTerm}' = 'Elektronisk resurs'
whelk->   and bib.data #>>'{@graph,0,bibliography,0,sigel}' = 'UR';
 count 
-------
  7660
(1 rad)
```