### PR TITLE
Handle component hold items in script for deleting Nv NC holdings

### DIFF
--- a/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
+++ b/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
@@ -22,10 +22,7 @@ selectBySqlWhere(where, silent: false) { hold ->
     else if (item['hasComponent']) {
         List components = item['hasComponent']
         if (components.removeAll(this.&isNcShelf)) {
-            if (components.isEmpty()) {
-                delete(hold)
-            }
-            else if (components.size() == 1) {
+            if (components.size() == 1) {
                 try {
                     promoteLonelyComponent(item)
                     save(hold)
@@ -34,12 +31,16 @@ selectBySqlWhere(where, silent: false) { hold ->
                     failedHoldIDs.println("Failed to update ${hold.doc.shortId} due to: $e")
                 }
             }
+            else if (components.isEmpty()) {
+                delete(hold)
+            }
             else {
                 save(hold)
             }
         }
     }
 }
+
 
 void promoteLonelyComponent(Map item) {
     Map component = item['hasComponent'].first()

--- a/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
+++ b/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
@@ -1,5 +1,5 @@
 /*
- * This deletes holdings for sigel Nv with shelfMark starting with "NC "
+ * This deletes holdings for sigel Nv with shelfMark or physicalLocation starting with "NC"
  *
  * See LXL-2344 for more info.
  *
@@ -7,16 +7,43 @@
 
 PrintWriter failedHoldIDs = getReportWriter("failed-to-delete-holdIDs")
 PrintWriter scheduledForDeletion = getReportWriter("scheduled-for-deletion")
+PrintWriter scheduledForUpdate = getReportWriter("scheduled-for-update")
 
 where = """
 collection = 'hold'
 and data #>>'{@graph,1,heldBy,@id}' = 'https://libris.kb.se/library/Nv'
-and data #>>'{@graph,1,shelfMark,label}' like 'NC %'
 """
 
 selectBySqlWhere(where, silent: false) { hold ->
-    scheduledForDeletion.println("${hold.doc.getURI()}")
-    hold.scheduleDelete(onError: { e ->
-        failedHoldIDs.println("Failed to delete ${hold.doc.shortId} due to: $e")
-    })
+    def delete = {
+        scheduledForDeletion.println("${hold.doc.getURI()}")
+        hold.scheduleDelete(onError: { e ->
+            failedHoldIDs.println("Failed to delete ${hold.doc.shortId} due to: $e")
+        })
+    }
+
+    item = hold.doc.data['@graph'][1]
+    if(isNcShelf(item)) {
+        delete()
+    }
+    else if (item['hasComponent']) {
+        List components = item['hasComponent']
+        if (components.removeAll(this.&isNcShelf)) {
+            if (components.isEmpty()) {
+                delete()
+            } else {
+                scheduledForUpdate.println("${hold.doc.getURI()}")
+                hold.scheduleSave()
+            }
+        }
+    }
+}
+
+boolean isNcShelf(holdItem) {
+    (holdItem['shelfMark'] && holdItem['shelfMark']['label'].toString().startsWith('NC')) ||
+            (holdItem['physicalLocation']
+                    && holdItem['physicalLocation'].size() == 1
+                    && holdItem['physicalLocation'][0].startsWith('NC')
+            )
+
 }

--- a/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
+++ b/whelktool/scripts/cleanups/2019/09/delete-holdings-for-Nv-NC/delete-holdings-for-Nv-NC.groovy
@@ -5,9 +5,9 @@
  *
  */
 
-PrintWriter failedHoldIDs = getReportWriter("failed-to-delete-holdIDs")
-PrintWriter scheduledForDeletion = getReportWriter("scheduled-for-deletion")
-PrintWriter scheduledForUpdate = getReportWriter("scheduled-for-update")
+failedHoldIDs = getReportWriter("failed-holdIDs")
+scheduledForDeletion = getReportWriter("scheduled-for-deletion")
+scheduledForUpdate = getReportWriter("scheduled-for-update")
 
 where = """
 collection = 'hold'
@@ -15,28 +15,42 @@ and data #>>'{@graph,1,heldBy,@id}' = 'https://libris.kb.se/library/Nv'
 """
 
 selectBySqlWhere(where, silent: false) { hold ->
-    def delete = {
-        scheduledForDeletion.println("${hold.doc.getURI()}")
-        hold.scheduleDelete(onError: { e ->
-            failedHoldIDs.println("Failed to delete ${hold.doc.shortId} due to: $e")
-        })
-    }
-
-    item = hold.doc.data['@graph'][1]
+    Map item = hold.doc.data['@graph'][1]
     if(isNcShelf(item)) {
-        delete()
+        delete(hold)
     }
     else if (item['hasComponent']) {
         List components = item['hasComponent']
         if (components.removeAll(this.&isNcShelf)) {
             if (components.isEmpty()) {
-                delete()
-            } else {
-                scheduledForUpdate.println("${hold.doc.getURI()}")
-                hold.scheduleSave()
+                delete(hold)
+            }
+            else if (components.size() == 1) {
+                try {
+                    promoteLonelyComponent(item)
+                    save(hold)
+                }
+                catch (Exception e) {
+                    failedHoldIDs.println("Failed to update ${hold.doc.shortId} due to: $e")
+                }
+            }
+            else {
+                save(hold)
             }
         }
     }
+}
+
+void promoteLonelyComponent(Map item) {
+    Map component = item['hasComponent'].first()
+    for (key in component.keySet()) {
+        if (item.containsKey(key) && item[key] != component[key]) {
+            throw new RuntimeException("Top-level Item already has key with different value: " +
+                    "item[key]=${item[key]} component[key]=${component[key]}")
+        }
+        item[key] = component[key]
+    }
+    item.remove('hasComponent')
 }
 
 boolean isNcShelf(holdItem) {
@@ -46,4 +60,16 @@ boolean isNcShelf(holdItem) {
                     && holdItem['physicalLocation'][0].startsWith('NC')
             )
 
+}
+
+void delete(hold) {
+    scheduledForDeletion.println("${hold.doc.getURI()}")
+    hold.scheduleDelete(onError: { e ->
+        failedHoldIDs.println("Failed to delete ${hold.doc.shortId} due to: $e")
+    })
+}
+
+void save(hold) {
+    scheduledForUpdate.println("${hold.doc.getURI()}")
+    hold.scheduleSave()
 }


### PR DESCRIPTION
Updated script which handles the (18) posts which have component hold posts or use `physicalLocation` instead of `shelfMark`