### PR TITLE
Backend should set descriptionLastModifier

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -105,7 +105,7 @@ class Document {
 
     String getDescriptionCreator() { get(descriptionCreatorPath) }
 
-    void setDescriptionLastModifier(creator) { set(descriptionLastModifierPath, creator) }
+    void setDescriptionLastModifier(modifier) { set(descriptionLastModifierPath, modifier) }
 
     String getDescriptionLastModifier() { get(descriptionLastModifierPath) }
 


### PR DESCRIPTION
A bit ugly with the hardcoded check of `'https://libris.kb.se/sys/globalchanges/` and sigel SEK.
But we want `lddb.changedby` to be the script URI (?)

It would cleaner to pass `changedBy` = SEK from WhelkTool and maybe also have the possibility to override Sigel in the script.