### PR TITLE
Add Geographic and Temporal to marc:headingmain false map

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -16999,7 +16999,9 @@
         "valueMap": {
           "Topic": false,
           "TopicSubdivision": false,
+          "Geographic": false,
           "GeographicSubdivision": false,
+          "Temporal": false,
           "TemporalSubdivision": false,
           "GenreForm": false,
           "GenreSubdivision" : false,


### PR DESCRIPTION
Add Geographic and Temporal to marc:headingmain valuemap to create 'b' in auth 008/14.