### PR TITLE
Disable gretty hot deployment for rest

### DIFF
--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -168,6 +168,8 @@ gretty {
             debugSuspend = false
         }
     }
+
+    scanInterval = 0
 }
 
 task(groovy, dependsOn: "classes", type: JavaExec) {

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -170,6 +170,7 @@ gretty {
     }
 
     scanInterval = 0
+    interactiveMode = 'rebuildAndRestartOnKeyPress'
 }
 
 task(groovy, dependsOn: "classes", type: JavaExec) {


### PR DESCRIPTION
Disable gretty hot deployment. It leaks database connections so that the local backend stops working if you touch the code too much. Annoying IMO.