### PR TITLE
Try to avoid deadlocks when executing global changes

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1605,6 +1605,7 @@ class PostgreSQLComponent implements Storage {
             while (rs.next()) {
                 dependencies.add( new Tuple2<String, String>(rs.getString(1), rs.getString(2)) )
             }
+            dependencies.sort {a, b -> a.get(0) <=> b.get(0)}
             return dependencies
         }
         finally {


### PR DESCRIPTION
It's hard to test the absence of deadlocks but I ran the following script successfully two times on QA ...
```
selectByCollection('auth') { auth ->
    try {
        auth.scheduleSave()
    }
    catch(Exception e) {
        println(e)
        e.printStackTrace()
    }
}

¯\_(ツ)_/¯
```