### PR TITLE
Add script for removing marc properties on Works

### DIFF
--- a/whelktool/scripts/cleanups/2019/11/lxl-2806-remove-properties-from-works/script.groovy
+++ b/whelktool/scripts/cleanups/2019/11/lxl-2806-remove-properties-from-works/script.groovy
@@ -2,7 +2,7 @@
 See LXL-2806 & LXL-2395 for more info.
 */
 
-PrintWriter failedIDs = getReportWriter("failed-to-delete-bibIDs")
+PrintWriter failedIDs = getReportWriter("failed-to-delete-authIDs")
 scheduledForChange = getReportWriter("scheduledForChange")
 
 selectBySqlWhere("""

--- a/whelktool/scripts/cleanups/2019/11/lxl-2806-remove-properties-from-works/script.groovy
+++ b/whelktool/scripts/cleanups/2019/11/lxl-2806-remove-properties-from-works/script.groovy
@@ -1,0 +1,32 @@
+/*
+See LXL-2806 & LXL-2395 for more info.
+*/
+
+PrintWriter failedIDs = getReportWriter("failed-to-delete-bibIDs")
+scheduledForChange = getReportWriter("scheduledForChange")
+
+selectBySqlWhere("""
+collection = 'auth' AND 
+data#>>'{@graph,1,@type}' = 'Work'
+ """, silent: false) { documentItem ->
+
+    removeFieldFromRecord(documentItem, "marc:kindOfRecord")
+    removeFieldFromRecord(documentItem, "marc:govtAgency")
+    removeFieldFromRecord(documentItem, "marc:level")
+    removeFieldFromRecord(documentItem, "marc:personalName")
+    removeFieldFromRecord(documentItem, "marc:reference")
+    removeFieldFromRecord(documentItem, "marc:transcribingAgency") // mostly faulty languagues
+
+}
+
+private void removeFieldFromRecord(documentItem, String fieldName) {
+    def record = documentItem.doc.data.get('@graph')[0]
+    if (record.remove(fieldName) == null) {
+        scheduledForChange.println "Field $fieldName not present for ${record[ID]}"
+    } else {
+        documentItem.scheduleSave(onError: { e ->
+          failedIDs.println("Failed to save ${record[ID]} due to: $e")
+        })
+        scheduledForChange.println "Remove field $fieldName from ${record[ID]}"
+    }
+}


### PR DESCRIPTION
Removing redundant marc properties from adminMetadata on auth Works

* marc:kindOfRecord
* marc:govtAgency // Not Works
* marc:level
* marc:personalName // Not Works
* marc:reference
* marc:transcribingAgency // 68 records, mostly faulty languagues or '???' therefore has no value for marc:romanization which we are keeping for now.