### PR TITLE
Add scripts for removing marc properties for agents

### DIFF
--- a/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/family.groovy
+++ b/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/family.groovy
@@ -1,0 +1,35 @@
+/*
+See LXL-2809 & LXL-2395 for more info.
+*/
+
+PrintWriter failedIDs = getReportWriter("failed-to-delete-authIDs")
+scheduledForChange = getReportWriter("scheduledForChange")
+
+selectBySqlWhere("""
+collection = 'auth' AND 
+data#>>'{@graph,1,@type}' = 'Family'
+ """, silent: false) { documentItem ->
+
+   removeFieldFromRecord(documentItem, "marc:kindOfRecord")
+   removeFieldFromRecord(documentItem, "marc:govtAgency")
+   removeFieldFromRecord(documentItem, "marc:headingSeries")
+   removeFieldFromRecord(documentItem, "marc:level")
+   removeFieldFromRecord(documentItem, "marc:numberedSeries")
+   removeFieldFromRecord(documentItem, "marc:personalName")
+   removeFieldFromRecord(documentItem, "marc:reference")
+   removeFieldFromRecord(documentItem, "marc:transcribingAgency")
+   removeFieldFromRecord(documentItem, "marc:typeOfSeries")
+
+}
+
+private void removeFieldFromRecord(documentItem, String fieldName) {
+    def record = documentItem.doc.data.get('@graph')[0]
+    if (record.remove(fieldName) == null) {
+        scheduledForChange.println "Field $fieldName not present for ${record[ID]}"
+    } else {
+        documentItem.scheduleSave(onError: { e ->
+          failedIDs.println("Failed to save ${record[ID]} due to: $e")
+        })
+        scheduledForChange.println "Remove field $fieldName from ${record[ID]}"
+    }
+}

--- a/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/organization-jurisdiction-meeting.groovy
+++ b/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/organization-jurisdiction-meeting.groovy
@@ -1,0 +1,39 @@
+/*
+See LXL-2809 & LXL-2395 for more info.
+*/
+
+PrintWriter failedIDs = getReportWriter("failed-to-delete-authIDs")
+scheduledForChange = getReportWriter("scheduledForChange")
+
+selectBySqlWhere("""
+collection = 'auth' 
+AND (
+ data#>>'{@graph,1,@type}' = 'Organization' OR
+ data#>>'{@graph,1,@type}' = 'Jurisdiction' OR
+ data#>>'{@graph,1,@type}' = 'Meeting'
+ )
+ """, silent: false) { documentItem ->
+
+    removeFieldFromRecord(documentItem, "marc:kindOfRecord")
+    removeFieldFromRecord(documentItem, "marc:headingSeries")
+    removeFieldFromRecord(documentItem, "marc:level")
+    removeFieldFromRecord(documentItem, "marc:numberedSeries")
+    removeFieldFromRecord(documentItem, "marc:personalName")
+    removeFieldFromRecord(documentItem, "marc:reference")
+    removeFieldFromRecord(documentItem, "marc:romanization")
+    removeFieldFromRecord(documentItem, "marc:transcribingAgency")
+    removeFieldFromRecord(documentItem, "marc:typeOfSeries")
+
+}
+
+private void removeFieldFromRecord(documentItem, String fieldName) {
+    def record = documentItem.doc.data.get('@graph')[0]
+    if (record.remove(fieldName) == null) {
+        scheduledForChange.println "Field $fieldName not present for ${record[ID]}"
+    } else {
+        documentItem.scheduleSave(onError: { e ->
+          failedIDs.println("Failed to save ${record[ID]} due to: $e")
+        })
+        scheduledForChange.println "Remove field $fieldName from ${record[ID]}"
+    }
+}

--- a/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/person.groovy
+++ b/whelktool/scripts/cleanups/2019/11/lxl-2809-remove-properties-from-agents/person.groovy
@@ -1,0 +1,35 @@
+/*
+See LXL-2809 & LXL-2395 for more info.
+*/
+
+PrintWriter failedIDs = getReportWriter("failed-to-delete-authIDs")
+scheduledForChange = getReportWriter("scheduledForChange")
+
+selectBySqlWhere("""
+collection = 'auth' AND 
+data#>>'{@graph,1,@type}' = 'Person'
+ """, silent: false) { documentItem ->
+
+   removeFieldFromRecord(documentItem, "marc:kindOfRecord")
+   removeFieldFromRecord(documentItem, "marc:fieldref")
+   removeFieldFromRecord(documentItem, "marc:govtAgency")
+   removeFieldFromRecord(documentItem, "marc:headingSeries")
+   removeFieldFromRecord(documentItem, "marc:level")
+   removeFieldFromRecord(documentItem, "marc:numberedSeries")
+   removeFieldFromRecord(documentItem, "marc:reference")
+   removeFieldFromRecord(documentItem, "marc:transcribingAgency")
+   removeFieldFromRecord(documentItem, "marc:typeOfSeries")
+
+}
+
+private void removeFieldFromRecord(documentItem, String fieldName) {
+    def record = documentItem.doc.data.get('@graph')[0]
+    if (record.remove(fieldName) == null) {
+        scheduledForChange.println "Field $fieldName not present for ${record[ID]}"
+    } else {
+        documentItem.scheduleSave(onError: { e ->
+          failedIDs.println("Failed to save ${record[ID]} due to: $e")
+        })
+        scheduledForChange.println "Remove field $fieldName from ${record[ID]}"
+    }
+}


### PR DESCRIPTION
Scripts for removing redundant marc properties in Adminmetadata for all Agents. Can be run independently for Family, Persons and Organization/Jurisdiction/Meeting.

Most important differences:

- GovtAgency is preserved on Organization, Jurisidiction and Meeting
- Personalname is preserved on Person