### PR TITLE
Make determineLegacyCollection more resilient

### DIFF
--- a/whelk-core/src/test/groovy/whelk/LegacyIntegrationToolsSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/LegacyIntegrationToolsSpec.groovy
@@ -4,6 +4,8 @@ import spock.lang.Specification
 
 class LegacyIntegrationToolsSpec extends Specification {
 
+    static idBase = 'https://id.kb.se/marc'
+
     def tool = new LegacyIntegrationTools()
 
     def "should encode and crc32 hash identifier"() {
@@ -17,6 +19,20 @@ class LegacyIntegrationToolsSpec extends Specification {
         "/hold/12345"       | "bgmp5x6h1ct51qd"
         "/auth/123551211"   | "53nnvnsp2gq1qpz"
         "/hold/999999999"   | "59snjbd943p7s0x"
+    }
+
+    def "should get marc category for term"() {
+        expect:
+        tool.getMarcCategoryForTerm([category: cats]) == id
+        where:
+        id      | cats
+        'bib'   | ['@id': "$idBase/bib"]
+        'bib'   | [['@id': "$idBase/bib"], ['@id': "pending"]]
+        'auth'  | [['@id': "$idBase/auth"]]
+        null    | ['@id': 'other']
+        null    | [['@id': 'other']]
+        null    | []
+        null    | null
     }
 
 }


### PR DESCRIPTION
It now verifies whether the found category is a known MARC collection,
and continues to look upward in the class hierarchy otherwise.