### PR TITLE
Added ISBN13 <-> ISBN10 conversion for indexing in Elastic

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -398,32 +398,27 @@ class Document {
         }
     }
 
-    void addTypedRecordIdentifier(String type, String identifier) {
-        if (identifier == null)
-            throw new NullPointerException("Attempted to add typed null-identifier.")
-
-        if (preparePath(recordTypedIDsPath)) {
-            Object typedIDList = get(recordTypedIDsPath)
-            if (typedIDList == null || !(typedIDList instanceof List)) {
-                set(recordTypedIDsPath, [])
-                typedIDList = get(recordTypedIDsPath)
-            }
-
-            def idObject = ["value": identifier, "@type": type]
-            if (typedIDList.every { it -> it != idObject })
-                typedIDList.add(idObject)
-        }
+    void addTypedThingIdentifier(String type, String identifier) {
+        addTypedIdentifier(type, identifier, thingTypedIDsPath)
     }
 
-    void addTypedThingIdentifier(String type, String identifier) {
+    void addIndirectTypedThingIdentifier(String type, String identifier) {
+        addTypedIdentifier(type, identifier, thingIndirectTypedIDsPath)
+    }
+
+    void addTypedRecordIdentifier(String type, String identifier) {
+        addTypedIdentifier(type, identifier, recordIdPath)
+    }
+
+    private void addTypedIdentifier(String type, String identifier, List<Serializable> typedIdsPath) {
         if (identifier == null)
             throw new NullPointerException("Attempted to add typed null-identifier.")
 
-        if (preparePath(thingTypedIDsPath)) {
-            Object typedIDList = get(thingTypedIDsPath)
+        if (preparePath(typedIdsPath)) {
+            Object typedIDList = get(typedIdsPath)
             if (typedIDList == null || !(typedIDList instanceof List)) {
-                set(thingTypedIDsPath, [])
-                typedIDList = get(thingTypedIDsPath)
+                set(typedIdsPath, [])
+                typedIDList = get(typedIdsPath)
             }
 
             def idObject = ["value": identifier, "@type": type]

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -275,35 +275,33 @@ class ElasticSearch {
         List<String> isbnValues = doc.getIsbnValues()
         List<String> isbnHiddenValues = doc.getIsbnHiddenValues()
 
-        List<Isbn> isbnOther = getOtherIsbn(isbnValues)
-        isbnOther.each { other ->
+        List<Isbn> isbnOthers = isbnValues.findResults { getOtherIsbn(it) }
+        isbnOthers.each { other ->
             if (!isbnValues.contains(other)) {
                 doc.addTypedThingIdentifier('ISBN', other.toString())
             }
         }
 
-        List<Isbn> hiddenIsbnOther = getOtherIsbn(isbnHiddenValues)
-        hiddenIsbnOther.each { other ->
+        List<Isbn> hiddenIsbnOthers = isbnHiddenValues.findResults { getOtherIsbn(it) }
+        hiddenIsbnOthers.each { other ->
             if (!isbnHiddenValues.contains(other)) {
                 doc.addIndirectTypedThingIdentifier('ISBN', other.toString())
             }
         }
     }
 
-    private static List<Isbn> getOtherIsbn(List<String> isbnValues) {
-        return isbnValues.findResults { isbnValue ->
-            Isbn isbn = IsbnParser.parse(isbnValue)
-            if (isbn == null ) {
-                //Isbnparser.parse() returns null for invalid ISBN forms
-                return null
-            }
-            def isbnOtherType = isbn.getType() == Isbn.ISBN10 ? Isbn.ISBN13 : Isbn.ISBN10
-            try {
-                return isbn.convert(isbnOtherType)
-            } catch (ConvertException ignored) {
-                //Exception thrown when trying to transform non-convertible ISBN13 (starting with 979) to ISBN10
-                return null
-            }
+    private static Isbn getOtherIsbn(String isbnValue) {
+        Isbn isbn = IsbnParser.parse(isbnValue)
+        if (isbn == null) {
+            //Isbnparser.parse() returns null for invalid ISBN forms
+            return null
+        }
+        def isbnOtherType = isbn.getType() == Isbn.ISBN10 ? Isbn.ISBN13 : Isbn.ISBN10
+        try {
+            return isbn.convert(isbnOtherType)
+        } catch (ConvertException ignored) {
+            //Exception thrown when trying to transform non-convertible ISBN13 (starting with 979) to ISBN10
+            return null
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -272,22 +272,17 @@ class ElasticSearch {
     }
 
     private static void setComputedProperties(Document doc) {
-        List<String> isbnValues = doc.getIsbnValues()
-        List<String> isbnHiddenValues = doc.getIsbnHiddenValues()
+        List<String> identifiedByIsbns = doc.getIsbnValues()
+        identifiedByIsbns
+                .findResults { getOtherIsbn(it) }
+                .findAll { !identifiedByIsbns.contains(it) }
+                .each { doc.addTypedThingIdentifier('ISBN', it.toString()) }
 
-        List<Isbn> isbnOthers = isbnValues.findResults { getOtherIsbn(it) }
-        isbnOthers.each { other ->
-            if (!isbnValues.contains(other)) {
-                doc.addTypedThingIdentifier('ISBN', other.toString())
-            }
-        }
-
-        List<Isbn> hiddenIsbnOthers = isbnHiddenValues.findResults { getOtherIsbn(it) }
-        hiddenIsbnOthers.each { other ->
-            if (!isbnHiddenValues.contains(other)) {
-                doc.addIndirectTypedThingIdentifier('ISBN', other.toString())
-            }
-        }
+        List<String> indirectlyIdentifiedByIsbns = doc.getIsbnHiddenValues()
+        indirectlyIdentifiedByIsbns
+                .findResults { getOtherIsbn(it) }
+                .findAll { !indirectlyIdentifiedByIsbns.contains(it) }
+                .each { doc.addIndirectTypedThingIdentifier('ISBN', it.toString()) }
     }
 
     private static Isbn getOtherIsbn(String isbnValue) {


### PR DESCRIPTION
```
"identifiedBy": [
                        {
                            "@type": "ISBN",
                            "value": "0070231826",
                        }
```
is on reindex transformed to

```
"identifiedBy": [
                        {
                            "@type": "ISBN",
                            "value": "0070231826",
                            "_str": "ISBN 0070231826"
                        },
                        {
                            "@type": "ISBN",
                            "value": "9780070231825",
                            "_str": "ISBN 9780070231825"
                        }
```
so the document is searchable using both ISBN10 and ISBN13 in ISBN search as well as fritext. 

- The method addTypedThingIdentifier on the Document class was previously unused. Any risks using it?
- One problem now is that both ISBN types are presented when viewing the doc from the search result list (elastic), and only the original one is shown in the full document view (jsonld).  