### PR TITLE
Add a retry queue for failed ElasticSearch indexing attempts.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -90,7 +90,7 @@ class ElasticSearch {
         // httpParams.setParameter(ClientPNames.CONN_MANAGER_TIMEOUT, new Long(TIMEOUT_MS));
 
 
-        new Timer().schedule(new TimerTask() {
+        new Timer("ElasticIndexingRetrier", true).schedule(new TimerTask() {
             void run() {
                 if (retryLock.tryLock()) {
                     try {


### PR DESCRIPTION
The list is as of yet only memory resident, and retries are attempted
every 10 seconds.