### PR TITLE
Feature/elastic error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Session.vim
 # Java/Gradle Artifacts
 /.gradle
 /*/.gradle
+/build
 /*/build
 /*/catalina.base_IS_UNDEFINED
 /*/logs

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id "nebula.lint" version "16.0.2"
+}
+
+subprojects {
+    gradleLint.rules = ['all-dependency']
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.daemon=true
 jetty94Version = 9.4.20.v20190813
 prometheusVersion = 0.8.0
+resilience4jVersion = 1.2.0

--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -72,23 +72,30 @@ dependencies {
 
     // Dependencies inherited from classic libris, due to profile handling
     compile group: 'com.ibm.icu', name: 'icu4j', version: '4.8.1.1'
-    compile group: 'org.dspace', name: 'xoai', version: '3.2.10'
+    compile(group: 'org.dspace', name: 'xoai', version: '3.2.10') {
+        exclude group: 'org.mockito'
+        exclude group: 'org.hamcrest'
+        exclude group: 'junit'
+        exclude group: 'com.lyncode', module: 'test-support'
+    }
     compile group: 'xml-apis', name: 'xml-apis', version: '1.4.01'
 
     // Common tools
-    compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-    compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
-    compile 'commons-cli:commons-cli:1.2'
-    compile 'commons-io:commons-io:2.4'
-    compile 'commons-codec:commons-codec:1.7'
     compile "com.google.guava:guava:16.0.1"
-    compile 'commons-collections:commons-collections:3.2.1'
-    compile "stax:stax:1.2.0"
+    compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile "stax:stax-api:1.0.1"
     compile 'com.damnhandy:handy-uri-templates:2.0.4'
     compile 'com.zaxxer:HikariCP:3.4.1'
-    compile 'org.apache.jena:apache-jena-libs:3.0.1'
-    compile group: 'xerces', name: 'xercesImpl', version: '2.11.0' //KP
+    compile 'commons-codec:commons-codec:1.7'
+    compile 'commons-io:commons-io:2.4'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
+    compile 'org.codehaus.groovy:groovy-json:2.5.4'
+    compile 'org.codehaus.groovy:groovy-xml:2.5.4'
+    compile 'org.apache.httpcomponents:httpclient:4.2.6'
+    compile 'org.apache.httpcomponents:httpcore:4.2.5'
+    compile 'org.apache.jena:jena-core:3.0.1'
+    compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
+    compile 'xerces:xercesImpl:2.11.0' //KP
 
     // Logging
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
@@ -98,17 +105,13 @@ dependencies {
     compile 'org.apache.commons:commons-collections4:4.1'
 
     // metrics
-    compile "io.prometheus:simpleclient:${prometheusVersion}"
     compile "io.prometheus:simpleclient_guava:${prometheusVersion}"
 
     // Integration
     compile "org.apache.commons:commons-lang3:3.3.2"
-    compile 'com.vividsolutions:jts:1.13'
     compile 'org.postgresql:postgresql:9.4.1212.jre7'
 
     // profiling and test
-    testCompile "org.gperfutils:gprof:0.3.0-groovy-2.3"
-    testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
 
     // Integration Testing

--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'jacoco'
+apply plugin: 'nebula.lint'
 
 archivesBaseName = "xlcore"
 

--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -82,18 +82,21 @@ dependencies {
 
     // Common tools
     compile "com.google.guava:guava:16.0.1"
+    compile "io.github.resilience4j:resilience4j-circuitbreaker:${resilience4jVersion}"
+    compile "io.github.resilience4j:resilience4j-prometheus:${resilience4jVersion}"
+    compile "io.github.resilience4j:resilience4j-retry:${resilience4jVersion}"
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile "stax:stax-api:1.0.1"
     compile 'com.damnhandy:handy-uri-templates:2.0.4'
     compile 'com.zaxxer:HikariCP:3.4.1'
     compile 'commons-codec:commons-codec:1.7'
     compile 'commons-io:commons-io:2.4'
-    compile 'org.codehaus.groovy:groovy:2.5.4'
-    compile 'org.codehaus.groovy:groovy-json:2.5.4'
-    compile 'org.codehaus.groovy:groovy-xml:2.5.4'
     compile 'org.apache.httpcomponents:httpclient:4.2.6'
     compile 'org.apache.httpcomponents:httpcore:4.2.5'
     compile 'org.apache.jena:jena-core:3.0.1'
+    compile 'org.codehaus.groovy:groovy-json:2.5.4'
+    compile 'org.codehaus.groovy:groovy-xml:2.5.4'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
     compile 'xerces:xercesImpl:2.11.0' //KP
 

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -20,6 +20,8 @@ class DependencyCache {
     private static final int CACHE_SIZE = 10_000
     private static final int REFRESH_INTERVAL_MINUTES = 5
 
+    private static final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register()
+
     PostgreSQLComponent storage
 
     private Executor cacheRefresher = Executors.newSingleThreadExecutor(
@@ -40,7 +42,6 @@ class DependencyCache {
     DependencyCache(PostgreSQLComponent storage) {
         this.storage = storage
 
-        CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register()
         cacheMetrics.addCache('dependersCache', dependersCache)
         cacheMetrics.addCache('dependencyCache', dependenciesCache)
     }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -1,0 +1,193 @@
+package whelk.component
+
+import com.google.common.collect.Iterators
+import groovy.transform.CompileStatic
+import groovy.util.logging.Log4j2 as Log
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector
+import io.github.resilience4j.prometheus.collectors.RetryMetricsCollector
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.retry.RetryRegistry
+import io.prometheus.client.CollectorRegistry
+import org.apache.http.HttpEntity
+import org.apache.http.HttpRequest
+import org.apache.http.HttpResponse
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.client.methods.HttpPut
+import org.apache.http.client.methods.HttpRequestBase
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.impl.conn.PoolingClientConnectionManager
+import org.apache.http.params.HttpConnectionParams
+import org.apache.http.params.HttpParams
+import org.apache.http.util.EntityUtils
+import whelk.exception.ElasticIOException
+
+import java.time.Duration
+
+@Log
+@CompileStatic
+class ElasticClient {
+    static final int MAX_CONNECTIONS_PER_HOST = 12
+    static final int CONNECTION_POOL_SIZE = 30
+
+    static final int CONNECT_TIMEOUT_MS = 5 * 1000
+    static final int READ_TIMEOUT_MS = 40 * 1000
+    static final int MAX_BACKOFF_S = 1024
+
+    static final CircuitBreakerConfig CB_CONFIG = CircuitBreakerConfig.custom()
+            .minimumNumberOfCalls(10)
+            .slidingWindowSize(10)
+            .failureRateThreshold(50)
+            .waitDurationInOpenState(Duration.ofSeconds(10))
+            .slowCallRateThreshold(50)
+            .slowCallDurationThreshold(Duration.ofSeconds(30))
+            .permittedNumberOfCallsInHalfOpenState(1)
+            .build();
+
+    List<ElasticNode> elasticNodes
+    HttpClient httpClient
+    Random random = new Random()
+
+    CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults()
+    RetryRegistry retryRegistry = RetryRegistry.ofDefaults()
+    Retry globalRetry
+
+    static ElasticClient withDefaultHttpClient(List<String> elasticHosts) {
+        PoolingClientConnectionManager cm = new PoolingClientConnectionManager()
+        cm.setMaxTotal(CONNECTION_POOL_SIZE)
+        cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_HOST)
+
+        HttpClient httpClient = new DefaultHttpClient(cm)
+        HttpParams httpParams = httpClient.getParams()
+        HttpConnectionParams.setConnectionTimeout(httpParams, CONNECT_TIMEOUT_MS)
+        HttpConnectionParams.setSoTimeout(httpParams, READ_TIMEOUT_MS)
+        // FIXME: upgrade httpClient (and use RequestConfig)- https://issues.apache.org/jira/browse/HTTPCLIENT-1418
+        // httpParams.setParameter(ClientPNames.CONN_MANAGER_TIMEOUT, new Long(TIMEOUT_MS));
+
+        return new ElasticClient(httpClient, elasticHosts)
+    }
+
+    ElasticClient(HttpClient httpClient, List<String> elasticHosts) {
+        this.httpClient = httpClient
+        this.elasticNodes = elasticHosts.collect { new ElasticNode(it) }
+
+        globalRetry = retryRegistry.retry(ElasticClient.class.getSimpleName(), RetryConfig.custom()
+                .waitDuration(Duration.ofMillis(10))
+                .maxAttempts(elasticNodes.size() * 2)
+                .build())
+
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry
+        collectorRegistry.register(RetryMetricsCollector.ofRetryRegistry(retryRegistry))
+        collectorRegistry.register(CircuitBreakerMetricsCollector.ofCircuitBreakerRegistry(circuitBreakerRegistry))
+
+        log.info "ElasticSearch component initialized with ${elasticHosts.size()} nodes."
+    }
+
+    Tuple2<Integer, String> performRequest(String method, String path, String body, String contentType0 = null) {
+        try {
+            def nodes = cycleNodes()
+            return globalRetry.executeSupplier({ -> nodes.next().performRequest(method, path, body, contentType0) })
+        }
+        catch (Exception e) {
+            log.warn("Request to ElasticSearch failed: ${e}", e)
+            throw new ElasticIOException(e.getMessage(), e)
+        }
+    }
+
+    private Iterator<ElasticNode> cycleNodes() {
+        def cycle = Iterators.cycle(elasticNodes)
+        Iterators.advance(cycle, random.nextInt(elasticNodes.size()))
+        return cycle
+    }
+
+    class ElasticNode {
+        String host
+        CircuitBreaker circuitBreaker
+        Retry retry
+
+        ElasticNode(String host) {
+            this.host = host
+            this.circuitBreaker = circuitBreakerRegistry.circuitBreaker(host, CB_CONFIG)
+            this.retry = retryRegistry.retry(host, RetryConfig.custom()
+                    .maxAttempts(2)
+                    .retryOnException({ !(it instanceof RetriesExceededException) }).build())
+        }
+
+        Tuple2<Integer, String> performRequest(String method, String path, String body, String contentType0 = null) {
+            HttpRequest request = buildRequest(method, path, body, contentType0)
+            return circuitBreaker.executeSupplier(Retry.decorateSupplier(retry, { -> sendRequest(request) }))
+        }
+
+        private Tuple2<Integer, String> sendRequest(HttpRequestBase request) {
+            try {
+                return sendRequestRetry429(request)
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e)
+            }
+            finally {
+                request.reset()
+                request.releaseConnection()
+            }
+        }
+
+        private Tuple2<Integer, String> sendRequestRetry429(HttpRequestBase request) {
+            int backOffSeconds = 1
+            while (true) {
+                HttpResponse response = httpClient.execute(request)
+                int statusCode = response.getStatusLine().getStatusCode()
+
+                if (statusCode != 429) {
+                    return new Tuple2(statusCode, EntityUtils.toString(response.getEntity()))
+                }
+                else {
+                    if (backOffSeconds > MAX_BACKOFF_S) {
+                        throw new RetriesExceededException("Max retries exceeded: HTTP 429 from ElasticSearch")
+                    }
+
+                    request.reset()
+
+                    log.info("Bulk indexing request to ElasticSearch was throttled (HTTP 429) waiting $backOffSeconds seconds before retry.")
+                    Thread.sleep(backOffSeconds * 1000)
+
+                    backOffSeconds *= 2
+                }
+            }
+        }
+
+        private HttpRequestBase buildRequest(String method, String path, String body, String contentType0 = null) {
+            switch (method) {
+                case 'GET':
+                    return new HttpGet(host + path)
+                case 'PUT':
+                    HttpPut request = new HttpPut(host + path)
+                    request.setEntity(httpEntity(body, contentType0))
+                    return request
+                case 'POST':
+                    HttpPost request = new HttpPost(host + path)
+                    request.setEntity(httpEntity(body, contentType0))
+                    return request
+                default:
+                    throw new IllegalArgumentException("Bad request method:" + method)
+            }
+        }
+
+        private static HttpEntity httpEntity(String body, String contentType) {
+            return new StringEntity(body,
+                    contentType ? ContentType.create(contentType) : ContentType.APPLICATION_JSON)
+        }
+    }
+
+    class RetriesExceededException extends RuntimeException {
+        RetriesExceededException(String msg) {
+            super(msg)
+        }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -3,21 +3,6 @@ package whelk.component
 import groovy.json.JsonOutput
 import groovy.util.logging.Log4j2 as Log
 import org.apache.commons.codec.binary.Base64
-import org.apache.http.HttpEntity
-import org.apache.http.HttpRequest
-import org.apache.http.HttpResponse
-import org.apache.http.client.HttpClient
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpPut
-import org.apache.http.client.methods.HttpRequestBase
-import org.apache.http.entity.ContentType
-import org.apache.http.entity.StringEntity
-import org.apache.http.impl.client.DefaultHttpClient
-import org.apache.http.impl.conn.PoolingClientConnectionManager
-import org.apache.http.params.HttpConnectionParams
-import org.apache.http.params.HttpParams
-import org.apache.http.util.EntityUtils
 import org.codehaus.jackson.map.ObjectMapper
 import se.kb.libris.utils.isbn.ConvertException
 import se.kb.libris.utils.isbn.Isbn
@@ -25,28 +10,18 @@ import se.kb.libris.utils.isbn.IsbnParser
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
-import whelk.exception.WhelkRuntimeException
 
-import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.LinkedBlockingQueue
 
 @Log
 class ElasticSearch {
     static final String BULK_CONTENT_TYPE = "application/x-ndjson"
-    static final int MAX_CONNECTIONS_PER_HOST = 12
-    static final int CONNECTION_POOL_SIZE = 30
-    static final int TIMEOUT_MS = 40 * 1000
-    static final int MAX_BACKOFF = 1024
-
-    PoolingClientConnectionManager cm
-    HttpClient httpClient
+    private static final ObjectMapper mapper = new ObjectMapper()
 
     String defaultIndex = null
     private List<String> elasticHosts
     private String elasticCluster
-    Random random = new Random()
-
-    private static final ObjectMapper mapper = new ObjectMapper()
+    private ElasticClient client
 
     private class RetryEntry {
         Document doc
@@ -54,64 +29,44 @@ class ElasticSearch {
         Whelk whelk
     }
 
-    private final ReentrantLock retryLock = new ReentrantLock()
-    private final LinkedBlockingDeque<RetryEntry> indexingRetryQueue = new LinkedBlockingDeque()
+    private final Queue<RetryEntry> indexingRetryQueue = new LinkedBlockingQueue<>()
 
     ElasticSearch(Properties props) {
-        this.elasticHosts = getElasticHosts(props.getProperty("elasticHost"))
-        this.elasticCluster = props.getProperty("elasticCluster")
-        this.defaultIndex = props.getProperty("elasticIndex")
-        setup()
+        this(
+                props.getProperty("elasticHost"),
+                props.getProperty("elasticCluster"),
+                props.getProperty("elasticIndex")
+        )
     }
 
     ElasticSearch(String elasticHost, String elasticCluster, String elasticIndex) {
         this.elasticHosts = getElasticHosts(elasticHost)
         this.elasticCluster = elasticCluster
         this.defaultIndex = elasticIndex
-        setup()
+
+        client = ElasticClient.withDefaultHttpClient(elasticHosts)
+
+        new Timer("ElasticIndexingRetries", true).schedule(new TimerTask() {
+            void run() {
+                indexingRetryQueue.size().times {
+                    RetryEntry entry = indexingRetryQueue.poll()
+                    if (entry != null)
+                        index(entry.doc, entry.collection, entry.whelk)
+                }
+            }
+        }, 60*1000, 10*1000)
     }
 
     private List<String> getElasticHosts(String elasticHost) {
         List<String> hosts = []
         for (String host : elasticHost.split(",")) {
+            host = host.trim()
             if (!host.contains(":"))
                 host += ":9200"
             hosts.add("http://" + host)
         }
         return hosts
     }
-
-    private void setup() {
-        cm = new PoolingClientConnectionManager()
-        cm.setMaxTotal(CONNECTION_POOL_SIZE)
-        cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_HOST)
-
-        httpClient = new DefaultHttpClient(cm)
-        HttpParams httpParams = httpClient.getParams();
-        HttpConnectionParams.setConnectionTimeout(httpParams, TIMEOUT_MS)
-        HttpConnectionParams.setSoTimeout(httpParams, TIMEOUT_MS)
-        // FIXME: upgrade httpClient (and use RequestConfig)- https://issues.apache.org/jira/browse/HTTPCLIENT-1418
-        // httpParams.setParameter(ClientPNames.CONN_MANAGER_TIMEOUT, new Long(TIMEOUT_MS));
-
-
-        new Timer("ElasticIndexingRetrier", true).schedule(new TimerTask() {
-            void run() {
-                if (retryLock.tryLock()) {
-                    try {
-                        for (int i = 0; i < indexingRetryQueue.size(); ++i) {
-                            RetryEntry entry = indexingRetryQueue.poll()
-                            if (entry != null)
-                                index(entry.doc, entry.collection, entry.whelk)
-                        }
-                    } finally {
-                        retryLock.unlock()
-                    }
-                }
-            }
-        }, 60*1000, 10*1000)
-
-        log.info "ElasticSearch component initialized with ${elasticHosts.count{it}} nodes and $CONNECTION_POOL_SIZE workers."
-     }
 
     String getIndexName() { defaultIndex }
 
@@ -120,7 +75,7 @@ class ElasticSearch {
 	 *
 	 */
 	Map getMappings() {
-		Tuple2<Integer, String> res = performRequest('GET', "/${indexName}/_mappings", '')
+		Tuple2<Integer, String> res = client.performRequest('GET', "/${indexName}/_mappings", '')
 		int statusCode = res.first
 		if (statusCode != 200) {
 			log.warn("Got unexpected status code ${statusCode} when getting ES mappings.")
@@ -141,67 +96,6 @@ class ElasticSearch {
         }
     }
 
-    Tuple2<Integer, String> performRequest(String method, String path, String body, String contentType0 = null) {
-        String host = elasticHosts[random.nextInt(elasticHosts.size())]
-        HttpRequest request
-        switch (method) {
-            case 'GET':
-                request = new HttpGet(host + path)
-                break
-            case 'PUT':
-                request = new HttpPut(host + path)
-                request.setEntity(httpEntity(body, contentType0))
-                break;
-            case 'POST':
-                request = new HttpPost(host + path)
-                request.setEntity(httpEntity(body, contentType0))
-                break
-            default:
-                throw new IllegalArgumentException("Bad request method:" + method)
-        }
-
-        try {
-            performRequest(request)
-        }
-        catch (Exception e) {
-            log.warn("Request to ElasticSearch failed: ${e}", e)
-            throw new WhelkRuntimeException(e.getMessage(), e)
-        }
-        finally {
-            request.releaseConnection()
-        }
-    }
-
-    Tuple2<Integer, String> performRequest(HttpRequestBase request) {
-        int backOffTime = 1
-        while (true) {
-            HttpResponse response = httpClient.execute(request)
-            String responseBody = EntityUtils.toString(response.getEntity())
-            Tuple2<Integer, String> result = new Tuple2(response.getStatusLine().getStatusCode(), responseBody)
-
-            request.reset()
-
-            if (result.first == 429) {
-                if (backOffTime > MAX_BACKOFF) {
-                    throw new RuntimeException("Max retries exceeded: HTTP 429 from ElasticSearch")
-                }
-
-                log.info("Bulk indexing request to ElasticSearch was throttled (HTTP 429) waiting $backOffTime seconds before retry.")
-                Thread.sleep(backOffTime * 1000)
-
-                backOffTime *= 2
-            }
-            else {
-                return result
-            }
-        }
-    }
-
-    private HttpEntity httpEntity(String body, String contentType){
-        return new StringEntity(body,
-                contentType ? ContentType.create(contentType) : ContentType.APPLICATION_JSON)
-    }
-
     void bulkIndex(List<Document> docs, String collection, Whelk whelk) {
         assert collection
         if (docs) {
@@ -217,7 +111,7 @@ class ElasticSearch {
                 }
             }.join('')
 
-            String response = performRequest('POST', '/_bulk', bulkString, BULK_CONTENT_TYPE).second
+            String response = client.performRequest('POST', '/_bulk', bulkString, BULK_CONTENT_TYPE).second
             Map responseMap = mapper.readValue(response, Map)
             log.info("Bulk indexed ${docs.count{it}} docs in ${responseMap.took} ms")
         }
@@ -235,7 +129,7 @@ class ElasticSearch {
         // _internally_ but be otherwise invisible to clients (If postgres writing was ok, the save is considered ok).
         try {
             Map shapedData = getShapeForIndex(doc, whelk, collection)
-            def response = performRequest('PUT',
+            def response = client.performRequest('PUT',
                     "/${indexName}/${collection}" +
                             "/${toElasticId(doc.getShortId())}?pipeline=libris",
                     JsonOutput.toJson(shapedData)).second
@@ -250,7 +144,7 @@ class ElasticSearch {
     void remove(String identifier) {
         log.debug("Deleting object with identifier ${toElasticId(identifier)}.")
         def dsl = ["query":["term":["_id":toElasticId(identifier)]]]
-        def response = performRequest('POST',
+        def response = client.performRequest('POST',
                 "/${indexName}/_delete_by_query?conflicts=proceed",
                 JsonOutput.toJson(dsl)).second
         Map responseMap = mapper.readValue(response, Map)
@@ -347,9 +241,14 @@ class ElasticSearch {
         )
     }
 
+    @Override
+    int hashCode() {
+        return super.hashCode()
+    }
+
     private Map performQuery(Map jsonDsl, String queryUrl, Closure<Map> hitCollector) {
         def start = System.currentTimeMillis()
-        Tuple2<Integer, String> response = performRequest('POST',
+        Tuple2<Integer, String> response = client.performRequest('POST',
                 queryUrl,
                 JsonOutput.toJson(jsonDsl))
         int statusCode = response.first

--- a/whelk-core/src/main/java/whelk/exception/ElasticIOException.java
+++ b/whelk-core/src/main/java/whelk/exception/ElasticIOException.java
@@ -1,0 +1,7 @@
+package whelk.exception;
+
+public class ElasticIOException extends WhelkRuntimeException {
+    public ElasticIOException(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/whelk-core/src/test/groovy/PostgreSQLComponentSpec.groovy
+++ b/whelk-core/src/test/groovy/PostgreSQLComponentSpec.groovy
@@ -4,7 +4,6 @@ import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
 import spock.lang.Specification
 import whelk.Document
-import whelk.DocumentSpec
 
 import java.sql.Connection
 import java.sql.PreparedStatement


### PR DESCRIPTION
New dependency: resilience4j (https://resilience4j.readme.io/)
New dependency: nebula.lint for checking gradle dependecies (https://github.com/nebula-plugins/gradle-lint-plugin)

Removed unused dependencies and made undeclared uses of transitive dependencies explicit.

Example output from metrics:
```
# HELP api_requests_total Total requests to API.
# TYPE api_requests_total counter
api_requests_total{method="GET",} 152.0
# HELP resilience4j_retry_calls The number of calls
# TYPE resilience4j_retry_calls gauge
resilience4j_retry_calls{name="ElasticClient",kind="successful_without_retry",} 142.0
resilience4j_retry_calls{name="ElasticClient",kind="successful_with_retry",} 0.0
resilience4j_retry_calls{name="ElasticClient",kind="failed_without_retry",} 0.0
resilience4j_retry_calls{name="ElasticClient",kind="failed_with_retry",} 0.0
resilience4j_retry_calls{name="http://localhost:9200",kind="successful_without_retry",} 142.0
resilience4j_retry_calls{name="http://localhost:9200",kind="successful_with_retry",} 0.0
resilience4j_retry_calls{name="http://localhost:9200",kind="failed_without_retry",} 0.0
resilience4j_retry_calls{name="http://localhost:9200",kind="failed_with_retry",} 0.0
# HELP resilience4j_circuitbreaker_calls Total number of calls by kind
# TYPE resilience4j_circuitbreaker_calls histogram
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.005",} 121.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.01",} 133.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.025",} 136.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.05",} 139.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.075",} 141.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.1",} 141.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.25",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.5",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="0.75",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="1.0",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="2.5",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="5.0",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="7.5",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="10.0",} 142.0
resilience4j_circuitbreaker_calls_bucket{name="http://localhost:9200",kind="successful",le="+Inf",} 142.0
resilience4j_circuitbreaker_calls_count{name="http://localhost:9200",kind="successful",} 142.0
resilience4j_circuitbreaker_calls_sum{name="http://localhost:9200",kind="successful",} 0.8602747889999998
# HELP resilience4j_circuitbreaker_state The state of the circuit breaker:
# TYPE resilience4j_circuitbreaker_state gauge
resilience4j_circuitbreaker_state{name="http://localhost:9200",state="disabled",} 0.0
resilience4j_circuitbreaker_state{name="http://localhost:9200",state="closed",} 1.0
resilience4j_circuitbreaker_state{name="http://localhost:9200",state="open",} 0.0
resilience4j_circuitbreaker_state{name="http://localhost:9200",state="forced_open",} 0.0
resilience4j_circuitbreaker_state{name="http://localhost:9200",state="half_open",} 0.0
# HELP resilience4j_circuitbreaker_buffered_calls The number of buffered calls
# TYPE resilience4j_circuitbreaker_buffered_calls gauge
resilience4j_circuitbreaker_buffered_calls{name="http://localhost:9200",kind="successful",} 100.0
resilience4j_circuitbreaker_buffered_calls{name="http://localhost:9200",kind="failed",} 0.0
# HELP resilience4j_circuitbreaker_slow_calls The number of slow calls
# TYPE resilience4j_circuitbreaker_slow_calls gauge
resilience4j_circuitbreaker_slow_calls{name="http://localhost:9200",kind="successful",} 0.0
resilience4j_circuitbreaker_slow_calls{name="http://localhost:9200",kind="failed",} 0.0
```