### PR TITLE
Feature/use meta on revert

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -900,7 +900,8 @@ class JsonLd {
     }
 
     private static boolean shouldKeep(String key, List propertiesToKeep) {
-        return (key == RECORD_KEY || key in propertiesToKeep || key.startsWith("@"))
+        return (key == RECORD_KEY || key == THING_KEY ||
+                key in propertiesToKeep || key.startsWith("@"))
     }
 
 
@@ -974,6 +975,8 @@ class JsonLd {
     static Map frame(String mainId, Map inData) {
         Map<String, Map> idMap = getIdMap(inData)
 
+        putRecordReferencesIntoThings(idMap)
+
         Map mainItem = idMap[mainId]
 
         Map framedData
@@ -989,6 +992,19 @@ class JsonLd {
         cleanUp(framedData)
 
         return framedData
+    }
+
+    static void putRecordReferencesIntoThings(Map<String, Map> idMap) {
+        for (obj in idMap.values()) {
+            Map thingRef = obj[THING_KEY]
+            if (thingRef) {
+                String thingId = thingRef[ID_KEY]
+                Map thing = idMap[thingId]
+                Map recRef = [:]
+                recRef[ID_KEY] = obj[ID_KEY]
+                thing[RECORD_KEY] = recRef
+            }
+        }
     }
 
     private static Map embed(String mainId, Map mainItem, Map idMap, Set embedChain) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1049,11 +1049,16 @@ class ConversionPart {
                 def parents = pendingDfn.about == null ? [entity] :
                     pendingDfn.about in aboutMap ? aboutMap[pendingDfn.about] : null
 
-                parents?.each {
-                    def about = it[pendingDfn.link ?: pendingDfn.addLink]
+                parents?.each { parent ->
+                    String link = pendingDfn.link ?: pendingDfn.addLink
+                    def about = parent[link]
+                    if (!about && pendingDfn.infer == true) {
+                        about = ld.getSubProperties(link).findResult { parent[it] }
+                    }
+
                     if (!about && pendingDfn.absorbSingle) {
-                        if (isInstanceOf(it, pendingDfn.resourceType)) {
-                            about = it
+                        if (isInstanceOf(parent, pendingDfn.resourceType)) {
+                            about = parent
                         } else {
                             requiredOk = false
                         }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -8153,6 +8153,7 @@
       "$0": {
         "aboutEntity": "?work",
         "addLink": "describedBy", "resourceType": "Record", "property": "controlNumber",
+        "TODO": "Just drop or remap to something simpler? uriTemplate doesn't work, also only about 37 values? None is a Libris Id...",
         "uriTemplate": "http://libris.kb.se/auth/{_}",
         "matchUriToken": "^\\d{1,14}$"
       },
@@ -16856,6 +16857,7 @@
         },
         "_:describedBy": {
             "addLink": "describedBy",
+            "infer": true,
             "resourceType": "Record"
           }
       },


### PR DESCRIPTION
This enables the production of $w in MARC link fields from the record controlNumber of linked things.

It is also generic, which means it will expose the record of embellished things in embellished data. We probably want to unify this with https://github.com/libris/librisxl/pull/479 (possibly by just reverting that).