### PR TITLE
Fix import warnings

### DIFF
--- a/importers/build.gradle
+++ b/importers/build.gradle
@@ -73,32 +73,21 @@ dependencies {
     providedCompile 'javax.servlet:servlet-api:2.5'
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
-    compile 'commons-cli:commons-cli:1.2'
-    compile 'commons-io:commons-io:2.4'
-    compile 'commons-codec:commons-codec:1.7'
-    compile "com.google.guava:guava:16.0.1"
-    compile 'commons-collections:commons-collections:3.2.1'
-    compile "org.apache.httpcomponents:httpclient:4.3.1"
-    compile "stax:stax:1.2.0"
-    compile "stax:stax-api:1.0.1"
-    compile 'com.damnhandy:handy-uri-templates:2.0.4'
-    compile 'org.apache.commons:commons-dbcp2:2.0.1'
     // Integration
-    compile 'mysql:mysql-connector-java:8.0.17'
-    compile 'org.codehaus.gpars:gpars:1.2.1'
 
     // metrics
     compile "io.prometheus:simpleclient:${prometheusVersion}"
-    compile "io.prometheus:simpleclient_servlet:${prometheusVersion}"
 
     // Logging
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
 
     // profiling and test
-    testCompile "org.gperfutils:gprof:0.3.0-groovy-2.3"
-    testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
+    compile 'org.codehaus.groovy:groovy-json:2.5.4'
+    compile 'org.codehaus.groovy:groovy-sql:2.5.4'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
+    compile 'org.slf4j:slf4j-api:1.7.26'
 }
 
 // Include dependent libraries in archive.
@@ -131,7 +120,6 @@ project.afterEvaluate {
             configurations.executableWarDeps.collect {
                 //it.isDirectory() ? it : project.zipTree(it)
                 it.isDirectory() ? it : project.zipTree(it).matching {
-                    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
                 }
             }
         }

--- a/marc_export/build.gradle
+++ b/marc_export/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     compile group: 'com.ibm.icu', name: 'icu4j', version: '4.8.1.1'
     compile group: 'org.dspace', name: 'xoai', version: '3.2.10'
     compile group: 'xml-apis', name: 'xml-apis', version: '1.4.01'
+    compile 'org.apache.commons:commons-lang3:3.3.2'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
 }
 
 gretty {

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -87,43 +87,27 @@ dependencies {
 
     // Common tools
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-    compile "org.codehaus.groovy:groovy-dateutil:${groovyVersion}"
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
-    compile 'commons-cli:commons-cli:1.2'
     compile 'commons-io:commons-io:2.4'
-    compile 'commons-codec:commons-codec:1.7'
     compile "com.google.guava:guava:16.0.1"
-    compile 'commons-collections:commons-collections:3.2.1'
     compile "org.apache.httpcomponents:httpclient:4.3.1"
-    compile "stax:stax:1.2.0"
-    compile "stax:stax-api:1.0.1"
-    compile 'org.apache.commons:commons-dbcp2:2.0.1'
     // Integration
-    compile "org.apache.commons:commons-lang3:3.3.2"
-    compile 'com.vividsolutions:jts:1.13'
     /* Not needed?
     compile 'com.thoughtworks.paranamer:paranamer:2.7'
     compile 'asm:asm:3.3.1'
     */
     // Standalone
-    compile "org.eclipse.jetty:jetty-webapp:${jettyVersion}"
-    compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
     // Servlet dependencies
-    compile 'com.thetransactioncompany:cors-filter:2.1.2'
     providedCompile 'javax.servlet:javax.servlet-api:3.0.0'
 
     // metrics
     compile "io.prometheus:simpleclient:${prometheusVersion}"
-    compile "io.prometheus:simpleclient_servlet:${prometheusVersion}"
 
     // Logging
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.8.2'
 
     // profiling and test
-    testCompile "org.gperfutils:gprof:0.3.0-groovy-2.3"
-    testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
 
     // Standalone
@@ -131,6 +115,11 @@ dependencies {
     executableWarDeps "org.eclipse.jetty:jetty-webapp:${jettyVersion}"
     executableWarDeps "org.codehaus.groovy:groovy-all:${groovyVersion}"
     executableWarDeps 'commons-cli:commons-cli:1.2'
+    compile 'org.apache.httpcomponents:httpcore:4.3'
+    compile 'org.codehaus.groovy:groovy-xml:2.5.4'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
+    compile 'org.codehaus.jackson:jackson-core-asl:1.9.12'
+    compile 'xml-apis:xml-apis:1.4.01'
 }
 
 project.afterEvaluate {

--- a/transform/build.gradle
+++ b/transform/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 
     // Testing
     testCompile 'junit:junit:4.12'
+    compile 'org.apache.commons:commons-lang3:3.3.2'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
 }
 
 jar {

--- a/whelktool/build.gradle
+++ b/whelktool/build.gradle
@@ -47,6 +47,11 @@ repositories {
 dependencies {
     compile project(':whelk-core')
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
+    compile 'com.google.guava:guava:18.0'
+    compile 'org.codehaus.groovy:groovy-cli-commons:2.5.4'
+    compile 'org.codehaus.groovy:groovy-jsr223:2.5.4'
+    compile 'org.codehaus.groovy:groovy:2.5.4'
+    compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
 }
 
 jar {
@@ -57,7 +62,6 @@ jar {
     from {
         configurations.compile.collect {
             it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
             }
         }
     }


### PR DESCRIPTION
Remove unused imports and add implicit dependencies. Automatically fixed using fixGradleLint.

We still want either or both of:

- [ ] Fix remaining warnings (duplicated class path entries due to e.g. multiple versions in dependencies)
- [x] Avoid running the linting process on each test invocation (it seems to add like 20-30 seconds on my machine, hampering the flow...)
