### PR TITLE
Don't wait for MarcFrameConverter on startup

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/MarcFrameConverterInitializer.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/MarcFrameConverterInitializer.groovy
@@ -25,13 +25,12 @@ class MarcFrameConverterInitializer implements ServletContextListener {
             void run() {
                 try {
                     WhelkFactory.getSingletonWhelk().getMarcFrameConverter()
-                    log.info("Started {}", MarcFrameConverter.class.getSimpleName())
+                    log.info("Started ${MarcFrameConverter.class.getSimpleName()}")
                 }
                 catch (Exception e) {
-                    log.warn(String.format("Error starting %s: %s", MarcFrameConverter.class.getSimpleName(), e), e)
+                    log.warn("Error starting ${MarcFrameConverter.class.getSimpleName()}: $e", e)
                 }
             }
         }).start()
     }
-
 }

--- a/rest/src/main/groovy/whelk/rest/api/MarcFrameConverterInitializer.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/MarcFrameConverterInitializer.groovy
@@ -1,0 +1,37 @@
+package whelk.rest.api
+
+import groovy.util.logging.Log4j2 as Log
+import whelk.converter.marc.MarcFrameConverter
+import whelk.util.WhelkFactory
+
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletContextListener
+
+@Log
+class MarcFrameConverterInitializer implements ServletContextListener {
+
+    @Override
+    void contextInitialized(ServletContextEvent sce) {
+        initMarcFrameConverterAsync()
+    }
+
+    @Override
+    void contextDestroyed(ServletContextEvent sce) {
+        //
+    }
+
+    void initMarcFrameConverterAsync() {
+        new Thread(new Runnable() {
+            void run() {
+                try {
+                    WhelkFactory.getSingletonWhelk().getMarcFrameConverter()
+                    log.info("Started {}", MarcFrameConverter.class.getSimpleName())
+                }
+                catch (Exception e) {
+                    log.warn(String.format("Error starting %s: %s", MarcFrameConverter.class.getSimpleName(), e), e)
+                }
+            }
+        }).start()
+    }
+
+}

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -44,12 +44,10 @@
     <servlet>
         <servlet-name>RemoteSearch</servlet-name>
         <servlet-class>whelk.rest.api.RemoteSearchAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>MarcConverter</servlet-name>
         <servlet-class>whelk.rest.api.ConverterAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>LegacyVirtualMarc</servlet-name>
@@ -58,27 +56,22 @@
     <servlet>
         <servlet-name>RefreshAPI</servlet-name>
         <servlet-class>whelk.rest.api.RefreshAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>HoldAPI</servlet-name>
         <servlet-class>whelk.rest.api.HoldAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>MergeAPI</servlet-name>
         <servlet-class>whelk.rest.api.MergeAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>RelationsAPI</servlet-name>
         <servlet-class>whelk.rest.api.RecordRelationAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet>
         <servlet-name>DuplicatesAPI</servlet-name>
         <servlet-class>whelk.rest.api.DuplicatesAPI</servlet-class>
-        <load-on-startup>1</load-on-startup>
     </servlet>
 
     <servlet>
@@ -150,5 +143,9 @@
     <welcome-file-list>
         <welcome-file>index.xhtml</welcome-file>
     </welcome-file-list>
+
+    <listener>
+        <listener-class>whelk.rest.api.MarcFrameConverterInitializer</listener-class>
+    </listener>
 
 </web-app>

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -5,13 +5,14 @@ import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.JsonLd
-import whelk.Whelk
-import whelk.component.PostgreSQLComponent
 import whelk.converter.FormatConverter
 import whelk.filter.LinkFinder
-import whelk.util.PropertyLoader
 
-import java.time.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.time.temporal.Temporal

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -161,17 +161,16 @@ class MarcConversion {
         }
         addTypeMaps()
 
-        // log.warn? Though, this "should" not happen in prod...
         missingTerms.each {
-            System.err.println "Missing: $it.term a $it.type"
+            log.debug("Missing: $it.term a $it.type")
         }
         badRepeats.each {
             if (it.term.startsWith(converter.ld.expand('marc:')))
                 return
             if (it.shouldRepeat)
-                System.err.println "Expected to be repeatable: $it.term"
+                log.debug("Expected to be repeatable: $it.term")
             else
-                System.err.println "Unexpected repeat of: $it.term"
+                log.debug("Unexpected repeat of: $it.term")
         }
     }
 
@@ -609,13 +608,6 @@ class MarcRuleSet {
                 revertFieldOrder << tag
             }
         }
-
-        // DEBUG:
-        //fieldHandlers.each { tag, handler ->
-        //    if (handler instanceof MarcFieldHandler && handler.sharesGroupIdWith)
-        //        System.err.println "$tag: $handler.sharesGroupIdWith"
-        //}
-
     }
 
     def processInherit(config, subConf, tag, fieldDfn) {


### PR DESCRIPTION
This shaves ~10s from backend startup time by not waiting for MarcFrameConverter initialization.

* Lazy-load servlets depending on MarcFrameConverter
* Initialize MarcFrameConverter in a the background after application is loaded so that first request doesn't have to wait for it.
* Incoming requests between application started and MarcFrameConverter initialized are queued (web threads block on `Whelk.getMarcFrameConverter()`)