### PR TITLE
Handle framed top-level thing with meta record on revert to MARC

### DIFF
--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -141,7 +141,7 @@ class MarcFrameConverterSpec extends Specification {
         expect:
         converter.conversion.getRuleSetFromJsonLd(jsonld).name == marcType
         when:
-        def result = converter.conversion.revert(jsonld)
+        def result = converter.runRevert(jsonld)
 
         def source = fieldSpec.normalized != null ?
                         fieldSpec.normalized : fieldSpec.source
@@ -216,7 +216,7 @@ class MarcFrameConverterSpec extends Specification {
             ]
         ]
         when:
-        def result = converter.conversion.revert(jsonld)
+        def result = converter.runRevert(jsonld)
         then:
         result.fields == [
             ["001": "0000000"],
@@ -224,6 +224,20 @@ class MarcFrameConverterSpec extends Specification {
             ["008": "020409 | anznnbabn          |EEEEEEEEEEE"]
         ]
 
+    }
+
+    def "should handle various data shapes on revert"() {
+        given:
+        def data = [
+            "meta": ["controlNumber": "0000000"],
+            "@type": "Instance",
+            "instanceOf": ["@type": "Text"]
+        ]
+        when:
+        def marc = converter.runRevert(data)
+        then:
+        marc.leader.contains('|a|')
+        marc.fields[0]['001'] == '0000000'
     }
 
     def "should accept sameAs-token-URIs on revert"() {
@@ -245,7 +259,7 @@ class MarcFrameConverterSpec extends Specification {
             ]
         ]
         when:
-        def result = converter.conversion.revert(jsonld)
+        def result = converter.runRevert(jsonld)
         then:
         result.fields[1]["008"] == "900101|        |  |||||||||||000 1dswe| "
     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -94,6 +94,12 @@ class MarcFrameConverter implements FormatConverter {
         if (data['@graph']) {
             def entryId = data['@graph'][0]['@id']
             data = JsonLd.frame(entryId, data)
+        } else if (data[JsonLd.RECORD_KEY]) {
+            // Reshape a framed top-level thing with a meta record
+            Map thing = data.clone()
+            Map record = thing.remove(JsonLd.RECORD_KEY)
+            record.mainEntity = thing
+            data = record
         }
         return conversion.revert(data)
     }


### PR DESCRIPTION
This supports e.g. the SwePub data shapes directly on revert.