### PR TITLE
Do not import records with collection='definitions'

### DIFF
--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -73,7 +73,11 @@ class WhelkCopier {
             }
         } else {
             def collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, dest.jsonld)
-            dest.createDocument(newDoc, "xl", "WhelkCopier", collection, false)
+            if (collection) {
+                dest.createDocument(newDoc, "xl", "WhelkCopier", collection, false)
+            } else {
+                System.err.println "Collection could not be determined for id ${newDoc.getShortId()}, document will not be exported."
+            }
         }
         copied++
     }


### PR DESCRIPTION
The importer tries to copy definitions records such as https://libris-stg.kb.se/katalogisering/bq2n963md2b6xhs1 but fails since collection='definitions' is transformed to null in LegacyIntegrationTools.determineLegacyCollection(newDoc, dest.jsonld).