### PR TITLE
Fix to still use vocab for personalname

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18661,8 +18661,7 @@
         "targetEntity": "?record",
         "targetProperty": "marc:personalName",
         "valueMap": {
-          "Person": "a",
-          "Family": "n"
+          "Person": "https://id.kb.se/marc/PersonalNameType-a"
         },
         "_spec": [
           {
@@ -18673,7 +18672,7 @@
               }
             },
             "back": {
-              "marc:personalName": "a",
+              "marc:personalName": "https://id.kb.se/marc/PersonalNameType-a",
               "mainEntity": {
                 "@type": "Person"
               }


### PR DESCRIPTION
Fix personalName postprocessing to still use vocab but without the need of any value in Adminmetata. This means we can do the global change any time after the release, and do a proper vocab cleanup at a later point.