### PR TITLE
Fix o-search performance

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -122,19 +122,22 @@ class SearchUtils {
         lens = lens ? lens : 'cards'
         log.debug("findReverse. o: ${id}, _lens: ${lens}")
 
-        def ids = whelk.findIdsLinkingTo(id)
-        int total = ids.size()
+        int total = (int) whelk.getIncomingLinkCount(id)
+        List items
 
-        ids = slice(ids, offset, offset+limit)
-
-        List items = whelk.bulkLoad(ids).values()
-                .each(whelk.&embellish)
-                .collect(SearchUtils.&formatReverseResult)
-                .findAll{ !it.isEmpty() }
-                .collect{applyLens(it, id, lens)}
+        if (limit > 0) {
+            def ids = whelk.findIdsLinkingTo(id, limit, offset)
+            items = whelk.bulkLoad(ids).values()
+                    .each(whelk.&embellish)
+                    .collect(SearchUtils.&formatReverseResult)
+                    .findAll { !it.isEmpty() }
+                    .collect { applyLens(it, id, lens) }
+        }
+        else {
+            items = []
+        }
 
         Map pageParams = ['o': id, '_lens': lens, '_limit': limit]
-
         return assembleSearchResults(SearchType.FIND_REVERSE,
                 items, [], pageParams,
                 limit, offset, total)
@@ -154,14 +157,6 @@ class SearchUtils {
         return lens == 'chips'
                 ? ld.toChip(framedThing, preservedPaths)
                 : ld.toCard(framedThing, preservedPaths)
-    }
-
-    @PackageScope
-    static <T> List<T> slice(List<T> list, int fromIx, int toIx) {
-        if (fromIx > list.size() || fromIx > toIx) {
-            return []
-        }
-        return list[(Math.max(0,fromIx)..<Math.min(list.size(), toIx))]
     }
 
     private Map queryElasticSearch(Map queryParameters,

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -2,7 +2,6 @@ package whelk.rest.api
 
 import com.google.common.escape.Escaper
 import com.google.common.net.UrlEscapers
-import groovy.transform.PackageScope
 import groovy.util.logging.Log4j2 as Log
 import whelk.Document
 import whelk.JsonLd
@@ -127,6 +126,7 @@ class SearchUtils {
 
         if (limit > 0) {
             def ids = whelk.findIdsLinkingTo(id, limit, offset)
+            ids = ids.unique() // filter out duplicate documents (docs having more than one link)
             items = whelk.bulkLoad(ids).values()
                     .each(whelk.&embellish)
                     .collect(SearchUtils.&formatReverseResult)

--- a/rest/src/test/groovy/whelk/rest/api/SearchUtilsSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/SearchUtilsSpec.groovy
@@ -311,25 +311,4 @@ class SearchUtilsSpec extends Specification {
         [a: ['A', 'a'], 'b': 'B']|  [variable: 'a', value: 'a']                     | [a: ['A'], 'b': 'B']
     }
 
-    def "slicing should work"() {
-        expect:
-        List<String> list = ['a', 'b', 'c', 'd', 'e']
-        // Can't call variable 'expected' because 'expected' is declared as Map in test above...
-        // https://github.com/spockframework/spock/issues/880
-        SearchUtils.slice(list, from, to) == expectedSlice
-        where:
-        from | to | expectedSlice
-        0    | 1  | ['a']
-        0    | 5  | ['a', 'b', 'c', 'd', 'e']
-        0    | 6  | ['a', 'b', 'c', 'd', 'e']
-        1    | 5  | ['b', 'c', 'd', 'e']
-        2    | 2  | []
-        3    | 2  | []
-        2    | 3  | ['c']
-        5    | 0  | []
-        0    | 3  | ['a', 'b', 'c']
-        -4   | 9  | ['a', 'b', 'c', 'd', 'e']
-        5    | 0  | []
-    }
-
 }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -406,9 +406,7 @@ class Whelk implements Storage {
     }
 
     List<String> findIdsLinkingTo(String idOrIri, int limit, int offset) {
-        return storage
-                .getIncomingLinkIdsPaginated(tryGetSystemId(idOrIri), limit, offset)
-                .collect()
+        return storage.getIncomingLinkIdsPaginated(tryGetSystemId(idOrIri), limit, offset)
     }
 
     private String tryGetSystemId(String id) {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -401,9 +401,13 @@ class Whelk implements Storage {
         return storage.loadEmbellished(systemId, jsonld)
     }
 
-    List<String> findIdsLinkingTo(String idOrIri) {
+    long getIncomingLinkCount(String idOrIri) {
+        return storage.getIncomingLinkCount(tryGetSystemId(idOrIri))
+    }
+
+    List<String> findIdsLinkingTo(String idOrIri, int limit, int offset) {
         return storage
-                .getDependers(tryGetSystemId(idOrIri))
+                .getIncomingLinkIdsPaginated(tryGetSystemId(idOrIri), limit, offset)
                 .collect()
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -74,6 +74,7 @@ class PostgreSQLComponent implements Storage {
     protected String LOAD_SETTINGS, SAVE_SETTINGS
     protected String GET_INCOMING_LINK_COUNT
     protected String GET_DEPENDERS, GET_DEPENDENCIES
+    protected String GET_INCOMING_LINK_IDS_PAGINATED
     protected String GET_DEPENDENCIES_OF_TYPE, GET_DEPENDERS_OF_TYPE
     protected String DELETE_DEPENDENCIES, INSERT_DEPENDENCIES
     protected String QUERY_LD_API
@@ -245,6 +246,7 @@ class PostgreSQLComponent implements Storage {
                 "SELECT * FROM deps"
 
         GET_DEPENDERS = "SELECT DISTINCT id FROM $dependenciesTableName WHERE dependsOnId = ? ORDER BY id"
+        GET_INCOMING_LINK_IDS_PAGINATED = "SELECT id FROM $dependenciesTableName WHERE dependsOnId = ? ORDER BY id LIMIT ? OFFSET ?"
         GET_INCOMING_LINK_COUNT = "SELECT COUNT(id) FROM $dependenciesTableName WHERE dependsOnId = ?"
         GET_DEPENDENCIES = "SELECT DISTINCT dependsOnId FROM $dependenciesTableName WHERE id = ? ORDER BY dependsOnId"
         GET_DEPENDERS_OF_TYPE = "SELECT id FROM $dependenciesTableName WHERE dependsOnId = ? AND relation = ?"
@@ -1450,6 +1452,27 @@ class PostgreSQLComponent implements Storage {
             rs.next()
             return rs.getInt(1)
         } finally {
+            close(rs, preparedStatement, connection)
+        }
+    }
+
+    SortedSet<String> getIncomingLinkIdsPaginated(String id, int limit, int offset) {
+        Connection connection = getConnection()
+        PreparedStatement preparedStatement = null
+        ResultSet rs = null
+        try {
+            preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_IDS_PAGINATED)
+            preparedStatement.setString(1, id)
+            preparedStatement.setInt(2, limit)
+            preparedStatement.setInt(3, offset)
+            rs = preparedStatement.executeQuery()
+            SortedSet<String> result = new TreeSet<>()
+            while (rs.next()) {
+                result.add( rs.getString(1) )
+            }
+            return result
+        }
+        finally {
             close(rs, preparedStatement, connection)
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1456,7 +1456,7 @@ class PostgreSQLComponent implements Storage {
         }
     }
 
-    SortedSet<String> getIncomingLinkIdsPaginated(String id, int limit, int offset) {
+    List<String> getIncomingLinkIdsPaginated(String id, int limit, int offset) {
         Connection connection = getConnection()
         PreparedStatement preparedStatement = null
         ResultSet rs = null
@@ -1466,7 +1466,7 @@ class PostgreSQLComponent implements Storage {
             preparedStatement.setInt(2, limit)
             preparedStatement.setInt(3, offset)
             rs = preparedStatement.executeQuery()
-            SortedSet<String> result = new TreeSet<>()
+            List<String> result = new ArrayList<>(limit)
             while (rs.next()) {
                 result.add( rs.getString(1) )
             }


### PR DESCRIPTION
* `total` is now based on `getIncomingLinkCount` -> faster but now counts links, not "dependers"
* `limit` and `offset` are used all the way -> faster, less memory use when many links
* `offset` still plays nice with `total`, i.e. possible to skip to the last page
* duplicates are removed in a way that every page may contain less than `limit` items (this could be done client side instead)