### PR TITLE
Store document data in Unicode NFC form

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -486,6 +486,7 @@ class Crud extends HttpServlet {
         // should we deny the others?
 
         Document newDoc = new Document(requestBody)
+        newDoc.normalizeUnicode()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         // TODO https://jira.kb.se/browse/LXL-1263
         newDoc.setControlNumber(newDoc.getShortId())
@@ -629,6 +630,7 @@ class Crud extends HttpServlet {
         }
 
         Document updatedDoc = new Document(requestBody)
+        updatedDoc.normalizeUnicode()
         updatedDoc.setId(documentId)
 
         log.debug("Checking permissions for ${updatedDoc}")

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.util.LegacyIntegrationTools
 import whelk.util.PropertyLoader
+import whelk.util.Unicode
 
 import java.lang.reflect.Type
 import java.text.Normalizer
@@ -85,8 +86,8 @@ class Document {
 
     void normalizeUnicode() {
         String json = mapper.writeValueAsString(data)
-        if (!Normalizer.isNormalized(json, Normalizer.Form.NFC)) {
-            data = mapper.readValue(Normalizer.normalize(json, Normalizer.Form.NFC), Map)
+        if (!Unicode.isNormalized(json)) {
+            data = mapper.readValue(Unicode.normalize(json), Map)
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -6,6 +6,7 @@ import whelk.util.LegacyIntegrationTools
 import whelk.util.PropertyLoader
 
 import java.lang.reflect.Type
+import java.text.Normalizer
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -80,6 +81,13 @@ class Document {
     Document clone() {
         Map clonedDate = deepCopy(data)
         return new Document(clonedDate)
+    }
+
+    void normalizeUnicode() {
+        String json = mapper.writeValueAsString(data)
+        if (!Normalizer.isNormalized(json, Normalizer.Form.NFC)) {
+            data = mapper.readValue(Normalizer.normalize(json, Normalizer.Form.NFC), Map)
+        }
     }
 
     URI getURI() {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -422,6 +422,7 @@ class PostgreSQLComponent implements Storage {
     boolean createDocument(Document doc, String changedIn, String changedBy, String collection, boolean deleted) {
         log.debug("Saving ${doc.getShortId()}, ${changedIn}, ${changedBy}, ${collection}")
 
+        doc.normalizeUnicode()
         if (linkFinder != null)
             linkFinder.normalizeIdentifiers(doc)
 
@@ -700,6 +701,7 @@ class PostgreSQLComponent implements Storage {
             // Performs the callers updates on the document
             Document preUpdateDoc = doc.clone()
             updateAgent.update(doc)
+            doc.normalizeUnicode()
             if (linkFinder != null)
                 linkFinder.normalizeIdentifiers(doc, connection)
             if (doVerifyDocumentIdRetention) {
@@ -1273,6 +1275,7 @@ class PostgreSQLComponent implements Storage {
         PreparedStatement ver_batch = connection.prepareStatement(INSERT_DOCUMENT_VERSION)
         try {
             docs.each { doc ->
+                doc.normalizeUnicode()
                 if (linkFinder != null)
                     linkFinder.normalizeIdentifiers(doc)
                 Date now = new Date()

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -3,6 +3,12 @@ package whelk.util
 import java.text.Normalizer
 
 class Unicode {
+
+    /**
+     * Typographical ligatures from the "Alphabetic Presentation Forms" unicode block
+     * that are not covered by NFC but we want to normalize.
+     * https://www.unicode.org/charts/PDF/UFB00.pdf
+     */
     private static final List FORBIDDEN_UNICODE_CHARS = [
             'ﬀ', // 'LATIN SMALL LIGATURE FF'
             'ﬃ', // 'LATIN SMALL LIGATURE FFI'
@@ -13,20 +19,20 @@ class Unicode {
             'ﬆ', // 'LATIN SMALL LIGATURE ST'
     ]
 
-    private static final Map FORBIDDEN_UNICODE_MAP
+    private static final Map EXTRA_NORMALIZATION_MAP
 
     static {
-        FORBIDDEN_UNICODE_MAP = FORBIDDEN_UNICODE_CHARS.collectEntries {
+        EXTRA_NORMALIZATION_MAP = FORBIDDEN_UNICODE_CHARS.collectEntries {
             [(it): Normalizer.normalize(it, Normalizer.Form.NFKC)]
         }
     }
 
     static boolean isNormalized(String s) {
-        return Normalizer.isNormalized(s, Normalizer.Form.NFC) && !FORBIDDEN_UNICODE_MAP.keySet().any{ s.contains(it) }
+        return Normalizer.isNormalized(s, Normalizer.Form.NFC) && !EXTRA_NORMALIZATION_MAP.keySet().any{ s.contains(it) }
     }
 
     static String normalize(String s) {
-        return Normalizer.normalize(s, Normalizer.Form.NFC).replace(FORBIDDEN_UNICODE_MAP)
+        return Normalizer.normalize(s, Normalizer.Form.NFC).replace(EXTRA_NORMALIZATION_MAP)
     }
 
 }

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -1,0 +1,32 @@
+package whelk.util
+
+import java.text.Normalizer
+
+class Unicode {
+    private static final List FORBIDDEN_UNICODE_CHARS = [
+            'ﬀ', // 'LATIN SMALL LIGATURE FF'
+            'ﬃ', // 'LATIN SMALL LIGATURE FFI'
+            'ﬄ', // 'LATIN SMALL LIGATURE FFL'
+            'ﬁ', // 'LATIN SMALL LIGATURE FI'
+            'ﬂ', // 'LATIN SMALL LIGATURE FL'
+            'ﬅ', // 'LATIN SMALL LIGATURE LONG S T'
+            'ﬆ', // 'LATIN SMALL LIGATURE ST'
+    ]
+
+    private static final Map FORBIDDEN_UNICODE_MAP
+
+    static {
+        FORBIDDEN_UNICODE_MAP = FORBIDDEN_UNICODE_CHARS.collectEntries {
+            [(it): Normalizer.normalize(it, Normalizer.Form.NFKC)]
+        }
+    }
+
+    static boolean isNormalized(String s) {
+        return Normalizer.isNormalized(s, Normalizer.Form.NFC) && !FORBIDDEN_UNICODE_MAP.keySet().any{ s.contains(it) }
+    }
+
+    static String normalize(String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFC).replace(FORBIDDEN_UNICODE_MAP)
+    }
+
+}

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -5,9 +5,12 @@ import java.text.Normalizer
 class Unicode {
 
     /**
-     * Typographical ligatures from the "Alphabetic Presentation Forms" unicode block
-     * that are not covered by NFC but we want to normalize.
+     * Additional characters we want to normalize that are not covered by NFC.
+     *
+     * Ligatures from the "Alphabetic Presentation Forms" unicode block that are strictly typographical.
+     * (but we don't want to touch e.g. æ and ß that are actual letters in some alphabets)
      * https://www.unicode.org/charts/PDF/UFB00.pdf
+     * https://en.wikipedia.org/wiki/Orthographic_ligature
      */
     private static final List FORBIDDEN_UNICODE_CHARS = [
             'ﬀ', // 'LATIN SMALL LIGATURE FF'

--- a/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
@@ -1,0 +1,25 @@
+package whelk.util
+
+import spock.lang.Specification
+
+class UnicodeSpec extends Specification {
+
+    def "normalize to NFC"() {
+        given:
+        String s = "Adam f*å*r en melding fra det gamle friidrettslaget, som ønsker at"
+        String nfc = "Adam f*å*r en melding fra det gamle friidrettslaget, som ønsker at"
+        expect:
+        Unicode.isNormalized(s) == false
+        Unicode.normalize(s) == nfc
+    }
+
+    def "normalize typographic ligatures"() {
+        given:
+        String s = "societal bene*ﬁ*t is maximized. This means that the tracks should be used by as much tra*ﬃ*c"
+        String norm = "societal bene*fi*t is maximized. This means that the tracks should be used by as much tra*ffi*c"
+        expect:
+        Unicode.isNormalized(s) == false
+        Unicode.normalize(s) == norm
+    }
+
+}

--- a/whelktool/scripts/cleanups/2020/01/normalize-unicode.groovy
+++ b/whelktool/scripts/cleanups/2020/01/normalize-unicode.groovy
@@ -1,0 +1,11 @@
+import java.text.Normalizer
+
+PrintWriter failedIDs = getReportWriter("failed-IDs")
+PrintWriter scheduledForUpdate = getReportWriter("scheduled-for-update")
+
+selectBySqlWhere("deleted is false", silent: false, { docItem ->
+    if (!Normalizer.isNormalized(docItem.doc.getDataAsString(), Normalizer.Form.NFC)) {
+        scheduledForUpdate.println("${docItem.doc.getURI()}")
+        docItem.scheduleSave()
+    }
+})

--- a/whelktool/scripts/cleanups/2020/01/normalize-unicode.groovy
+++ b/whelktool/scripts/cleanups/2020/01/normalize-unicode.groovy
@@ -1,10 +1,10 @@
-import java.text.Normalizer
+import whelk.util.Unicode
 
 PrintWriter failedIDs = getReportWriter("failed-IDs")
 PrintWriter scheduledForUpdate = getReportWriter("scheduled-for-update")
 
 selectBySqlWhere("deleted is false", silent: false, { docItem ->
-    if (!Normalizer.isNormalized(docItem.doc.getDataAsString(), Normalizer.Form.NFC)) {
+    if (!Unicode.isNormalized(docItem.doc.getDataAsString())) {
         scheduledForUpdate.println("${docItem.doc.getURI()}")
         docItem.scheduleSave()
     }


### PR DESCRIPTION
Convert to unicode NFC form before saving to DB. We probably want to do this earlier (e.g. `Document` constructor) so that the data is always in NFC form internally before doing any other operation or checks on it. But starting this way we can run a simple script on correct all existing data.