### PR TITLE
Add script for correcting uppercase term links

### DIFF
--- a/whelktool/scripts/cleanups/2020/01/lxl-2494/repair-uppercase-term-links.groovy
+++ b/whelktool/scripts/cleanups/2020/01/lxl-2494/repair-uppercase-term-links.groovy
@@ -1,0 +1,27 @@
+/*
+ * * See LXL-2494 for more info.
+ */
+
+scheduledForChange = getReportWriter("scheduled-for-change")
+
+where = "collection = 'auth' AND data#>>'{@graph,1,inCollection}' is not null"
+
+links = ["https://id.kb.se/term/Fack" : "https://id.kb.se/term/fack",
+         "https://id.kb.se/term/Skon" : "https://id.kb.se/term/skon",
+         "https://id.kb.se/term/Musik": "https://id.kb.se/term/musik",
+         "https://id.kb.se/term/NLT"  : "https://id.kb.se/term/nlt"
+]
+
+selectBySqlWhere(where, silent: false) { docItem ->
+    List<Map> inCollection = docItem.doc.data["@graph"][1]["inCollection"]
+    
+    links.each { invalidLink, validLink ->
+        for (term in inCollection) {
+            if (term.'@id' == invalidLink) {
+                term.'@id' = validLink
+                docItem.scheduleSave()
+                scheduledForChange.println "Scheduling save for: ${docItem.doc.getURI()}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Made sure number of occurrences of:

https://id.kb.se/term/Fack
https://id.kb.se/term/Skon
https://id.kb.se/term/Musik 
https://id.kb.se/term/NLT

in auth-shapes (~ 37 250) is the same as number of corrected links when dry-run against QA. 