### PR TITLE
Performance: add bulk iri->systemId query

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1,12 +1,10 @@
 package whelk.component
 
-
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import groovy.json.StringEscapeUtils
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
-import io.vavr.Tuple
 import org.codehaus.jackson.map.ObjectMapper
 import org.postgresql.PGStatement
 import org.postgresql.util.PSQLException


### PR DESCRIPTION
refreshCards spends ~50% of time in `_calculateDependenciesSystemIDs`. 
This should speed things up a bit.
Should be exact same behavior.