### PR TITLE
When copying data from prod XL, retain the hardcoded library URIs.

### DIFF
--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -84,14 +84,14 @@ class WhelkCopier {
 
         def libUriPlaceholder = "___TEMP_HARDCODED_LIB_BASEURI"
         def newDataRepr = doc.dataAsString.replaceAll( // Move all lib uris, to a temporary placeholder.
-                source.baseUri.resolve("library/").toString().replace(".", "\\."),
-                libUriPlaceholder)
+                '"\\Q' + source.baseUri.resolve("library/").toString() + '\\E',
+                '"' + libUriPlaceholder)
         newDataRepr = newDataRepr.replaceAll( // Replace all other baseURIs
-                source.baseUri.toString().replace(".", "\\."),
-                dest.baseUri.toString().replace(".", "\\."))
+                '"\\Q' + source.baseUri.toString() + '\\E',
+                '"' + dest.baseUri.toString())
         newDataRepr = newDataRepr.replaceAll( // Move the hardcoded lib uris back
-                libUriPlaceholder,
-                source.baseUri.resolve("library/").toString().replace(".", "\\."))
+                '"\\Q' + libUriPlaceholder + '\\E',
+                '"' + source.baseUri.resolve("library/").toString())
 
         def newDoc = new Document(doc.mapper.readValue(newDataRepr, Map))
 

--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -82,8 +82,17 @@ class WhelkCopier {
     void save(doc) {
         System.err.println "[$copied] Copying $doc.shortId from $source.baseUri to $dest.baseUri"
 
-        def newDataRepr = doc.dataAsString.replaceAll(/"${source.baseUri}/,
-                '"'+dest.baseUri.toString())
+        def libUriPlaceholder = "___TEMP_HARDCODED_LIB_BASEURI"
+        def newDataRepr = doc.dataAsString.replaceAll( // Move all lib uris, to a temporary placeholder.
+                source.baseUri.resolve("library/").toString().replace(".", "\\."),
+                libUriPlaceholder)
+        newDataRepr = newDataRepr.replaceAll( // Replace all other baseURIs
+                source.baseUri.toString().replace(".", "\\."),
+                dest.baseUri.toString().replace(".", "\\."))
+        newDataRepr = newDataRepr.replaceAll( // Move the hardcoded lib uris back
+                libUriPlaceholder,
+                source.baseUri.resolve("library/").toString().replace(".", "\\."))
+
         def newDoc = new Document(doc.mapper.readValue(newDataRepr, Map))
 
         def newId = dest.baseUri.resolve(doc.shortId).toString()


### PR DESCRIPTION
Without this change, these URIs were being changed from
https://libris.kb.se/library/_
to
http://localhost:5000/library/_ (etc)

which caused all sorts of weird glitches _in test environments_.
OAIPMH and batch import were affected for example.

However, since the two URI forms coincide on PROD, no _real_ damage was done.