### PR TITLE
Feature/faster recursive embellish

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -46,6 +46,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
         boolean change = super.storeCard(cardEntry, connection)
         Document card = cardEntry.getCard()
         cardCache.put(card.getShortId(), card.data)
+        dependencyCache.invalidate(card.getShortId())
         return change
     }
 
@@ -53,6 +54,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     protected void deleteCard(String systemId, Connection connection) {
         super.deleteCard(systemId, connection)
         cardCache.invalidate(systemId)
+        dependencyCache.invalidate(systemId)
     }
 
     private SortedSet<String> superGetInCardDependers(String id) {

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -37,7 +37,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     }
 
     @Override
-    protected SortedSet<String> getInCardDependers(String id) {
+    protected SortedSet<String> getInCardDependencies(String id) {
         return dependencyCache.get(id)
     }
 
@@ -58,7 +58,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     }
 
     private SortedSet<String> superGetInCardDependers(String id) {
-        return super.getInCardDependers(id)
+        return super.getInCardDependencies(id)
     }
 
     private Map superGetCard(String id) {

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -77,7 +77,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
 
                     @Override
                     Map<String, Map> loadAll(Iterable<? extends String> systemIds) throws Exception {
-                        return addMissingCards(bulkLoadCards(systemIds))
+                        return createAndAddMissingCards(bulkLoadCards(systemIds))
                     }
                 })
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -889,7 +889,7 @@ class PostgreSQLComponent implements Storage {
     /**
      * Find all ids that depend on a card by having it in their embellish dependencies.
      * <p>i.e. the card + all cards that link to it, recursively + all documents that link to any of all these cards</p>
-     * Excluding {@link #EMBELLISH_EXCLUDE_RELATIONS}.
+     * Excluding {@link #EMBELLISH_EXCLUDE_RELATIONS} AND itemOf.
      *
      * @param systemId id of card
      * @return a set of depender system ids

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1071,15 +1071,19 @@ class PostgreSQLComponent implements Storage {
         }
 
         while(!queue.isEmpty()) {
-            getConnection().withCloseable { connection ->
-                SortedSet<String> ids = getDependencyData(queue.poll(), GET_IN_CARD_DEPENDENCIES, connection)
-                ids.removeAll(result)
-                queue.addAll(ids)
-                result.addAll(ids)
-            }
+            SortedSet<String> ids = getInCardDependers(queue.poll())
+            ids.removeAll(result)
+            queue.addAll(ids)
+            result.addAll(ids)
         }
 
         return result
+    }
+
+    protected SortedSet<String> getInCardDependers(String id) {
+        getConnection().withCloseable { connection ->
+            return getDependencyData(id, GET_IN_CARD_DEPENDENCIES, connection)
+        }
     }
 
     protected Map<String, Map> bulkLoadCards(Iterable<String> ids) {


### PR DESCRIPTION
* Replace CTE queries with regular queries and do recursion (actually iteration) in application.
* cache card dependencies
* always do `reindexAffected` on backgronud thread (except for whelktool) since calculating dependers set can be slow

makes reindex go from painfully slow to done in 1.8 hours on xlbuild->QA