### PR TITLE
ES index: don't shrink embellishments to chips

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -56,42 +56,6 @@ class ImporterMain {
         new CardRefresher(whelk).refresh(collection)
     }
 
-    @Command(args='[COLLECTION] [no-embellish|no-cache]')
-    void reindexToStdout(String collection=null, String directive=null) {
-        if (directive == null && collection?.indexOf('-') > -1) {
-            directive = collection
-            collection = null
-        }
-        boolean useCache = directive != 'no-cache'
-        boolean doEmbellish = directive != 'no-embellish'
-
-        Whelk whelk = Whelk.createLoadedCoreWhelk(props, useCache)
-
-        println "Creating whelk with dummy ElasticSearch"
-        println "- collection: $collection"
-        println "- directive: $directive"
-        println "- useCache: $useCache"
-        println "- doEmbellish: $doEmbellish"
-
-        whelk.elastic = new ElasticSearch("", "", "") {
-            Tuple2<Integer, String> performRequest(String method,
-                    String path, String body, String contentType0 = null) {
-                println "PATH: $path, CONTENT_TYPE: $contentType0, SIZE: ${body.size()}"
-                println body
-                return new Tuple2(-1, "{}")
-            }
-
-            void embellish(Whelk w, Document src, Document copy) {
-                if (doEmbellish) {
-                    super.embellish(w, src, copy)
-                }
-            }
-        }
-
-        def reindex = new ElasticReindexer(whelk)
-        reindex.reindex(collection)
-    }
-
     @Command(args='[FROM]')
     void reindexFrom(String from=null) {
         boolean useCache = true

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -22,8 +22,8 @@ class Embellisher {
     }
 
     // FIXME: describe me
-    void embellish(Document document, boolean filterOutNonChipTerms = false) {
-        jsonld.embellish(document.data, getEmbellishData(document), filterOutNonChipTerms)
+    void embellish(Document document) {
+        jsonld.embellish(document.data, getEmbellishData(document))
     }
 
     private List getEmbellishData(Document document) {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -698,30 +698,19 @@ class JsonLd {
 
     //==== Embellish ====
 
-    Map embellish(Map jsonLd, Iterable additionalObjects, boolean filterOutNonChipTerms = true) {
+    Map embellish(Map jsonLd, Iterable additionalObjects) {
         if (!jsonLd.get(GRAPH_KEY)) {
             return jsonLd
         }
 
         List graphItems = jsonLd.get(GRAPH_KEY)
 
-        if (filterOutNonChipTerms) {
-            additionalObjects.each { object ->
-                Map chip = (Map) toChip(object)
-                if (chip.containsKey('@graph')) {
-                    graphItems << chip
+        additionalObjects.each { object ->
+            if (object instanceof Map) {
+                if (((Map)object).containsKey('@graph')) {
+                    graphItems << object
                 } else {
-                    graphItems << ['@graph': chip]
-                }
-            }
-        } else {
-            additionalObjects.each { object ->
-                if (object instanceof Map) {
-                    if (((Map)object).containsKey('@graph')) {
-                        graphItems << object
-                    } else {
-                        graphItems << ['@graph': object]
-                    }
+                    graphItems << ['@graph': object]
                 }
             }
         }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -329,8 +329,8 @@ class Whelk implements Storage {
         }
     }
 
-    void embellish(Document document, boolean filterOutNonChipTerms = false) {
-        new Embellisher(jsonld, storage.&getCards, relations.&getByReverse).embellish(document, filterOutNonChipTerms)
+    void embellish(Document document) {
+        new Embellisher(jsonld, storage.&getCards, relations.&getByReverse).embellish(document)
     }
 
     Document loadEmbellished(String systemId) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -195,8 +195,8 @@ class ElasticSearch {
     Map getShapeForIndex(Document document, Whelk whelk, String collection) {
         Document copy = document.clone()
 
-        if (!collection.equals("hold")) {
-            embellish(whelk, document, copy)
+        if (collection != "hold") {
+            whelk.embellish(copy)
         }
 
         log.debug("Framing ${document.getShortId()}")
@@ -217,11 +217,6 @@ class ElasticSearch {
         log.trace("Framed data: ${framed}")
 
         return framed
-    }
-
-    void embellish(Whelk whelk, Document document, Document copy) {
-        boolean filterOutNonChipTerms = true // Consider using false here, since cards-in-cards work now.
-        whelk.embellish(copy, filterOutNonChipTerms)
     }
 
     private static void setComputedProperties(Document doc, Document unEmbellished, Whelk whelk) {

--- a/whelk-core/src/test/groovy/EmbellishSpec.groovy
+++ b/whelk-core/src/test/groovy/EmbellishSpec.groovy
@@ -171,7 +171,7 @@ digraph {
 
         Document document = new Document(doc)
 
-        embellisher.embellish(document, false)
+        embellisher.embellish(document)
         def result = document.data
 
         expect:


### PR DESCRIPTION
When embellishing doc for index, don't make chips out of everything that is included.
Because we want e.g.  Instance:instanceOf-> Work:contribution -> Agent to be indexed.

Also removed the `filterOutNonChipTerms` parameter to embellish since it was only used here.
Also removed `ImporterMain::reindexToStdout` since it was not working.