### PR TITLE
Feature/move linkfield to instance

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17548,6 +17548,7 @@
       ]
     },
     "773": {
+      "NOTE": "We deviate from https://www.loc.gov/bibframe/mtbf/ as we do not link from the Work with hasInstance.",
       "include": ["referenceToInstanceSansDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
@@ -17903,6 +17904,7 @@
       ]
     },
     "775": {
+      "NOTE": "We deviate from https://www.loc.gov/bibframe/mtbf/ as we do not link from the Work with hasInstance.",
       "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
@@ -18027,14 +18029,12 @@
       ]
     },
     "776": {
-      "NOTE": "We deviate from BF2 as we do not link from the Work with hasInstance.",
       "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherPhysicalFormat",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": "8"},
-      "NOTE:$i": "Not using same pattern as all other linkfields since only 776 is correctly mapped to Instance. Not creating new pattern because aiming for get rid of displayText",
       "_spec": [
         {
           "source": {"776": {"ind1": "0", "ind2": "8", "subfields": [
@@ -18705,6 +18705,7 @@
       ]
     },
     "786": {
+      "NOTE": "We deviate from https://www.loc.gov/bibframe/mtbf/ as we do not link from the Work with hasInstance.",
       "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17130,6 +17130,7 @@
             {"i": "displayText"},
             {"t": "Publikation"},
             {"c": "Särskiljande tillägg"},
+            {"g": "s. 144-145"},
             {"x": "1401-9612"}
           ]}},
           "result": {"mainEntity": {
@@ -17144,6 +17145,7 @@
                 "@type": "ISSN",
                 "value": "1401-9612"
               }],
+              "part": ["s. 144-145"],
               "instanceOf": {
                 "@type": "Work",
                 "hasTitle": [{
@@ -17398,10 +17400,12 @@
         {
           "source": {"772": {"ind1": " ", "ind2": " ", "subfields": [
             {"s": "Main Thing"},
+            {"g": "part 1"},
             {"z": "00-0-000000-0"}
           ]}},
           "normalized": {"772": {"ind1": "0", "ind2": "0", "subfields": [
             {"s": "Main Thing"},
+            {"g": "part 1"},
             {"z": "00-0-000000-0"}
           ]}},
           "result": {"mainEntity": {
@@ -17418,7 +17422,8 @@
                   "identifiedBy": [{
                     "@type": "ISBN",
                     "value": "00-0-000000-0"
-                  }]
+                  }],
+                  "part": ["part 1"]
                 }
               }]
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1461,7 +1461,7 @@
     },
 
     "referenceToWork": {
-      "include": ["referencedObjectDetails", "serialSpecificDetails", "workTitleQualifier", "linkRelation"],
+      "include": ["referencedObjectDetails", "serialSpecificDetails", "workTitleQualifier", "workDisplayText"],
       "pendingResources": {
         "_:instance": {
           "about": "_:work",
@@ -1476,7 +1476,7 @@
     },
 
     "referenceToSeriesInstance": {
-      "include": ["instanceOfObject", "referencedObjectDetails", "workTitleQualifier", "linkRelation"]
+      "include": ["instanceOfObject", "referencedObjectDetails", "workTitleQualifier", "workDisplayText"]
     },
 
     "instanceOfObject": {
@@ -1489,7 +1489,12 @@
       }
     },
 
-    "linkRelation": {
+    "instanceDisplayText": {
+      "TODO:?$i": {"addLink": "relationship", "resourceType": "Relationship", "property": "label"},
+      "$i": {"about": "_:instance", "addProperty": "marc:displayText"}
+    },
+
+    "workDisplayText": {
       "TODO:?$i": {"addLink": "relationship", "resourceType": "Relationship", "property": "label"},
       "$i": {"about": "_:work", "addProperty": "marc:displayText"}
     },
@@ -17867,7 +17872,7 @@
       ]
     },
     "775": {
-      "include": ["referenceToInstanceSansDisplayText"],
+      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherEdition",
@@ -17882,7 +17887,6 @@
       "i2": {"ignored": true, "marcDefault": " "},
       "$e": {"addLink": "language", "NOTE:marc-repeatable": false, "resourceType": "Language", "property": "label", "infer": true, "TODO:inherit": "008:[35:38]"},
       "$f": {"about": "_:provisionActivity", "link": "place", "resourceType": "Place", "property": "code", "NOTE:marc-repeatable": false, "TODO:inherit": "008:[15:18]"},
-      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "name": "Example from xf7626r83c73st9",
@@ -17963,14 +17967,13 @@
     },
     "776": {
       "NOTE": "We deviate from BF2 as we do not link from the Work with hasInstance.",
-      "include": ["referenceToInstanceSansDisplayText"],
+      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherPhysicalFormat",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": "8"},
       "NOTE:$i": "Not using same pattern as all other linkfields since only 776 is correctly mapped to Instance. Not creating new pattern because aiming for get rid of displayText",
-      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "source": {"776": {"ind1": "0", "ind2": "8", "subfields": [
@@ -18138,14 +18141,12 @@
       ]
     },
     "777": {
-      "include": ["referenceToInstanceSansDisplayText"],
+      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "issuedWith",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": " "},
-      "NOTE:$i": "Not using same pattern as all other linkfields since only 776 is correctly mapped to Instance. Not creating new pattern because aiming for get rid of displayText",
-      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "name": "Example from fxqnstdr4mdmvws",
@@ -18643,13 +18644,12 @@
       ]
     },
     "786": {
-      "include": ["referenceToInstanceSansDisplayText"],
+      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "dataSource",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": " "},
-      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "$p": {"about": "_:instance", "addLink": "hasTitle", "resourceType": "AbbreviatedTitle", "property": "mainTitle",  "TODO:targetMatch": "210", "NOTE:LC":"ignore", "NOTE:marc-repeatable": false},
       "_spec": [
         {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1460,35 +1460,26 @@
       "$z": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISBN", "property": "value", "TODO:targetMatch": "020"}
     },
 
-    "referenceToInstance": {
-      "include": ["referencedObjectDetails", "serialSpecificDetails"],
-      "pendingResources": {
-        "_:work": {
-          "about": "_:instance",
-          "link": "instanceOf",
-          "resourceType": "Work"
-        }
-      },
-      "TODO": "Does $c relates to $t or $s?. Check statistics. Deviates from 'referenceToWork' and 'referenceToSeriesInstance'",
-      "NOTE": "For now, continue to map bib 776 differently; $c together with $t",
-      "$c": {"about": "_:title", "property": "qualifier", "NOTE:marc-repeatable": false},
-      "$i": {"about": "_:instance", "addProperty": "marc:displayText"}
-    },
-
     "referenceToWork": {
-      "include": ["referencedObjectDetails", "serialSpecificDetails", "linkQualifier"],
+      "include": ["referencedObjectDetails", "serialSpecificDetails", "workTitleQualifier", "linkRelation"],
       "pendingResources": {
         "_:instance": {
           "about": "_:work",
           "link": "hasInstance",
           "resourceType": "Instance"
         }
-      },
-      "$i": {"about": "_:work", "addProperty": "marc:displayText"}
+      }
+    },
+
+    "referenceToInstanceSansDisplayText": {
+      "include": ["instanceOfObject", "referencedObjectDetails", "instanceTitleQualifier", "serialSpecificDetails"]
     },
 
     "referenceToSeriesInstance": {
-      "include": ["referencedObjectDetails", "linkQualifier"],
+      "include": ["instanceOfObject", "referencedObjectDetails", "workTitleQualifier", "linkRelation"]
+    },
+
+    "instanceOfObject": {
       "pendingResources": {
         "_:work": {
           "about": "_:instance",
@@ -1498,10 +1489,21 @@
       }
     },
 
-    "linkQualifier": {
+    "linkRelation": {
+      "TODO:?$i": {"addLink": "relationship", "resourceType": "Relationship", "property": "label"},
+      "$i": {"about": "_:work", "addProperty": "marc:displayText"}
+    },
+
+    "workTitleQualifier": {
       "TODO": "Does $c relates to $t or $s?. Check statistics. Deviates from 'referenceToInstance'",
       "NOTE": "For now, continue to map $c together with $s - applies to all linkfields (except 776)",
       "$c": {"about": "_:workTitle", "property": "qualifier", "NOTE:marc-repeatable": false}
+    },
+
+    "instanceTitleQualifier": {
+      "TODO": "Does $c relates to $t or $s?. Check statistics. Deviates from 'referenceToWork' and 'referenceToSeriesInstance'",
+      "NOTE": "For now, continue to map bib 776 differently; $c together with $t",
+      "$c": {"about": "_:title", "property": "qualifier", "NOTE:marc-repeatable": false}
     }
   },
 
@@ -17120,6 +17122,7 @@
       "_spec": [
         {
           "source": {"760": {"ind1": "0", "ind2": " ", "subfields": [
+            {"i": "displayText"},
             {"t": "Publikation"},
             {"c": "Särskiljande tillägg"},
             {"x": "1401-9612"}
@@ -17141,7 +17144,8 @@
                 "hasTitle": [{
                   "@type": "Title",
                   "qualifier": "Särskiljande tillägg"
-                }]
+                }],
+                "marc:displayText": ["displayText"]
               }
             }]
           }}
@@ -17508,12 +17512,13 @@
       ]
     },
     "773": {
-      "include": ["referenceToWork"],
-      "aboutEntity": "?work",
-      "aboutAlias": "_:work",
+      "include": ["referenceToInstanceSansDisplayText"],
+      "aboutEntity": "?thing",
+      "aboutAlias": "_:instance",
       "addLink": "isPartOf",
-      "resourceType": "Aggregate",
+      "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": "0"},
+      "$i": {"ignored": true, "TODO": "Or do we want to make it a hasNote? Local libraries have given their OK to remove"},
       "$p": {"about": "_:instance", "addLink": "hasTitle", "resourceType": "AbbreviatedTitle", "property": "mainTitle",  "TODO:targetMatch": "210", "NOTE:LC":"ignore", "NOTE:marc-repeatable": false},
       "$q": {"about": "_:instance", "property": "marc:enumerationAndFirstPage", "NOTE:LC":"ignore"},
       "_spec": [
@@ -17532,29 +17537,23 @@
             {"w": "8258455"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "isPartOf": [{
-                "@type": "Aggregate",
-                "hasInstance": {
-                  "@type": "Instance",
-                  "describedBy": [{
-                    "@type": "Record",
-                    "controlNumber": "8258455"
-                  }],
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "Tidskrift i sjöväsendet"
-                  }],
-                  "identifiedBy": [{
-                    "@type": "ISSN",
-                    "value": "0040-6945"
-                  }],
-                  "part": ["127:1964, s. 495-534"]
-                },
-                "marc:toDisplayNote": true
-              }]
-            }
+            "isPartOf": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "8258455"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Tidskrift i sjöväsendet"
+              }],
+              "identifiedBy": [{
+                "@type": "ISSN",
+                "value": "0040-6945"
+              }],
+              "part": ["127:1964, s. 495-534"],
+              "marc:toDisplayNote": true
+            }]
           }}
         },
         {
@@ -17571,32 +17570,26 @@
             {"9": "34"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "isPartOf": [{
-                "@type": "Aggregate",
-                "hasInstance": {
-                  "@type": "Instance",
-                  "describedBy": [{
-                    "@type": "Record",
-                    "controlNumber": "517883"
-                  }],
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "I Värend och Sunnerbo"
-                  }],
-                  "identifiedBy": [{
-                    "@type": "ISSN",
-                    "value": "ISSN 0284-771X"
-                  }],
-                  "part": ["1992 (33:1), s. 34-35 : ill."],
-                  "provisionActivityStatement": "Växjö : Kronobergs läns hembydsförbund, 1985-1995"
-                },
-                "marc:controlSubfield": "n s",
-                "marc:toDisplayNote": true,
-                "partNumber": ["1992", "1", "34"]
-              }]
-            }
+            "isPartOf": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "517883"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "I Värend och Sunnerbo"
+              }],
+              "identifiedBy": [{
+                "@type": "ISSN",
+                "value": "ISSN 0284-771X"
+              }],
+              "part": ["1992 (33:1), s. 34-35 : ill."],
+              "provisionActivityStatement": "Växjö : Kronobergs läns hembydsförbund, 1985-1995",
+              "marc:controlSubfield": "n s",
+              "marc:toDisplayNote": true,
+              "partNumber": ["1992", "1", "34"]
+            }]
           }}
         },
         {
@@ -17618,37 +17611,127 @@
             {"w": "11899145"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "isPartOf": [{
-                "@type": "Aggregate",
+            "isPartOf": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "11899145"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Power of place : the religious landscape of the Southern Sacred Peak (Nanyue) in medieval China /"
+              }],
+              "identifiedBy": [{
+                "@type": "ISBN",
+                "value": "9780674033320 (cl : alk. paper)"
+              }],
+              "part": ["S.184-212"],
+              "provisionActivityStatement": "cop. 2009",
+              "instanceOf": {
+                "@type": "Work",
                 "contribution": [{
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
                     "label": "Robson, James,"
                   }
+                }]
+              },
+              "marc:toDisplayNote": true
+            }]
+          }}
+        },
+        {
+          "name": "Example from https://www.kb.se/katalogisering/Katalogisering/artikelindexering/exempel/#14.",
+          "source": [
+            {"245": {"ind1": "1", "ind2": "0", "subfields": [
+              {"a": "Hur gammal är arbetslösheten?"}
+            ]}},
+            {"773": {"ind1": "0", "ind2": " ", "subfields": [
+              {"t": "Historisk tidskrift (Stockholm)"},
+              {"x": "0345-469X"},
+              {"w": "8261328"},
+              {"g": "2002(122):1, s. [99]-108"}
+            ]}},
+            {"787": {"ind1": "0", "ind2": "8", "subfields": [
+              {"i": "Recension av:"},
+              {"a": "Olofsson, Jonas"},
+              {"t": "Arbetslöshetsfrågan i historisk belysning : en diskussion om arbetslöshet och social politik i Sverige 1830-1920"},
+              {"d": "1996"},
+              {"z": "91-7966-400-8"},
+              {"w": "7677734"}
+            ]}}],
+          "normalized": [
+            {"245": {"ind1": "1", "ind2": "0", "subfields": [
+              {"a": "Hur gammal är arbetslösheten?"}
+            ]}},
+            {"773": {"ind1": "0", "ind2": "0", "subfields": [
+              {"t": "Historisk tidskrift (Stockholm)"},
+              {"g": "2002(122):1, s. [99]-108"},
+              {"x": "0345-469X"},
+              {"w": "8261328"}
+            ]}},
+            {"787": {"ind1": "0", "ind2": " ", "subfields": [
+              {"i": "Recension av:"},
+              {"a": "Olofsson, Jonas"},
+              {"t": "Arbetslöshetsfrågan i historisk belysning : en diskussion om arbetslöshet och social politik i Sverige 1830-1920"},
+              {"d": "1996"},
+              {"z": "91-7966-400-8"},
+              {"w": "7677734"}
+            ]}}],
+          "result": {"mainEntity": {
+            "hasTitle": [{
+              "@type": "Title",
+              "mainTitle": "Hur gammal är arbetslösheten?"
+            }],
+            "instanceOf": {
+              "@type": "Text",
+              "relatedTo": [{
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Agent",
+                    "label": "Olofsson, Jonas"
+                  }
                 }],
                 "hasInstance": {
                   "@type": "Instance",
                   "describedBy": [{
                     "@type": "Record",
-                    "controlNumber": "11899145"
+                    "controlNumber": "7677734"
                   }],
                   "hasTitle": [{
                     "@type": "Title",
-                    "mainTitle": "Power of place : the religious landscape of the Southern Sacred Peak (Nanyue) in medieval China /"
+                    "mainTitle": "Arbetslöshetsfrågan i historisk belysning : en diskussion om arbetslöshet och social politik i Sverige 1830-1920"
                   }],
                   "identifiedBy": [{
                     "@type": "ISBN",
-                    "value": "9780674033320 (cl : alk. paper)"
+                    "value": "91-7966-400-8"
                   }],
-                  "part": ["S.184-212"],
-                  "provisionActivityStatement": "cop. 2009"
+                  "provisionActivityStatement": "1996"
                 },
+                "marc:displayText": ["Recension av:"],
                 "marc:toDisplayNote": true
               }]
-            }
+            },
+            "isPartOf": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "8261328"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Historisk tidskrift (Stockholm)"
+              }],
+              "identifiedBy": [{
+                "@type": "ISSN",
+                "value": "0345-469X"
+              }],
+              "part": ["2002(122):1, s. [99]-108"],
+              "marc:toDisplayNote": true
+            }]
           }}
         },
         {
@@ -17658,17 +17741,11 @@
             {"w": "8258455"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "isPartOf": [{
-                "@type": "Aggregate",
-                "hasInstance": {
-                  "@type": "Instance",
-                  "meta": [{"@type": "Record", "controlNumber": "8258455"}],
-                  "hasTitle": [{"@type": "Title", "mainTitle": "Tidskrift"}]
-                }
-              }]
-            }
+            "isPartOf": [{
+              "@type": "Instance",
+              "meta": [{"@type": "Record", "controlNumber": "8258455"}],
+              "hasTitle": [{"@type": "Title", "mainTitle": "Tidskrift"}]
+            }]
           }}
         }
       ]
@@ -17790,11 +17867,11 @@
       ]
     },
     "775": {
-      "include": ["referenceToWork"],
-      "aboutEntity": "?work",
-      "aboutAlias": "_:work",
+      "include": ["referenceToInstanceSansDisplayText"],
+      "aboutEntity": "?thing",
+      "aboutAlias": "_:instance",
       "addLink": "otherEdition",
-      "resourceType": "Work",
+      "resourceType": "Instance",
       "pendingResources": {
         "_:provisionActivity": {
           "about": "_:instance",
@@ -17805,6 +17882,7 @@
       "i2": {"ignored": true, "marcDefault": " "},
       "$e": {"addLink": "language", "NOTE:marc-repeatable": false, "resourceType": "Language", "property": "label", "infer": true, "TODO:inherit": "008:[35:38]"},
       "$f": {"about": "_:provisionActivity", "link": "place", "resourceType": "Place", "property": "code", "NOTE:marc-repeatable": false, "TODO:inherit": "008:[15:18]"},
+      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "name": "Example from xf7626r83c73st9",
@@ -17817,9 +17895,26 @@
             {"w": "1320351"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "otherEdition": [{
+            "otherEdition": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "1320351"
+              }],
+              "identifiedBy": [{
+                "@type": "ISBN",
+                "value": "91-40-55055-9"
+              }],
+              "part": ["Övningsbok"],
+              "provisionActivity": {
+                "@type": "ProvisionActivity",
+                "place": {
+                  "@type": "Place",
+                  "code": "Företagsekonomi 80"
+                }
+              },
+              "provisionActivityStatement": "1979",
+              "instanceOf": {
                 "@type": "Work",
                 "contribution": [{
                   "@type": "PrimaryContribution",
@@ -17827,30 +17922,10 @@
                     "@type": "Agent",
                     "label": "Olsson, Jan"
                   }
-                }],
-                "hasInstance": {
-                  "@type": "Instance",
-                  "describedBy": [{
-                    "@type": "Record",
-                    "controlNumber": "1320351"
-                  }],
-                  "identifiedBy": [{
-                    "@type": "ISBN",
-                    "value": "91-40-55055-9"
-                  }],
-                  "part": ["Övningsbok"],
-                  "provisionActivity": {
-                    "@type": "ProvisionActivity",
-                    "place": {
-                      "@type": "Place",
-                      "code": "Företagsekonomi 80"
-                    }
-                  },
-                  "provisionActivityStatement": "1979"
-                },
-                "marc:toDisplayNote" : false
-              }]
-            }
+                }]
+              },
+              "marc:toDisplayNote" : false
+            }]
           }}
         },
         {
@@ -17868,38 +17943,34 @@
             {"w": "10948597"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "otherEdition": [{
-                "@type": "Work",
-                "marc:displayText": ["Parallellupplaga"],
-                "hasInstance": {
-                  "@type": "Instance",
-                  "describedBy": [{
-                    "@type": "Record",
-                    "controlNumber": "10948597"
-                  }],
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "Hållbar utveckling nu!"
-                  }],
-                  "provisionActivityStatement": "[2008?]"
-                },
-                "marc:toDisplayNote" : false
-              }]
-            }
+            "otherEdition": [{
+              "@type": "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "10948597"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Hållbar utveckling nu!"
+              }],
+              "provisionActivityStatement": "[2008?]",
+              "marc:displayText": ["Parallellupplaga"],
+              "marc:toDisplayNote" : false
+            }]
           }}
         }
       ]
     },
     "776": {
       "NOTE": "We deviate from BF2 as we do not link from the Work with hasInstance.",
-      "include": ["referenceToInstance"],
+      "include": ["referenceToInstanceSansDisplayText"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherPhysicalFormat",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": "8"},
+      "NOTE:$i": "Not using same pattern as all other linkfields since only 776 is correctly mapped to Instance. Not creating new pattern because aiming for get rid of displayText",
+      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "source": {"776": {"ind1": "0", "ind2": "8", "subfields": [
@@ -18067,12 +18138,14 @@
       ]
     },
     "777": {
-      "include": ["referenceToWork"],
-      "aboutEntity": "?work",
-      "aboutAlias": "_:work",
+      "include": ["referenceToInstanceSansDisplayText"],
+      "aboutEntity": "?thing",
+      "aboutAlias": "_:instance",
       "addLink": "issuedWith",
-      "resourceType": "Work",
+      "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": " "},
+      "NOTE:$i": "Not using same pattern as all other linkfields since only 776 is correctly mapped to Instance. Not creating new pattern because aiming for get rid of displayText",
+      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "_spec": [
         {
           "name": "Example from fxqnstdr4mdmvws",
@@ -18082,9 +18155,17 @@
             {"w": "9735858"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "issuedWith": [{
+            "issuedWith": [{
+              "@type": "Instance",
+              "describedBy": [ {
+                "@type": "Record",
+                "controlNumber": "9735858"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Autism : svårigehter och möjligheter"
+              }],
+              "instanceOf": {
                 "@type": "Work",
                 "contribution": [{
                   "@type": "PrimaryContribution",
@@ -18092,21 +18173,10 @@
                     "@type": "Agent",
                     "label": "Gerland, Gunilla"
                   }
-                }],
-                "hasInstance": {
-                  "@type": "Instance",
-                  "describedBy": [ {
-                    "@type": "Record",
-                    "controlNumber": "9735858"
-                  }],
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "Autism : svårigehter och möjligheter"
-                  }]
-                },
-                "marc:toDisplayNote" : true
-              }]
-            }
+                }]
+              },
+              "marc:toDisplayNote" : true
+            }]
           }}
         },
         {
@@ -18126,9 +18196,18 @@
             {"w": "12033323"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "issuedWith": [{
+            "issuedWith": [{
+              "@type" : "Instance",
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "12033323"
+              }],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Personlig utveckling för alla medarbetare - Fallrapport (Länia AB, Örebro)"
+              }],
+              "provisionActivityStatement": "1994",
+              "instanceOf": {
                 "@type": "Work",
                 "contribution": [{
                   "@type": "PrimaryContribution",
@@ -18136,24 +18215,11 @@
                     "@type": "Agent",
                     "label": "Andersson, Jan"
                   }
-                }],
-                "hasInstance": {
-                  "@type" : "Instance",
-                  "describedBy": [{
-                    "@type": "Record",
-                    "controlNumber": "12033323"
-                  }],
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "Personlig utveckling för alla medarbetare - Fallrapport (Länia AB, Örebro)"
-                  }],
-                  "provisionActivityStatement": "1994"
-                },
-                "marc:displayText": ["Online"],
-                "marc:toDisplayNote": true
-              }]
-            }
-          }}
+                }]
+              },
+              "marc:displayText": ["Online"],
+              "marc:toDisplayNote": true
+            }]          }}
         },
         {
           "name": "Verify mapping of seriesStatement",
@@ -18162,21 +18228,15 @@
             {"k": "Statens offentliga utredningar"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "issuedWith": [{
-                "@type": "Work",
-                "hasInstance": {
-                  "@type": "Instance",
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "Statliga betongbestämmelser"
-                  }],
-                  "seriesStatement": ["Statens offentliga utredningar"]
-                },
-                "marc:toDisplayNote": true
-              }]
-            }
+            "issuedWith": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Statliga betongbestämmelser"
+              }],
+              "seriesStatement": ["Statens offentliga utredningar"],
+              "marc:toDisplayNote": true
+            }]
           }}
         }
       ]

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9070,11 +9070,6 @@
 
     "250": {
       "aboutEntity": "?thing",
-      "onRevertPrefer": "775",
-      "linkSubsequentRepeated": {
-        "addLink": "otherEdition",
-        "embedded": true
-      },
       "$a": {"property": "editionStatement", "punctuationChars": "/"},
       "$b": {"property": "editionStatementRemainder"},
       "$3": {
@@ -9097,15 +9092,14 @@
           "result": {"mainEntity": {"editionStatement": "New ed."}}
         },
         {
+          "name": "Repeated 250: added to list and for now only the first value will be exported",
           "source": [
             {"250": {"ind1": " ", "ind2": " ", "subfields": [{"a": "New"}]}},
             {"250": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Newer"}]}}
           ],
+          "normalized": {"250": {"ind1": " ", "ind2": " ", "subfields": [{"a": "New"}]}},
           "result": {"mainEntity": {
-            "editionStatement": "New",
-            "otherEdition": [
-              {"editionStatement": "Newer"}
-            ]
+            "editionStatement": ["New", "Newer"]
           }}
         }
       ]

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9070,6 +9070,7 @@
 
     "250": {
       "aboutEntity": "?thing",
+      "onRevertPrefer": "775",
       "linkSubsequentRepeated": {
         "addLink": "otherEdition",
         "embedded": true
@@ -17995,7 +17996,37 @@
               "marc:toDisplayNote" : false
             }]
           }}
+        },
+        {
+          "normalized": {"775": {"ind1": "0", "ind2": " ", "subfields": [
+            {"i": "Parallellutgåva"},
+            {"t": "Tolkning och översättning vid straffrättsliga förfaranden"},
+            {"b": "genomförande av EU:s tolknings- och översättningsdirektiv : betänkande"},
+            {"z": "9789138237748"},
+            {"w": "13506478"}
+          ]}},
+          "result": {"mainEntity": {
+            "otherEdition": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Tolkning och översättning vid straffrättsliga förfaranden"
+              }],
+              "describedBy": [{
+                "@type": "Record",
+                "controlNumber": "13506478"
+              }],
+              "identifiedBy": [{
+                "@type": "ISBN",
+                "value": "9789138237748"
+              }],
+              "editionStatement": "genomförande av EU:s tolknings- och översättningsdirektiv : betänkande",
+              "marc:displayText": "Parallellutgåva",
+              "marc:toDisplayNote": true
+            }]
+          }}
         }
+
       ]
     },
     "776": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18643,12 +18643,13 @@
       ]
     },
     "786": {
-      "include": ["referenceToWork"],
-      "aboutEntity": "?work",
-      "aboutAlias": "_:work",
+      "include": ["referenceToInstanceSansDisplayText"],
+      "aboutEntity": "?thing",
+      "aboutAlias": "_:instance",
       "addLink": "dataSource",
-      "resourceType": "Dataset",
+      "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": " "},
+      "$i": {"about": "_:instance", "addProperty": "marc:displayText"},
       "$p": {"about": "_:instance", "addLink": "hasTitle", "resourceType": "AbbreviatedTitle", "property": "mainTitle",  "TODO:targetMatch": "210", "NOTE:LC":"ignore", "NOTE:marc-repeatable": false},
       "_spec": [
         {
@@ -18664,25 +18665,19 @@
             {"w": "13527363"}
           ]}},
           "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "dataSource": [{
-                "@type": "Dataset",
-                "hasInstance": {
-                  "@type": "Instance",
-                  "hasTitle": [{
-                    "@type": "Title",
-                    "mainTitle": "The catalogue of the book collection of the Jesuit College in Braniewo held in the University Library in Uppsala"
-                  }],
-                  "describedBy": [{
-                    "@type" : "Record",
-                    "controlNumber": "13527363"
-                  }]
-                },
-                "marc:displayText": ["Source"],
-                "marc:toDisplayNote": true
-              }]
-            }
+            "dataSource": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "The catalogue of the book collection of the Jesuit College in Braniewo held in the University Library in Uppsala"
+              }],
+              "describedBy": [{
+                "@type" : "Record",
+                "controlNumber": "13527363"
+              }],
+              "marc:displayText": ["Source"],
+              "marc:toDisplayNote": true
+            }]
           }}
         }
       ]

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -12997,7 +12997,29 @@
       "addLink": "hasNote",
       "resourceType": "marc:LinkingEntryComplexityNote",
       "$a": {"property": "label"},
-      "$6": {"property": "marc:fieldref"}
+      "$6": {"property": "marc:fieldref"},
+      "_spec": [
+        {
+          "source": [
+            {"580": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Continues: Civil air regulations and reference guide for pilots."}]}},
+            {"580": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Continued by: Federal aviation regulations and flight standards for pilots."}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "instanceOf" : {
+                "@type": "Text",
+                "hasNote": [{
+                  "@type": "marc:LinkingEntryComplexityNote",
+                  "label": "Continues: Civil air regulations and reference guide for pilots."
+                },{
+                  "@type": "marc:LinkingEntryComplexityNote",
+                  "label": "Continued by: Federal aviation regulations and flight standards for pilots."
+                }]
+              }
+            }
+          }
+        }
+      ]
     },
     "581": {
       "aboutEntity": "?thing",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -12993,7 +12993,7 @@
       "NOTE:record-count": 0
     },
     "580": {
-      "aboutEntity": "?work",
+      "aboutEntity": "?thing",
       "addLink": "hasNote",
       "resourceType": "marc:LinkingEntryComplexityNote",
       "$a": {"property": "label"},
@@ -13006,16 +13006,13 @@
           ],
           "result": {
             "mainEntity": {
-              "instanceOf" : {
-                "@type": "Text",
-                "hasNote": [{
-                  "@type": "marc:LinkingEntryComplexityNote",
-                  "label": "Continues: Civil air regulations and reference guide for pilots."
-                },{
-                  "@type": "marc:LinkingEntryComplexityNote",
-                  "label": "Continued by: Federal aviation regulations and flight standards for pilots."
-                }]
-              }
+              "hasNote": [{
+                "@type": "marc:LinkingEntryComplexityNote",
+                "label": "Continues: Civil air regulations and reference guide for pilots."
+              },{
+                "@type": "marc:LinkingEntryComplexityNote",
+                "label": "Continued by: Federal aviation regulations and flight standards for pilots."
+              }]
             }
           }
         }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1435,7 +1435,6 @@
       "$a": {"about": "_:agent", "property": "label", "infer": true, "TODO:targetMatch": "1xx"},
       "$b": {"about": "_:instance", "property": "editionStatement", "TODO:targetMatch": "250"},
       "$d": {"about": "_:instance", "property": "provisionActivityStatement", "TODO:targetMatch": "260$c"},
-      "$g": {"about": "_:instance", "addProperty": "part"},
       "$h": {"about": "_:instance", "addLink": "extent", "resourceType": "Extent", "property": "label", "NOTE:marc-repeatable": false},
       "$m": {"about": "_:instance", "property": "marc:materialSpecificDetails"},
       "$n": {"about": "_:instance", "addLink": "hasNote", "resourceType": "Note", "property": "label"},
@@ -1461,7 +1460,7 @@
     },
 
     "referenceToWork": {
-      "include": ["referencedObjectDetails", "serialSpecificDetails", "workTitleQualifier", "workDisplayText"],
+      "include": ["referencedObjectDetailsWithPart", "serialSpecificDetails", "workTitleQualifier", "workDisplayText"],
       "pendingResources": {
         "_:instance": {
           "about": "_:work",
@@ -1471,12 +1470,22 @@
       }
     },
 
+    "referencedObjectDetailsWithPart": {
+      "include": ["referencedObjectDetails"],
+      "$g": {"about": "_:instance", "addProperty": "part"}
+    },
+
+    "referenceToInstance": {
+      "include": ["instanceOfObject", "referencedObjectDetailsWithPart", "instanceTitleQualifier", "serialSpecificDetails", "instanceDisplayText"]
+    },
+
     "referenceToInstanceSansDisplayText": {
-      "include": ["instanceOfObject", "referencedObjectDetails", "instanceTitleQualifier", "serialSpecificDetails"]
+      "include": ["instanceOfObject", "referencedObjectDetails", "instanceTitleQualifier", "serialSpecificDetails"],
+      "$g": {"aboutEntity": "?thing", "addProperty": "part"}
     },
 
     "referenceToSeriesInstance": {
-      "include": ["instanceOfObject", "referencedObjectDetails", "workTitleQualifier", "workDisplayText"]
+      "include": ["instanceOfObject", "referencedObjectDetailsWithPart", "workTitleQualifier", "workDisplayText"]
     },
 
     "instanceOfObject": {
@@ -17547,6 +17556,7 @@
             {"w": "8258455"}
           ]}},
           "result": {"mainEntity": {
+            "part": ["127:1964, s. 495-534"],
             "isPartOf": [{
               "@type": "Instance",
               "describedBy": [{
@@ -17561,7 +17571,6 @@
                 "@type": "ISSN",
                 "value": "0040-6945"
               }],
-              "part": ["127:1964, s. 495-534"],
               "marc:toDisplayNote": true
             }]
           }}
@@ -17580,6 +17589,7 @@
             {"9": "34"}
           ]}},
           "result": {"mainEntity": {
+            "part": ["1992 (33:1), s. 34-35 : ill."],
             "isPartOf": [{
               "@type": "Instance",
               "describedBy": [{
@@ -17594,7 +17604,6 @@
                 "@type": "ISSN",
                 "value": "ISSN 0284-771X"
               }],
-              "part": ["1992 (33:1), s. 34-35 : ill."],
               "provisionActivityStatement": "Växjö : Kronobergs läns hembydsförbund, 1985-1995",
               "marc:controlSubfield": "n s",
               "marc:toDisplayNote": true,
@@ -17621,6 +17630,7 @@
             {"w": "11899145"}
           ]}},
           "result": {"mainEntity": {
+            "part": ["S.184-212"],
             "isPartOf": [{
               "@type": "Instance",
               "describedBy": [{
@@ -17635,7 +17645,6 @@
                 "@type": "ISBN",
                 "value": "9780674033320 (cl : alk. paper)"
               }],
-              "part": ["S.184-212"],
               "provisionActivityStatement": "cop. 2009",
               "instanceOf": {
                 "@type": "Work",
@@ -17725,6 +17734,7 @@
                 "marc:toDisplayNote": true
               }]
             },
+            "part": ["2002(122):1, s. [99]-108"],
             "isPartOf": [{
               "@type": "Instance",
               "describedBy": [{
@@ -17739,7 +17749,6 @@
                 "@type": "ISSN",
                 "value": "0345-469X"
               }],
-              "part": ["2002(122):1, s. [99]-108"],
               "marc:toDisplayNote": true
             }]
           }}
@@ -17877,7 +17886,7 @@
       ]
     },
     "775": {
-      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
+      "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherEdition",
@@ -17972,7 +17981,7 @@
     },
     "776": {
       "NOTE": "We deviate from BF2 as we do not link from the Work with hasInstance.",
-      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
+      "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherPhysicalFormat",
@@ -18146,7 +18155,7 @@
       ]
     },
     "777": {
-      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
+      "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "issuedWith",
@@ -18649,7 +18658,7 @@
       ]
     },
     "786": {
-      "include": ["referenceToInstanceSansDisplayText", "instanceDisplayText"],
+      "include": ["referenceToInstance"],
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "dataSource",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1485,7 +1485,7 @@
     },
 
     "referenceToSeriesInstance": {
-      "include": ["instanceOfObject", "referencedObjectDetailsWithPart", "workTitleQualifier", "workDisplayText"]
+      "include": ["instanceOfObject", "referencedObjectDetailsWithPart", "workTitleQualifier", "instanceDisplayText"]
     },
 
     "instanceOfObject": {
@@ -17169,13 +17169,13 @@
                 "value": "1401-9612"
               }],
               "part": ["s. 144-145"],
+              "marc:displayText": ["displayText"],
               "instanceOf": {
                 "@type": "Work",
                 "hasTitle": [{
                   "@type": "Title",
                   "qualifier": "Särskiljande tillägg"
-                }],
-                "marc:displayText": ["displayText"]
+                }]
               }
             }]
           }}
@@ -17193,10 +17193,12 @@
       "_spec": [
         {
           "source": {"762": {"ind1": "0", "ind2": " ", "subfields": [
+            {"i": "displayText"},
             {"t": "Rätt fart"},
             {"w": "9823877"}
           ]}},
           "normalized": {"762": {"ind1": "0", "ind2": " ", "subfields": [
+            {"i": "displayText"},
             {"t": "Rätt fart"},
             {"w": "9823877"}
           ]}},
@@ -17204,6 +17206,7 @@
             "hasSubseries": [{
               "@type": "Instance",
               "marc:toDisplayNote": true,
+              "marc:displayText": ["displayText"],
               "hasTitle": [{
                 "@type": "Title",
                 "mainTitle": "Rätt fart"

--- a/whelktool/scripts/2020/01/remodel-link-fields/move-linkfield-to-instance.groovy
+++ b/whelktool/scripts/2020/01/remodel-link-fields/move-linkfield-to-instance.groovy
@@ -1,0 +1,142 @@
+/*
+ * Move following properties from Work to Instance and make object an Instance
+ *
+ * NOTE: This script does not take into account marc:displayNote, marc:controlSubfield
+ * partNumber, marc:fieldref or marc:groupid. Will be handled with separate issue. For
+ * now the properties will remain directly on the object.
+ *
+ * Also move isPartOf.part to thing.part
+ *
+ * See LXL-1717, LXL-1135, LXL-2777 and LXL-2787
+ *
+ */
+
+LINK_FIELDS_TO_MOVE = ['isPartOf', 'otherEdition', 'issuedWith', 'dataSource']
+NOTE_TO_MOVE = ['hasNote' : 'marc:LinkingEntryComplexityNote']
+LEGACY_PROPERTIES = ['marc:toDisplayNote', 'marc:controlSubfield', 'partNumber', 'marc:fieldref', 'marc:groupid', 'marc:displayText']
+PROPERTIES_TO_IGNORE = ['marc:displayText', 'part']
+
+PrintWriter failedIDs = getReportWriter("failed-to-update")
+scheduledForChange = getReportWriter("scheduled-for-change")
+deviantRecords = getReportWriter("deviant-records-to-analyze")
+
+String subQuery = LINK_FIELDS_TO_MOVE.collect {"data#>>'{@graph,2,${it}}' IS NOT NULL"}.join(" OR ")
+String subQueryNote = NOTE_TO_MOVE.collect {"data#>>'{@graph,2,${it.key}}' LIKE '%${it.value}%'"}.join(" OR ")
+String query = "collection = 'bib' AND ( ${subQuery} OR ${subQueryNote} )"
+
+selectBySqlWhere(query) { data ->
+    def (record, thing, work) = data.graph
+
+    work.subMap(LINK_FIELDS_TO_MOVE + NOTE_TO_MOVE.keySet()).each { key, val ->
+        def newListOfObjects
+        boolean shouldRemoveProperties = false
+
+        if (key == 'hasNote') {
+            newListOfObjects = val.findAll { it[TYPE] == NOTE_TO_MOVE[key] }
+            val.removeIf { it[TYPE] == NOTE_TO_MOVE[key] }
+        } else {
+            if (key == 'isPartOf') {
+                shouldRemoveProperties = true
+                def part = fixIsPartOf(val, record[ID])
+                if (!part.isEmpty())
+                    thing << ['part': part]
+            }
+            newListOfObjects = updateProperties(record[ID], val, shouldRemoveProperties)
+        }
+
+        if (!newListOfObjects.isEmpty()) {
+            if (thing.containsKey(key))
+                thing[key].addAll(newListOfObjects)
+            else
+                thing[key] = newListOfObjects
+        }
+    }
+
+    work.entrySet().removeIf { LINK_FIELDS_TO_MOVE.contains(it.key) ||
+            (NOTE_TO_MOVE.containsKey(it.key) && it.value.isEmpty()) }
+
+    scheduledForChange.println "Record was updated ${record[ID]}"
+    data.scheduleSave(onError: { e ->
+        failedIDs.println("Failed to save ${record[ID]} due to: $e")
+    })
+}
+
+List fixIsPartOf(listOfObjects, docId) {
+    Set parts = []
+    listOfObjects.each {
+        if (it.hasInstance && it.hasInstance instanceof List)
+            it.hasInstance.each { if (it.part) { parts = addUniquePart(it.part, parts, docId) } }
+        else if (it.hasInstance?.part)
+            parts = addUniquePart(it.hasInstance.part, parts, docId)
+    }
+    return parts as List
+}
+
+Set addUniquePart(part, existingParts, docId) {
+    def updatedParts = new LinkedHashSet<String>(existingParts)
+    updatedParts.addAll(part)
+
+    if (!existingParts.isEmpty() && updatedParts.size() > existingParts.size())
+        deviantRecords.println "${docId} contains more than one unique part"
+
+    return updatedParts
+}
+
+List updateProperties(docID, listOfObjects, shouldIgnoreProperties) {
+    def newListOfObjects = []
+
+    listOfObjects.each {
+        instanceObject = remodelObjectToInstance(it, docID, shouldIgnoreProperties)
+        if (instanceObject)
+            newListOfObjects << instanceObject
+    }
+    return newListOfObjects
+}
+
+Map remodelObjectToInstance(object, docID, shouldIgnoreProperties) {
+    Map instanceProperties = [:]
+    Map workProperties = [:]
+    Map newInstanceObject = [:]
+
+    if (object.hasInstance instanceof List && object.hasInstance?.size() > 1) {
+        deviantRecords.println "${docID} contains more than one hasInstance entity"
+        return
+    }
+
+    object.each {
+        if (it.key == 'hasInstance')
+            instanceProperties << it.value
+        else if (LEGACY_PROPERTIES.contains(it.key))
+            instanceProperties << it
+        else
+            workProperties << it
+    }
+
+    if (shouldIgnoreProperties)
+        instanceProperties.keySet().removeIf { PROPERTIES_TO_IGNORE.contains(it) }
+
+    if (instanceProperties && !onlyContainsNoise(instanceProperties)) {
+        //TODO: If hasInstance only contains @id --> log to be analyzed!!
+        if (instanceProperties.containsKey(ID))
+            deviantRecords.println "${docID} contains hasInstance with link"
+        instanceProperties[TYPE] = "Instance"
+        newInstanceObject << instanceProperties
+    }
+
+    if (workProperties && !onlyContainsNoise(workProperties)) {
+        workProperties[TYPE] = "Work"
+        newInstanceObject << ['instanceOf': workProperties]
+    }
+
+    return newInstanceObject
+}
+
+boolean onlyContainsNoise(map) {
+    boolean noise = true
+    def noiseProperties = LEGACY_PROPERTIES + TYPE
+    map.each { key, val ->
+        if (!noiseProperties.contains(key))
+            noise = false
+    }
+    return noise
+}

--- a/whelktool/scripts/2020/01/remodel-link-fields/move-linkfield-to-instance.groovy
+++ b/whelktool/scripts/2020/01/remodel-link-fields/move-linkfield-to-instance.groovy
@@ -1,9 +1,9 @@
 /*
  * Move following properties from Work to Instance and make object an Instance
  *
- * NOTE: This script does not take into account marc:displayNote, marc:controlSubfield
- * partNumber, marc:fieldref or marc:groupid. Will be handled with separate issue. For
- * now the properties will remain directly on the object.
+ * NOTE: This script temporarily keeps marc:displayNote, marc:controlSubfield
+ * partNumber, marc:fieldref and marc:groupid and moves them to the Instance entity.
+ * These properties will be be cleaned up in the following steps (separate issue LXL-3019)
  *
  * Also move isPartOf.part to thing.part
  *
@@ -41,7 +41,7 @@ selectBySqlWhere(query) { data ->
                 if (!part.isEmpty())
                     thing << ['part': part]
             }
-            newListOfObjects = updateProperties(record[ID], val, shouldRemoveProperties)
+            newListOfObjects = updateProperties(val, shouldRemoveProperties, record[ID])
         }
 
         if (!newListOfObjects.isEmpty()) {
@@ -82,18 +82,18 @@ Set addUniquePart(part, existingParts, docId) {
     return updatedParts
 }
 
-List updateProperties(docID, listOfObjects, shouldIgnoreProperties) {
+List updateProperties(listOfObjects, shouldIgnoreProperties, docID) {
     def newListOfObjects = []
 
     listOfObjects.each {
-        instanceObject = remodelObjectToInstance(it, docID, shouldIgnoreProperties)
+        instanceObject = remodelObjectToInstance(it, shouldIgnoreProperties, docID)
         if (instanceObject)
             newListOfObjects << instanceObject
     }
     return newListOfObjects
 }
 
-Map remodelObjectToInstance(object, docID, shouldIgnoreProperties) {
+Map remodelObjectToInstance(object, shouldIgnoreProperties, docID) {
     Map instanceProperties = [:]
     Map workProperties = [:]
     Map newInstanceObject = [:]

--- a/whelktool/scripts/2020/01/remodel-link-fields/remove-repeated-editionstatements.groovy
+++ b/whelktool/scripts/2020/01/remodel-link-fields/remove-repeated-editionstatements.groovy
@@ -1,0 +1,32 @@
+EXPECTED = [TYPE, 'editionStatement', 'editionStatementRemainder'] as Set
+
+selectBySqlWhere(""" data#>'{@graph,1,otherEdition}' notnull """) { data ->
+    def instance = data.graph[1]
+
+    //def stmts = []
+    def iter = instance.otherEdition?.iterator()
+    for (other in iter) {
+        if ((other.keySet() - EXPECTED).size() == 0 &&
+            (other.editionStatement || other.editionStatementRemainder)) {
+            iter.remove()
+            data.scheduleSave()
+        }
+    }
+
+    if (!instance.otherEdition) {
+        instance.remove('otherEdition')
+    }
+
+    /* NOTE: we DROP these; determined to be import noise of no value.
+    if (stmts) {
+        def notes = instance.get('hasNote', [])
+        notes << stmts.collect {
+            [
+                (TYPE): 'Note',
+                label: [it.editionStatement, it.editionStatementRemainder].findAll().join(' / ')
+            ]
+        }
+        data.scheduleSave()
+    }
+    */
+}


### PR DESCRIPTION
* Move isPartOf, otherEdition, issuedWith and dataSource from Work to Instance and reference to an Instance object
* Remove marc:displayText from isPartOf
* Move isPartOf.part to a part property directly on Instance (Align with PR https://github.com/libris/definitions/pull/181)
* Move hasNote a marc:LinkingEntryComplexityNote to Instance

## Checklist:
- [x] I have run the unit tests. `gradlew integTest`
- [x] I have run script as dry-run on QA
- [x] Export issue: How to handle the potential collision between repeated bib 250 $a and bib 775 $b. Both maps to otherEdition.editionStatement. Fixed with script remove-repeated-editionstatements.groovy and https://jira.kb.se/browse/LXL-3022
- [x] Move hasSeries.instanceOf.marc:displayText and hasSubSeries.instanceOf.marc:displayText to Move hasSeries/hasSubSeries.marc:displayText. Will be fixed with https://jira.kb.se/browse/LXL-3025
