### PR TITLE
Keep _limit when generating facet links

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -202,7 +202,7 @@ class SearchUtils {
      */
     private Map stripNonStatsParams(Map incoming) {
         Map result = [:]
-        List reserved = getReservedAuxParameters()
+        List reserved = ['_offset']
         incoming.each { k, v ->
             if (!reserved.contains(k)) {
                 result[k] = v
@@ -575,14 +575,7 @@ class SearchUtils {
      * Return a list of reserved query params
      */
     private List getReservedParameters() {
-        return ['q', 'p', 'o', 'value'] + getReservedAuxParameters()
-    }
-
-    /*
-     * Return a list of reserved helper params
-     */
-    private List getReservedAuxParameters() {
-        return ['_limit', '_offset']
+        return ['q', 'p', 'o', 'value', '_limit', '_offset']
     }
 
     /*


### PR DESCRIPTION
Keep `_limit` parameter when generating facet links in search results.
Otherwise facets will contain the default number of results (200).
Makes it consistent with `next`, `last`, `up` etc.