### PR TITLE
Feature/lxl 1455 allow isbn in remote search

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -291,7 +291,7 @@ class RemoteSearchAPI extends HttpServlet {
     private List getRange(List resultsList) {
         def hitList = resultsList*.hits
         def largestNumberOfHits = hitList*.size().max()
-        return  0..(largestNumberOfHits-1)
+        return  0..<largestNumberOfHits
     }
 
     class MetaproxyQuery implements Callable<MetaproxySearchResult> {

--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -150,34 +150,6 @@ class RemoteSearchAPI extends HttpServlet {
         log.info("Started ...")
     }
 
-    List loadMetaProxyInfo(URL url) {
-        List databases = []
-        try {
-            def xml = new XmlSlurper(false, false).parse(url.newInputStream())
-
-            databases = xml.libraryCode.collect {
-                def map = ["database": createString(it.@id)]
-                it.children().each { node ->
-                    def n = node.name().toString()
-                    def o = node.text().toString()
-                    def v = map[n]
-                    if (v) {
-                        if (v instanceof String) {
-                            v = map[n] = [v]
-                        }
-                        v << o
-                    } else {
-                        map[n] = o
-                    }
-                }
-                return map
-            }
-        } catch (SocketException se) {
-            log.error("Unable to load database list.")
-        }
-        return databases
-    }
-
     @Override
     void doGet(HttpServletRequest request, HttpServletResponse response) {
         // Check that we have kat-rights.
@@ -292,6 +264,34 @@ class RemoteSearchAPI extends HttpServlet {
         def hitList = resultsList*.hits
         def largestNumberOfHits = hitList*.size().max()
         return  0..<largestNumberOfHits
+    }
+
+    List loadMetaProxyInfo(URL url) {
+        List databases = []
+        try {
+            def xml = new XmlSlurper(false, false).parse(url.newInputStream())
+
+            databases = xml.libraryCode.collect {
+                def map = ["database": createString(it.@id)]
+                it.children().each { node ->
+                    def name = node.name().toString()
+                    def text = node.text().toString()
+                    def v = map[name]
+                    if (v) {
+                        if (v instanceof String) {
+                            v = map[name] = [v]
+                        }
+                        v << text
+                    } else {
+                        map[name] = text
+                    }
+                }
+                return map
+            }
+        } catch (SocketException se) {
+            log.error("Unable to load database list.")
+        }
+        return databases
     }
 
     class MetaproxyQuery implements Callable<MetaproxySearchResult> {

--- a/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
@@ -10,7 +10,7 @@ class RemoteSearchAPISpec extends Specification {
         remote = new RemoteSearchAPI()
     }
 
-    def "Merge should return formatted output"() {
+    def "Merge results should return formatted output"() {
         given:
         def doc = new Document(['@graph': [['@id': "testId"]]])
         def resultBNB = createResult("BNB", 1, null, [doc])
@@ -41,7 +41,7 @@ class RemoteSearchAPISpec extends Specification {
         output  == '{"totalResults":{"OCLC":1,"BNB":2,"CORNELL":3},"items":[{"database":"OCLC","data":{"@graph":[{"@id":"testId"}]}},{"database":"BNB","data":{"@graph":[{"@id":"testId"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId"}]}},{"database":"BNB","data":{"@graph":[{"@id":"testId2"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId2"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId3"}]}}]}'
     }
 
-    def "Merge should append error message to output"() {
+    def "Merge results should append error message to output"() {
         given:
         def doc = new Document(['@graph': [['@id': "testId"]]])
         def resultBNB = createResult("BNB", 1, "Error message", [doc])
@@ -53,6 +53,19 @@ class RemoteSearchAPISpec extends Specification {
 
         then:
         output == '{"totalResults":{"OCLC":1,"BNB":1},"items":[{"database":"OCLC","data":{"@graph":[{"@id":"testId"}]}}],"errors":{"BNB":{"0":"Error message"}}}'
+    }
+
+    def "Merge results should handle empty results"() {
+        given:
+        def resultBNB = createResult("BNB", 0, null, [])
+        def resultOCLC = createResult("OCLC", 0, null, [])
+        def resultLists = [resultOCLC, resultBNB]
+
+        when:
+        def output = remote.mergeResults(resultLists)
+
+        then:
+        output == '{"totalResults":{"OCLC":0,"BNB":0},"items":[]}'
     }
 
     def createResult(String database, int numberOfHits, error, docs) {

--- a/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
@@ -1,0 +1,67 @@
+package whelk.rest.api
+
+import spock.lang.Specification
+import whelk.Document
+
+class RemoteSearchAPISpec extends Specification {
+    RemoteSearchAPI remote
+
+    void setup() {
+        remote = new RemoteSearchAPI()
+    }
+
+    def "Merge should return formatted output"() {
+        given:
+        def doc = new Document(['@graph': [['@id': "testId"]]])
+        def resultBNB = createResult("BNB", 1, null, [doc])
+        def resultOCLC = createResult("OCLC", 1, null, [doc])
+        def resultLists = [resultOCLC, resultBNB]
+
+        when:
+        def output = remote.mergeResults(resultLists)
+
+        then:
+        output == '{"totalResults":{"OCLC":1,"BNB":1},"items":[{"database":"OCLC","data":{"@graph":[{"@id":"testId"}]}},{"database":"BNB","data":{"@graph":[{"@id":"testId"}]}}]}'
+    }
+
+    def "Merge result should not be grouped by database"() {
+        given:
+        def doc1 = new Document(['@graph': [['@id': "testId"]]])
+        def doc2 = new Document(['@graph': [['@id': "testId2"]]])
+        def doc3 = new Document(['@graph': [['@id': "testId3"]]])
+        def resultOCLC = createResult("OCLC", 1, null, [doc1])
+        def resultBNB = createResult("BNB", 2, null, [doc1, doc2])
+        def resultCORNELL = createResult("CORNELL", 3, null, [doc1, doc2, doc3])
+        def resultLists = [resultOCLC, resultBNB, resultCORNELL]
+
+        when:
+        def output = remote.mergeResults(resultLists)
+
+        then:
+        output  == '{"totalResults":{"OCLC":1,"BNB":2,"CORNELL":3},"items":[{"database":"OCLC","data":{"@graph":[{"@id":"testId"}]}},{"database":"BNB","data":{"@graph":[{"@id":"testId"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId"}]}},{"database":"BNB","data":{"@graph":[{"@id":"testId2"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId2"}]}},{"database":"CORNELL","data":{"@graph":[{"@id":"testId3"}]}}]}'
+    }
+
+    def "Merge should append error message to output"() {
+        given:
+        def doc = new Document(['@graph': [['@id': "testId"]]])
+        def resultBNB = createResult("BNB", 1, "Error message", [doc])
+        def resultOCLC = createResult("OCLC", 1, null, [doc])
+        def resultLists = [resultOCLC, resultBNB]
+
+        when:
+        def output = remote.mergeResults(resultLists)
+
+        then:
+        output == '{"totalResults":{"OCLC":1,"BNB":1},"items":[{"database":"OCLC","data":{"@graph":[{"@id":"testId"}]}}],"errors":{"BNB":{"0":"Error message"}}}'
+    }
+
+    def createResult(String database, int numberOfHits, error, docs) {
+        def result = new RemoteSearchAPI.MetaproxySearchResult(null, database, numberOfHits)
+        result.error = error
+        for (doc in docs) {
+            result.addHit(doc)
+        }
+        return result
+    }
+}
+


### PR DESCRIPTION
This pull request depends on additions in the metaproxy xml-file: 

`http://mproxy.libris.kb.se/db_Metaproxy.xml`

Correct behaviour has been verified with a local copy of the file where each library element has an additional child element:

```
<libraryCode id="NLH">
   <name>National Széchényi Library</name>
   <alternativeName>National Library of Hungary</alternativeName>
   <country>Ungern</country>
   <comment/>
   <address>http://regi.oszk.hu/index_en.htm</address>
   <requiresDcIdentifier>true</requiresDcIdentifier>
   <port>2222</port>
</libraryCode>
```