### PR TITLE
Feature/lxl 2952

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1031,7 +1031,10 @@ class JsonLd {
         embedChain.add(mainId)
         Map newItem = [:]
         mainItem.each { key, value ->
-            newItem.put(key, toEmbedded(value, idMap, embedChain))
+            if (!key.equals(JSONLD_ALT_ID_KEY))
+                newItem.put(key, toEmbedded(value, idMap, embedChain))
+            else
+                newItem.put(key, value)
         }
         return newItem
     }

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1061,7 +1061,7 @@ class JsonLd {
     }
 
     /*
-     * Traverse the data and index all non-reference objects on their @id:s.
+     * Traverse the data and index all non-reference objects on their @id:s and sameAs:s.
      */
     private static Map getIdMap(Map data) {
         Map idMap = new HashMap()
@@ -1078,7 +1078,14 @@ class JsonLd {
                 && !data.containsKey(GRAPH_KEY)
                ) {
                 idMap.put(data.get(key), data)
-                continue
+            } else if (key.equals(JSONLD_ALT_ID_KEY)
+                    // Don't index graphs, since their @id:s do not denote them.
+                    && !data.containsKey(GRAPH_KEY)) {
+                List sameAsList = (List) data.get(key)
+                for (Object altIdObject : sameAsList) {
+                    Map altIdMap = (Map) altIdObject
+                    idMap.put(altIdMap.get(ID_KEY), data)
+                }
             }
             Object obj = data.get(key)
             if (obj instanceof List)

--- a/whelk-core/src/test/groovy/JsonLdSpec.groovy
+++ b/whelk-core/src/test/groovy/JsonLdSpec.groovy
@@ -153,6 +153,19 @@ class JsonLdSpec extends Specification {
         assert JsonLd.frame(id, input) == input
     }
 
+    def "should frame on sameAs-link"() {
+        given:
+        def id = "1234"
+        def sameAs = "4321"
+        def input = ["@graph": [
+                ["@id": id, "foo": "bar", "linksTo": ["@id" : sameAs]],
+                ["@id": "other_id", "sameAs":[["@id": sameAs]], "some":"data"]
+        ]]
+        def expected = ["@id": id, "foo": "bar", "linksTo": ["@id": "other_id", "sameAs":[["@id": sameAs]], "some":"data"]]
+        expect:
+        assert JsonLd.frame(id, input) == expected
+    }
+
     def "should flatten framed jsonld"() {
         given:
         def id = "1234"

--- a/whelk-core/src/test/resources/flatten-001-in.jsonld
+++ b/whelk-core/src/test/resources/flatten-001-in.jsonld
@@ -1,11 +1,11 @@
 {
   "@type": "Record",
   "@id": "https://libris.kb.se/record/something",
-  "sameAs": ["/auth/1"],
+  "sameAs": [{"@id":"/auth/1"}],
   "about": {
     "@id": "/thing/something",
     "@type": "Thing",
-    "sameAs": ["/resouce/auth/1", "http://dbpedia.org/resource/Thing"],
+    "sameAs": [{"@id":"/resouce/auth/1"}, {"@id":"http://dbpedia.org/resource/Thing"}],
     "name": "Something",
     "creator": {
       "@id": "/agent/somebody",

--- a/whelk-core/src/test/resources/flatten-001-out.jsonld
+++ b/whelk-core/src/test/resources/flatten-001-out.jsonld
@@ -3,13 +3,13 @@
     {
       "@type": "Record",
       "@id": "https://libris.kb.se/record/something",
-      "sameAs": ["/auth/1"],
+      "sameAs": [{"@id":"/auth/1"}],
       "about": {"@id": "/thing/something"}
     },
     {
       "@type": "Thing",
       "@id": "/thing/something",
-      "sameAs": ["/resouce/auth/1", "http://dbpedia.org/resource/Thing"],
+      "sameAs": [{"@id":"/resouce/auth/1"}, {"@id":"http://dbpedia.org/resource/Thing"}],
       "name": "Something",
       "creator": {"@id": "/agent/somebody"},
       "publisher": {"@id": "/agent/everybody"},

--- a/whelk-core/src/test/resources/frame-001-in.jsonld
+++ b/whelk-core/src/test/resources/frame-001-in.jsonld
@@ -3,13 +3,13 @@
     {
       "@type": "Record",
       "@id": "https://libris.kb.se/record/something",
-      "sameAs": ["/auth/1"],
+      "sameAs": [{"@id": "/auth/1"}],
       "about": {"@id": "/thing/something"}
     },
     {
       "@type": "Thing",
       "@id": "/thing/something",
-      "sameAs": ["/resouce/auth/1", "http://dbpedia.org/resource/Thing"],
+      "sameAs": [{"@id":"/resouce/auth/1"}, {"@id":"http://dbpedia.org/resource/Thing"}],
       "name": "Something",
       "creator": {"@id": "/agent/somebody"},
       "publisher": {"@id": "/agent/everybody"},

--- a/whelk-core/src/test/resources/frame-001-out.jsonld
+++ b/whelk-core/src/test/resources/frame-001-out.jsonld
@@ -1,11 +1,11 @@
 {
   "@type": "Record",
   "@id": "https://libris.kb.se/record/something",
-  "sameAs": ["/auth/1"],
+  "sameAs": [{"@id":"/auth/1"}],
   "about": {
     "@id": "/thing/something",
     "@type": "Thing",
-    "sameAs": ["/resouce/auth/1", "http://dbpedia.org/resource/Thing"],
+    "sameAs": [{"@id":"/resouce/auth/1"}, {"@id":"http://dbpedia.org/resource/Thing"}],
     "name": "Something",
     "creator": {
       "@id": "/agent/somebody",


### PR DESCRIPTION
Den här PRen gör så att även sameAs-IDn går att länka till, utan att saker slutar fungera.

Tidigare har man bara kunnat länka till posters primär-IDn. Men eftersom vi nu börjar ändra primärIDn på poster (uppdateringar av koncept med id.kb.se-IDn), och peta ner gamla primärIDn till sameAs-IDn, så behöver länkar till sameAs-IDn också fungera.

Embellish klarade redan detta, men framingen gjorde det inte (vilket nu åtgärdas).