### PR TITLE
Feature/lxl 2952 2

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -612,8 +612,8 @@ class PostgreSQLComponent implements Storage {
             if ( preUpdateDoc.getThingIdentifiers()[0] &&
                     doc.getThingIdentifiers()[0] &&
                     doc.getThingIdentifiers()[0] != preUpdateDoc.getThingIdentifiers()[0]) {
-                // This is normally done in refreshDerivativeTables, but the NEW id needs to
-                // replaced early, so that it is available in the ID table, when all there dependers
+                // This is normally done in refreshDerivativeTables, but the NEW id needs to be
+                // replaced early, so that it is available in the ID table, when all the dependers
                 // re-calculate their dependencies
                 saveIdentifiers(doc, connection, deleted)
                 SortedSet<String> idsLinkingToOldId = getDependencyData(id, GET_DEPENDERS, connection)

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -84,7 +84,6 @@ class LinkFinder {
     }
 
     void normalizeIdentifiers(Document document, Connection connection, boolean cacheAuthForever = false) {
-
         // Normalize ISBN and ISSN identifiers. No hyphens and upper case.
         for (List<String> path : [Document.thingTypedIDsPath, Document.thingIndirectTypedIDsPath]) {
             List typedIDs = document.get(path)
@@ -141,7 +140,7 @@ class LinkFinder {
             // sameAs objects are not links per se, and must not be replaced
             String keyString = (String) key
             if (keyString.equals("sameAs"))
-                return
+                continue
 
             Object value = data.get(key)
 


### PR DESCRIPTION
This makes it so that when a record is saved with a replaced mainEntity URI (for example a new id.kb.se-uri)
Any other records linking to that old URI will now be resaved, and in the process of being resaved they will also (the point) update their links to the new URI.