### PR TITLE
Force reindexing of _all_ records linking to A, when A changes URI.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Storage.groovy
+++ b/whelk-core/src/main/groovy/whelk/Storage.groovy
@@ -14,7 +14,7 @@ interface Storage {
         public void update(Document doc)
     }
 
-    Document storeAtomicUpdate(String id, boolean minorUpdate, String changedIn, String changedBy, UpdateAgent updateAgent)
+    List<Document> storeAtomicUpdate(String id, boolean minorUpdate, String changedIn, String changedBy, UpdateAgent updateAgent)
     boolean createDocument(Document document, String changedIn, String changedBy, String collection, boolean deleted)
 
 }


### PR DESCRIPTION
Normally you would only reindex those records for which cards have
changed, but for o-searches to work correctly, all linkers must be
reindexed when the URI they're linking to has changed.