### PR TITLE
Set elastic settings.index.mapping.total_fields to 100,000

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -4,7 +4,7 @@
             "max_result_window": 100000,
             "mapping": {
                 "total_fields": {
-                    "limit": 10000
+                    "limit": 100000
                 }
             }
         },


### PR DESCRIPTION
It seems like updating the value after index creation doesn't always
work since we get an error message with max 10,000 even though it is set
higher through the settings API by the create_es_index fab task.