### PR TITLE
When framing, always embed the largest object/version of each ID.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1080,7 +1080,7 @@ class JsonLd {
                 // Don't index graphs, since their @id:s do not denote them.
                 && !data.containsKey(GRAPH_KEY)
                ) {
-                idMap.put(data.get(key), data)
+                addToIdMap(idMap, data, (String) data.get(key))
             } else if (key.equals(JSONLD_ALT_ID_KEY)
                     // Don't index graphs, since their @id:s do not denote them.
                     && !data.containsKey(GRAPH_KEY)
@@ -1088,7 +1088,7 @@ class JsonLd {
                 List sameAsList = (List) data.get(key)
                 for (Object altIdObject : sameAsList) {
                     Map altIdMap = (Map) altIdObject
-                    idMap.put(altIdMap.get(ID_KEY), data)
+                    addToIdMap(idMap, data, (String) altIdMap.get(ID_KEY))
                 }
             }
             Object obj = data.get(key)
@@ -1097,6 +1097,16 @@ class JsonLd {
             else if (obj instanceof Map)
                 populateIdMap( (Map) obj, idMap )
         }
+    }
+
+    private static void addToIdMap(Map idMap, Map object, String id) {
+        // Do not replace a large object with a smaller one (with the same id).
+        // Doing so means data is lost in the framing.
+        Object preExisting = idMap.get(id)
+        if (preExisting != null && preExisting instanceof Map && preExisting.size() > object.size())
+            return
+
+        idMap.put(id, object)
     }
 
     private static void populateIdMap(List data, Map idMap) {


### PR DESCRIPTION
In cases where an embellished record contains both the original
record and card (smaller) versions of the same thing, due to
circular embellishment this is critical.

When this happened some data could go missing. For example "_links" fields, which in turn are necessary for reverse-dependency searches (o-sökningar) to work correctly.