### PR TITLE
Add document normalization step when saving

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -343,7 +343,10 @@ class RemoteSearchAPI extends HttpServlet {
                         def jsonDoc = marcFrameConverter.convert(mapper.readValue(jsonRec.getBytes("UTF-8"), Map), generatedId)
                         log.trace("Marcframeconverter done")
 
-                        results.addHit(new Document(jsonDoc))
+                        Document doc = new Document(jsonDoc)
+                        whelk.normalize(doc)
+                        whelk.embellish(doc)
+                        results.addHit(doc)
                     }
                 } else {
                     log.warn("Received errorMessage from metaproxy: $errorMessage")

--- a/whelk-core/src/main/groovy/se/kb/libris/BlankNodeNormalizers.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/BlankNodeNormalizers.groovy
@@ -1,0 +1,70 @@
+package se.kb.libris
+
+import groovy.util.logging.Log4j2 as Log
+import whelk.Document
+import whelk.JsonLd
+import whelk.Whelk
+import whelk.component.DocumentNormalizer
+import whelk.filter.BlankNodeLinker
+import whelk.filter.LanguageLinker
+
+import java.sql.Connection
+
+@Log
+class BlankNodeNormalizers {
+
+    static DocumentNormalizer language(Whelk whelk) {
+        LanguageLinker linker = new LanguageLinker()
+        loadDefinitions(linker, whelk)
+
+        return { Document doc, Connection connection ->
+            linker.linkAll(doc.data, 'associatedLanguage')
+            linker.linkAll(doc.data, 'language')
+        }
+    }
+
+    static DocumentNormalizer contributionRole(Whelk whelk) {
+        BlankNodeLinker linker = new BlankNodeLinker(
+                'Role', ['code', 'label', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabel'])
+        loadDefinitions(linker, whelk)
+
+        return { Document doc, Connection connection ->
+            Map work = getWork(whelk.jsonld, doc)
+            if (work && work['contribution']) {
+                linker.linkAll(work['contribution'], 'role')
+            }
+        }
+    }
+
+    static void loadDefinitions(BlankNodeLinker linker, Whelk whelk) {
+        try {
+            linker.loadDefinitions(whelk)
+            log.info("Loaded normalizer: $linker")
+        }
+        catch (Exception e) {
+            log.warn("Failed to load definitions for $linker: $e", e)
+        }
+    }
+
+    static Map getWork(JsonLd jsonLd, Document doc) {
+        def (record, thing, legacyWork) = doc.data['@graph']
+        if (thing && isInstanceOf(jsonLd, thing, 'Work')) {
+            return thing
+        }
+        else if(thing && thing['instanceOf'] && isInstanceOf(jsonLd, thing['instanceOf'], 'Work')) {
+            return thing['instanceOf']
+        }
+        else if (legacyWork && isInstanceOf(jsonLd, legacyWork, 'Work')) {
+            return legacyWork
+        }
+        return null
+    }
+
+    static boolean isInstanceOf(JsonLd jsonLd, Map entity, String baseType) {
+        def type = entity['@type']
+        if (type == null)
+            return false
+        def types = type instanceof String ? [type] : type
+        return types.any { jsonLd.isSubClassOf(it, baseType) }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/component/DocumentNormalizer.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DocumentNormalizer.groovy
@@ -1,0 +1,9 @@
+package whelk.component
+
+import whelk.Document
+
+import java.sql.Connection
+
+interface DocumentNormalizer {
+    void normalize(Document doc, Connection connection)
+}

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -1,8 +1,8 @@
 package whelk.filter
 
-
 import whelk.Whelk
 import whelk.search.ESQuery
+import whelk.search.ElasticFind
 import whelk.util.DocumentUtil
 import whelk.util.Statistics
 
@@ -48,12 +48,15 @@ class BlankNodeLinker implements DocumentUtil.Linker {
     void loadDefinitions(Whelk whelk) {
         def q = [
                 (TYPE_KEY): [type],
-                "q"              : ["*"],
-                '_sort'          : [ID_KEY]
+                "q"       : ["*"],
+                '_sort'   : [ID_KEY]
         ]
 
-        whelk.bulkLoad(new ESQuery(whelk).doQueryIds(q)).values().each { definition ->
-            addDefinition(definition.data[GRAPH_KEY][1])
+        new ElasticFind(new ESQuery(whelk)).findIds(q).each { id ->
+            def doc = whelk.getDocument(id)
+            if (doc) {
+                addDefinition(doc.data[GRAPH_KEY][1])
+            }
         }
     }
 
@@ -219,5 +222,10 @@ class BlankNodeLinker implements DocumentUtil.Linker {
                 c.call(o)
             }
         }
+    }
+
+    @Override
+    String toString() {
+        return "${TYPE_KEY}: $type (${map.size()} mappings)"
     }
 }

--- a/whelk-core/src/main/groovy/whelk/filter/NormalizerChain.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/NormalizerChain.groovy
@@ -1,0 +1,28 @@
+package whelk.filter
+
+import groovy.util.logging.Log4j2 as Log
+import whelk.Document
+import whelk.component.DocumentNormalizer
+
+import java.sql.Connection
+
+@Log
+class NormalizerChain implements DocumentNormalizer{
+    Collection<DocumentNormalizer> normalizers
+
+    NormalizerChain(Collection<DocumentNormalizer> normalizers) {
+        this.normalizers = normalizers.collect()
+    }
+
+    @Override
+    void normalize(Document doc, Connection connection) {
+        normalizers.each { n ->
+            try {
+                n.normalize(doc, connection)
+            }
+            catch (Exception e) {
+                log.warn("Failed to normalize ${doc.shortId}: $e", e)
+            }
+        }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
@@ -4,7 +4,7 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class ElasticFind {
-    private static final int PAGE_SIZE = 50
+    private static final int PAGE_SIZE = 100
 
     ESQuery esQuery
 


### PR DESCRIPTION
Normalize documents before saving and in remote search results.

Problems with this implementation:
* Adds several seconds to whelk startup time (maybe because I tested on a remote Postgres instance)
* Adds some KBV specific stuff to whelk-core
* Need to rethink how to handle DB connections if we add e.g. a normalizer using Whelk.relations


Add index on `data #> '{@graph,1,@type}` in `lddb` so that we don't have to use elastic to find definitions?