### PR TITLE
Feature/limit revert linkfields

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2806,6 +2806,10 @@ class MarcSubFieldHandler extends ConversionPart {
 
             def propertyValue = getPropertyValue(entity, property)
 
+            if (ignoreOnRevert) {
+                continue
+            }
+
             if (propertyValue == null && castProperty)
                 propertyValue = entity[castProperty]
 
@@ -2831,10 +2835,6 @@ class MarcSubFieldHandler extends ConversionPart {
 
             if (checkResourceType && resourceType &&
                     !isInstanceOf(entity, resourceType)) {
-                continue
-            }
-
-            if (ignoreOnRevert) {
                 continue
             }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2527,6 +2527,7 @@ class MarcSubFieldHandler extends ConversionPart {
     String definedElsewhereToken
     String marcDefault
     boolean ignored = false
+    boolean ignoreOnRevert = false
     boolean required = false
     boolean supplementary = false
     String requiresI1
@@ -2542,6 +2543,7 @@ class MarcSubFieldHandler extends ConversionPart {
         super.setTokenMap(fieldHandler, subDfn)
         aboutEntityName = subDfn.aboutEntity
         ignored = subDfn.ignored == true
+        ignoreOnRevert = subDfn.ignoreOnRevert == true
 
         trailingPunctuation = subDfn.trailingPunctuation
         leadingPunctuation = subDfn.leadingPunctuation
@@ -2829,6 +2831,10 @@ class MarcSubFieldHandler extends ConversionPart {
 
             if (checkResourceType && resourceType &&
                     !isInstanceOf(entity, resourceType)) {
+                continue
+            }
+
+            if (ignoreOnRevert) {
                 continue
             }
 

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1428,11 +1428,11 @@
         "marcDefault": "0"
       },
       "$a": {"about": "_:agent", "property": "label", "infer": true, "TODO:targetMatch": "1xx"},
-      "$b": {"about": "_:instance", "property": "editionStatement", "TODO:targetMatch": "250"},
+      "$b": {"about": "_:instance", "property": "editionStatement", "ignoreOnRevert": true, "TODO:targetMatch": "250"},
       "$d": {"about": "_:instance", "property": "provisionActivityStatement", "TODO:targetMatch": "260$c"},
-      "$h": {"about": "_:instance", "addLink": "extent", "resourceType": "Extent", "property": "label", "NOTE:marc-repeatable": false},
+      "$h": {"about": "_:instance", "addLink": "extent", "resourceType": "Extent", "property": "label", "ignoreOnRevert": true, "NOTE:marc-repeatable": false},
       "$m": {"about": "_:instance", "property": "marc:materialSpecificDetails"},
-      "$n": {"about": "_:instance", "addLink": "hasNote", "resourceType": "Note", "property": "label"},
+      "$n": {"about": "_:instance", "addLink": "hasNote", "resourceType": "Note", "property": "label",  "ignoreOnRevert": true},
       "$o": {"NOTE:subfield-count (Libris)": 0, "NOTE": "Cannot ignore this field since we import Mimer data with $o (We have lost $o data between 1.14.0 and 1.15.0). See LXL-1517"},
       "$s": {"about": "_:workTitle", "property": "mainTitle", "TODO:targetMatch": "240"},
       "$t": {"about": "_:title", "property": "mainTitle", "TODO:targetMatch": "222, 245"},
@@ -17142,9 +17142,7 @@
             {"i": "displayText"},
             {"t": "Publikation"},
             {"c": "Särskiljande tillägg"},
-            {"h": "Fysisk beskrivning"},
             {"g": "s. 144-145"},
-            {"n": "Anmärkning"},
             {"x": "1401-9612"}
           ]}},
           "result": {"mainEntity": {
@@ -17263,8 +17261,6 @@
           ]}},
           "normalized": {"765": {"ind1": "0", "ind2": " ", "subfields": [
             {"t": "Tempelriddaren"},
-            {"h": "Fysisk beskrivning"},
-            {"n": "Anmärkning"},
             {"w": "000"}
           ]}},
           "result": {"mainEntity": {
@@ -17844,7 +17840,6 @@
           ]}},
           "normalized": {"774": {"ind1": "0", "ind2": "0", "subfields": [
             {"t": "Map of area with highlighted street"},
-            {"b": "3. ed."},
             {"w": "000"}
           ]}},
           "result": {"mainEntity": {
@@ -17971,10 +17966,8 @@
           "normalized": {"775": {"ind1": "0", "ind2": " ", "subfields": [
             {"a": "Olsson, Jan"},
             {"d": "1979"},
-            {"h": "Fysisk beskrivning"},
             {"g": "Övningsbok"},
             {"f": "Företagsekonomi 80"},
-            {"n": "Anmärkning"},
             {"z": "91-40-55055-9"},
             {"w": "1320351"}
           ]}},
@@ -18053,7 +18046,6 @@
           "normalized": {"775": {"ind1": "0", "ind2": " ", "subfields": [
             {"i": "Parallellutgåva"},
             {"t": "Tolkning och översättning vid straffrättsliga förfaranden"},
-            {"b": "genomförande av EU:s tolknings- och översättningsdirektiv : betänkande"},
             {"z": "9789138237748"},
             {"w": "13506478"}
           ]}},
@@ -18098,7 +18090,6 @@
           "normalized": {"776": {"ind1": "0", "ind2": "8", "subfields": [
             {"i": "Print"},
             {"t": "War of Words: Dutch Pro-Boer Propaganda and the South African War (1899-1902)"},
-            {"b": "First edition"},
             {"z": "978-90-8964-412-1"}
           ]}},
           "result": {"mainEntity": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1506,13 +1506,13 @@
     "workTitleQualifier": {
       "TODO": "Does $c relates to $t or $s?. Check statistics. Deviates from 'referenceToInstance'",
       "NOTE": "For now, continue to map $c together with $s - applies to all linkfields (except 776)",
-      "$c": {"about": "_:workTitle", "property": "qualifier", "NOTE:marc-repeatable": false}
+      "$c": {"about": "_:workTitle", "property": "qualifier", "ignoreOnRevert": true, "NOTE:marc-repeatable": false}
     },
 
     "instanceTitleQualifier": {
       "TODO": "Does $c relates to $t or $s?. Check statistics. Deviates from 'referenceToWork' and 'referenceToSeriesInstance'",
       "NOTE": "For now, continue to map bib 776 differently; $c together with $t",
-      "$c": {"about": "_:title", "property": "qualifier", "NOTE:marc-repeatable": false}
+      "$c": {"about": "_:title", "property": "qualifier", "ignoreOnRevert": true, "NOTE:marc-repeatable": false}
     }
   },
 
@@ -17141,7 +17141,6 @@
           "normalized": {"760": {"ind1": "0", "ind2": " ", "subfields": [
             {"i": "displayText"},
             {"t": "Publikation"},
-            {"c": "Särskiljande tillägg"},
             {"g": "s. 144-145"},
             {"x": "1401-9612"}
           ]}},
@@ -17514,7 +17513,6 @@
           "normalized": {"772": {"ind1": "0", "ind2": "0", "subfields": [
             {"a": "Hellström, Lennart, 1942-"},
             {"t": "Grundläggande matematik för tillämpningar"},
-            {"c": "Lennart Hellström, Lars-Åke Lindahl"},
             {"d": "Uppsala : förf., cop. 1973"},
             {"w": "9901066360"}
           ]}},
@@ -18219,6 +18217,11 @@
             {"i": "Print"},
             {"t": "Entangled world"},
             {"c": "Original"},
+            {"z": "9783527404704"}
+          ]}},
+          "normalized": {"776": {"ind1": "0", "ind2": "8", "subfields": [
+            {"i": "Print"},
+            {"t": "Entangled world"},
             {"z": "9783527404704"}
           ]}},
           "result": {"mainEntity": {


### PR DESCRIPTION
## Description:
Add functionality to MarcframeConverter to be able to set specific subfields to not be exported. 

## Checklist:
- [x] I have built integ tests. `gradlew integTest`

### Tickets involved
https://jira.kb.se/browse/LXL-2907

### Solves
To avoid exporting specific subfields. 
In this particular case, it is about avoiding exporting data from linked objects, that can collide with current practice/regulations

