### PR TITLE
Feature/limit revert in collection

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1142,7 +1142,8 @@
       "$9": {
         "addLink": "inCollection",
         "resourceType": "TermCollection",
-        "property": "code"
+        "property": "code",
+        "ignoreOnRevert": true
       },
       "constructProperties": {
         "prefLabel": {"property": "termComponentList.prefLabel", "join": "--"}
@@ -14513,6 +14514,9 @@
           "source": {"650": {"ind1": " ", "ind2": "7",
             "subfields": [{"a": "Fysik"}, {"2": "sao"}, {"9": "Fack"}]}
           },
+          "normalized": {"650": {"ind1": " ", "ind2": "7",
+            "subfields": [{"a": "Fysik"}, {"2": "sao"}]}
+          },
           "result": {"mainEntity": {
             "instanceOf": {
               "@type": "Text",
@@ -15189,6 +15193,10 @@
             {"a": "Deckare"},
             {"2": "saogf"},
             {"9": "Skon"}
+          ]}},
+          "normalized": {"655": {"ind1": " ", "ind2": "7", "subfields": [
+            {"a": "Deckare"},
+            {"2": "saogf"}
           ]}},
           "result": {"mainEntity": {
             "instanceOf": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -14511,7 +14511,7 @@
       "_spec": [
         {
           "source": {"650": {"ind1": " ", "ind2": "7",
-            "subfields": [{"a": "Fysik"}, {"2": "sao"}]}
+            "subfields": [{"a": "Fysik"}, {"2": "sao"}, {"9": "Fack"}]}
           },
           "result": {"mainEntity": {
             "instanceOf": {
@@ -14525,6 +14525,10 @@
                     "@type": "ConceptScheme",
                     "code": "sao"
                   },
+                  "inCollection": [{
+                    "@type": "TermCollection",
+                    "code": "Fack"
+                  }],
                   "prefLabel": "Fysik"
                 }
               ]
@@ -15181,7 +15185,11 @@
       "subfieldOrder": "8 6 a x z y v 0 2 1",
       "_spec": [
         {
-          "source": {"655": {"ind1": " ", "ind2": "7", "subfields": [{"a": "Deckare"}, {"2": "saogf"}]}},
+          "source": {"655": {"ind1": " ", "ind2": "7", "subfields": [
+            {"a": "Deckare"},
+            {"2": "saogf"},
+            {"9": "Skon"}
+          ]}},
           "result": {"mainEntity": {
             "instanceOf": {
               "@type": "Text",
@@ -15194,6 +15202,10 @@
                     "@type": "ConceptScheme",
                     "code": "saogf"
                   },
+                  "inCollection": [{
+                    "@type": "TermCollection",
+                    "code": "Skon"
+                  }],
                   "prefLabel": "Deckare"
                 }
               ]


### PR DESCRIPTION
## Description:
Disable revert of inCollection (650/655 subfield 9)

## Checklist:
- [x] I have built integ tests. `gradlew integTest`

### Tickets involved
https://jira.kb.se/browse/LXL-3096

### Solves
Local library systems can not handle subfield 9 in field 650 and 655.

