### PR TITLE
Feature/shrink index

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -355,9 +355,15 @@ class Whelk implements Storage {
         }
     }
 
-    void embellish(Document document) {
+    void embellish(Document document, List<String> levels = null) {
         def docsByIris = { List<String> iris -> bulkLoad(iris).values().collect{ it.data } }
-        new Embellisher(jsonld, docsByIris, storage.&getCards, relations.&getByReverse).embellish(document)
+        Embellisher e = new Embellisher(jsonld, docsByIris, storage.&getCards, relations.&getByReverse)
+
+        if(levels) {
+            e.setEmbellishLevels(levels)
+        }
+
+        e.embellish(document)
     }
 
     Document loadEmbellished(String systemId) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -254,6 +254,13 @@ class ElasticSearch {
 
     private static Map recordToChip(Whelk whelk, Map thing) {
         if (thing[JsonLd.GRAPH_KEY]) {
+
+            // FIXME: this is a temporary workaround for documents from definitions that are missing @type in record.
+            //  Remove when LXL-3098 is fixed.
+            if (!thing[JsonLd.GRAPH_KEY][0][JsonLd.TYPE_KEY]) {
+                thing[JsonLd.GRAPH_KEY][0][JsonLd.TYPE_KEY] = 'Record'
+            }
+
             thing[JsonLd.GRAPH_KEY][0] = whelk.jsonld.toChip(thing[JsonLd.GRAPH_KEY][0])
         }
         thing

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -199,7 +199,7 @@ class ElasticSearch {
         Document copy = document.clone()
 
         if (collection != "hold") {
-            whelk.embellish(copy)
+            whelk.embellish(copy, ['chips'])
         }
 
         log.debug("Framing ${document.getShortId()}")

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -230,21 +230,13 @@ class ElasticSearch {
             }
         }
 
-        /*
-        // FIXME: temporary fix to keep number of elastic field in check
-        // Shrink all meta properties except for root document
-        DocumentUtil.findKey(framed, 'meta') { value, path ->
-            if (path.size() > 1 && value instanceof Map) {
-                Map meta = (Map) value
-                meta.remove('created')
-                meta.remove('modified')
-                meta.remove('recordStatus')
-                meta.remove('mainEntity')
+        Set languageContainers = whelk.jsonld.langContainerAlias.values() as Set
+        Set languagesToKeep = ['sv', 'en'] // TODO: where do we define these?
+        DocumentUtil.traverse(framed, { value, path ->
+            if (path && path.last() in languageContainers) {
+                return new DocumentUtil.Replace(value.findAll {lang, str -> lang in languagesToKeep})
             }
-            return DocumentUtil.NOP
-        }
-
-         */
+        })
 
         log.trace("Framed data: ${framed}")
 

--- a/whelktool/scripts/examples/updatebyid.groovy
+++ b/whelktool/scripts/examples/updatebyid.groovy
@@ -1,0 +1,5 @@
+selectByIds([
+    'https://libris-dev.kb.se/j2vzn03v08lfhrm',
+]) {
+    it.scheduleSave()
+}


### PR DESCRIPTION
See LXL-3081

Remove a lot of stuff from the ES index.

Summary of changes:
* Only embellish one level with chips for ES index. (IS IT ENOUGH?)
  * (because of LXL-3094, `instanceOf` is included "for free")
* Only include Swedish and English xByLang
* No _str in `meta` of embellishments

**Example**
Before:
http://kblxes01.kb.local:9200/libris_qa/bib/j2vzn03v08lfhrm
~972 fields (`curl ... | jq ._source | grep ':' | wc -l`)
27647 bytes

After:
http://es01-dev.libris.kb.se:9200/libris_dev/bib/j2vzn03v08lfhrm
~388 fields
11830 bytes
