### PR TITLE
Add uriToken for musicFormat and marc:parts

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -2890,7 +2890,7 @@
         "[3]": {
           "link": "musicFormat",
           "uriTemplate": "https://id.kb.se/marc/MusicFormatType-{_}",
-          "matchUriToken": "^[_abcdeghijklm]$"
+          "matchUriToken": "^[abcdeghijklmp]$"
         },
         "[4]": {
           "link": "marc:parts",
@@ -4461,12 +4461,14 @@
         "[20]": {
           "aboutEntity": "?work",
           "link": "musicFormat",
-          "uriTemplate": "https://id.kb.se/marc/MusicFormatType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MusicFormatType-{_}",
+          "matchUriToken": "^[abcdeghijklmp]$"
         },
         "[21]": {
           "aboutEntity": "?work",
           "link": "marc:parts",
-          "uriTemplate": "https://id.kb.se/marc/MusicPartsType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MusicPartsType-{_}",
+          "matchUriToken": "^[def]$"
         },
         "[22]": {
           "aboutEntity": "?work",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4400,7 +4400,8 @@
         "[18] [19] [20] [21]": {
           "TODO:aboutEntity": "?cartographic",
           "addLink": "marc:relief",
-          "uriTemplate": "https://id.kb.se/marc/MapsReliefType-{_}"
+          "uriTemplate": "https://id.kb.se/marc/MapsReliefType-{_}",
+          "matchUriToken": "^[abcdefgijkmz]$"
         },
         "[22:24]": {
           "link": "projection",


### PR DESCRIPTION
- [x] run integTest on Marcframe.

Making sure that only valid tokens get mapped to a URI in musicFormat and marc:parts.
... and MapsReliefType

see also https://github.com/libris/librisxl/pull/588