### PR TITLE
Feature/revert linkfield agent

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2640,7 +2640,7 @@ class MarcSubFieldHandler extends ConversionPart {
 
         infer = subDfn.infer == true
 
-        if (subDfn.splitValuePattern || subDfn.splitValueProperties) {
+        if (subDfn.splitValueProperties) {
             /*TODO: assert subDfn.splitValuePattern=~ /^\^.+\$$/,
                    'For explicit safety, these patterns must start with ^ and end with $' */
             // TODO: support repeatable?

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2640,11 +2640,12 @@ class MarcSubFieldHandler extends ConversionPart {
 
         infer = subDfn.infer == true
 
-        if (subDfn.splitValuePattern) {
+        if (subDfn.splitValuePattern || subDfn.splitValueProperties) {
             /*TODO: assert subDfn.splitValuePattern=~ /^\^.+\$$/,
                    'For explicit safety, these patterns must start with ^ and end with $' */
             // TODO: support repeatable?
-            splitValuePattern = Pattern.compile(subDfn.splitValuePattern)
+            if (subDfn.splitValuePattern)
+                splitValuePattern = Pattern.compile(subDfn.splitValuePattern)
             splitValueProperties = subDfn.splitValueProperties
             rejoin = subDfn.rejoin
             joinEnd = subDfn.joinEnd

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18450,6 +18450,50 @@
               "seriesStatement": ["Statens offentliga utredningar"]
             }]
           }}
+        },
+        {
+          "name": "Revert linked Meeting entity containing name and additionalName to $a",
+          "normalized": {"777": {"ind1": "0", "ind2": " ", "subfields": [
+            {"a": "Paris, Peace Conference"}
+          ]}},
+          "result": {"mainEntity": {
+            "issuedWith": [{
+              "@type": "Instance",
+              "instanceOf": {
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Meeting",
+                    "name": "Paris",
+                    "additionalName": "Peace Conference"
+                  }
+                }]
+              }
+            }]
+          }}
+        },
+        {
+          "name": "Revert linked Meeting entity containing name and marc:subordinateUnit to $a",
+          "normalized": {"777": {"ind1": "0", "ind2": " ", "subfields": [
+            {"a": "Delegation from Sweden, World Peace Conference"}
+          ]}},
+          "result": {"mainEntity": {
+            "issuedWith": [{
+              "@type": "Instance",
+              "instanceOf": {
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Meeting",
+                    "name": "World Peace Conference",
+                    "marc:subordinateUnit" : [ "Delegation from Sweden" ]
+                  }
+                }]
+              }
+            }]
+          }}
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17903,6 +17903,31 @@
               }
             }]
           }}
+        },
+        {
+          "name": "Linked entity containing marc:subordinateUnit should revert to subfield $a",
+          "normalized": {"773": {"ind1": "0", "ind2": "0", "subfields": [
+            {"a": "Institutionen för psykologi"}
+          ]}},
+          "result": {"mainEntity": {
+            "isPartOf": [{
+              "@type": "Instance",
+              "instanceOf": {
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Organization",
+                    "marc:subordinateUnit": ["Institutionen för psykologi"],
+                    "isPartOf": {
+                      "@type": "Organization",
+                      "name": "Uppsala universitet."
+                    }
+                  }
+                }]
+              }
+            }]
+          }}
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1430,8 +1430,9 @@
       },
       "$a": {
         "about": "_:agent",
-        "property": "name",
-        "splitValueProperties": ["familyName", "givenName"], "rejoin": ", ",
+        "property": "label",
+        "splitValueProperties": ["familyName", "givenName"],
+        "rejoin": ", ",
         "infer": true,
         "TODO:targetMatch": "1xx"
       },
@@ -17556,7 +17557,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Beckmann, Max"
+                    "label": "Beckmann, Max"
                   }
                 }]
               }]
@@ -17589,7 +17590,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Hellström, Lennart, 1942-"
+                    "label": "Hellström, Lennart, 1942-"
                   }
                 }],
                 "hasInstance": {
@@ -17740,7 +17741,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Robson, James,"
+                    "label": "Robson, James,"
                   }
                 }]
               }
@@ -17798,7 +17799,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Olofsson, Jonas"
+                    "label": "Olofsson, Jonas"
                   }
                 }],
                 "hasInstance": {
@@ -17991,7 +17992,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Bonnevie, Kristine"
+                    "label": "Bonnevie, Kristine"
                   }
                 }],
                 "hasInstance": {
@@ -18114,7 +18115,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Olsson, Jan"
+                    "label": "Olsson, Jan"
                   }
                 }]
               }
@@ -18265,7 +18266,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Andersson, Lennart"
+                    "label": "Andersson, Lennart"
                   }
                 }]
               },
@@ -18302,7 +18303,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Adam, von Bremen, 11th cent."
+                    "label": "Adam, von Bremen, 11th cent."
                   }
                 }],
                 "hasTitle": [{
@@ -18385,7 +18386,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Gerland, Gunilla"
+                    "label": "Gerland, Gunilla"
                   }
                 }]
               }
@@ -18426,7 +18427,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "name": "Andersson, Jan"
+                    "label": "Andersson, Jan"
                   }
                 }]
               },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1428,7 +1428,13 @@
         "NOTE": "After using inventory and no contradictions from local libraries, it has been decided to remove this property with release 1.16",
         "marcDefault": "0"
       },
-      "$a": {"about": "_:agent", "property": "label", "infer": true, "TODO:targetMatch": "1xx"},
+      "$a": {
+        "about": "_:agent",
+        "property": "name",
+        "splitValueProperties": ["familyName", "givenName"], "rejoin": ", ",
+        "infer": true,
+        "TODO:targetMatch": "1xx"
+      },
       "$b": {"about": "_:instance", "property": "editionStatement", "ignoreOnRevert": true, "TODO:targetMatch": "250"},
       "$d": {"about": "_:instance", "property": "provisionActivityStatement", "TODO:targetMatch": "260$c"},
       "$h": {"about": "_:instance", "addLink": "extent", "resourceType": "Extent", "property": "label", "ignoreOnRevert": true, "NOTE:marc-repeatable": false},
@@ -17550,7 +17556,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Beckmann, Max"
+                    "name": "Beckmann, Max"
                   }
                 }]
               }]
@@ -17583,7 +17589,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Hellström, Lennart, 1942-"
+                    "name": "Hellström, Lennart, 1942-"
                   }
                 }],
                 "hasInstance": {
@@ -17734,7 +17740,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Robson, James,"
+                    "name": "Robson, James,"
                   }
                 }]
               }
@@ -17792,7 +17798,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Olofsson, Jonas"
+                    "name": "Olofsson, Jonas"
                   }
                 }],
                 "hasInstance": {
@@ -17875,6 +17881,28 @@
               }]
             }
           }}
+        },
+        {
+          "name": "Linked entity containing familyName/givenName should revert to subfield $a",
+          "normalized": {"773": {"ind1": "0", "ind2": "0", "subfields": [
+            {"a": "Sandemo, Margit"}
+          ]}},
+          "result": {"mainEntity": {
+            "isPartOf": [{
+              "@type": "Instance",
+              "instanceOf": {
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Person",
+                    "familyName": "Sandemo",
+                    "givenName": "Margit"
+                  }
+                }]
+              }
+            }]
+          }}
         }
       ]
     },
@@ -17938,7 +17966,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Bonnevie, Kristine"
+                    "name": "Bonnevie, Kristine"
                   }
                 }],
                 "hasInstance": {
@@ -18061,7 +18089,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Olsson, Jan"
+                    "name": "Olsson, Jan"
                   }
                 }]
               }
@@ -18212,7 +18240,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Andersson, Lennart"
+                    "name": "Andersson, Lennart"
                   }
                 }]
               },
@@ -18249,7 +18277,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Adam, von Bremen, 11th cent."
+                    "name": "Adam, von Bremen, 11th cent."
                   }
                 }],
                 "hasTitle": [{
@@ -18332,7 +18360,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Gerland, Gunilla"
+                    "name": "Gerland, Gunilla"
                   }
                 }]
               }
@@ -18373,7 +18401,7 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Agent",
-                    "label": "Andersson, Jan"
+                    "name": "Andersson, Jan"
                   }
                 }]
               },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18453,11 +18453,11 @@
           }}
         },
         {
-          "name": "Revert linked Meeting entity containing name and additionalName to $a",
+          "TODO": "Revert linked Meeting entity containing name and additionalName to $a - Not in place yet. Only reverts one of them",
           "normalized": {"777": {"ind1": "0", "ind2": " ", "subfields": [
             {"a": "Paris, Peace Conference"}
           ]}},
-          "result": {"mainEntity": {
+          "TODO:result": {"mainEntity": {
             "issuedWith": [{
               "@type": "Instance",
               "instanceOf": {
@@ -18475,11 +18475,11 @@
           }}
         },
         {
-          "name": "Revert linked Meeting entity containing name and marc:subordinateUnit to $a",
+          "TODO": "Revert linked Meeting entity containing name and marc:subordinateUnit to $a - Not in place yet. Only reverts one of them",
           "normalized": {"777": {"ind1": "0", "ind2": " ", "subfields": [
             {"a": "Delegation from Sweden, World Peace Conference"}
           ]}},
-          "result": {"mainEntity": {
+          "TODO:result": {"mainEntity": {
             "issuedWith": [{
               "@type": "Instance",
               "instanceOf": {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -17919,6 +17919,27 @@
                   "@type": "PrimaryContribution",
                   "agent": {
                     "@type": "Organization",
+                    "marc:subordinateUnit": ["Institutionen för psykologi"]
+                  }
+                }]
+              }
+            }]
+          }}
+        },
+        {
+          "TODO": "Linked entity containing marc:subordinateUnit and isPartOf should revert to subfield $a",
+          "normalized": {"773": {"ind1": "0", "ind2": "0", "subfields": [
+            {"a": "Institutionen för psykologi, Uppsala universitet."}
+          ]}},
+          "TODO:result": {"mainEntity": {
+            "isPartOf": [{
+              "@type": "Instance",
+              "instanceOf": {
+                "@type": "Work",
+                "contribution": [{
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Organization",
                     "marc:subordinateUnit": ["Institutionen för psykologi"],
                     "isPartOf": {
                       "@type": "Organization",


### PR DESCRIPTION
## Checklist:
- [x] I have run the integ tests. `gradlew integTest`

## Description
Export fix: When linkfields (bib 760-78X) consist of a linked entity the agent might have different structure with familyName and givenName. This fixes that also these values ​​can be exported to subfield a.

### Tickets involved
[LXL-3063](https://jira.kb.se/browse/LXL-3063)

### Solves

Possible to export familyName and givenName for linkfields

### Related PR
https://github.com/libris/definitions/pull/198
