### PR TITLE
Add metrics for HikariCP

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2,6 +2,7 @@ package whelk.component
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
 import groovy.json.StringEscapeUtils
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
@@ -313,6 +314,7 @@ class PostgreSQLComponent implements Storage {
             config.setJdbcUrl(sqlUrl.replaceAll(":\\/\\/\\w+:*.*@", ":\\/\\/"))
             config.setDriverClassName(driverClass)
             config.setConnectionTimeout(0)
+            config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory())
 
             log.info("Connecting to sql database at ${config.getJdbcUrl()}, using driver $driverClass. Pool size: $maxPoolSize")
             URI connURI = new URI(sqlUrl.substring(5))


### PR DESCRIPTION
Also works for additional pools (e.g. "OuterPool").

Example output

`curl http://localhost:8180/metrics | grep hikari`
```
# HELP hikaricp_connection_timeout_total Connection timeout total count
# TYPE hikaricp_connection_timeout_total counter
hikaricp_connection_timeout_total{pool="HikariPool-1",} 0.0
# HELP hikaricp_active_connections Active connections
# TYPE hikaricp_active_connections gauge
hikaricp_active_connections{pool="HikariPool-1",} 0.0
# HELP hikaricp_idle_connections Idle connections
# TYPE hikaricp_idle_connections gauge
hikaricp_idle_connections{pool="HikariPool-1",} 16.0
# HELP hikaricp_pending_threads Pending threads
# TYPE hikaricp_pending_threads gauge
hikaricp_pending_threads{pool="HikariPool-1",} 0.0
# HELP hikaricp_connections The number of current connections
# TYPE hikaricp_connections gauge
hikaricp_connections{pool="HikariPool-1",} 16.0
# HELP hikaricp_max_connections Max connections
# TYPE hikaricp_max_connections gauge
hikaricp_max_connections{pool="HikariPool-1",} 16.0
# HELP hikaricp_min_connections Min connections
# TYPE hikaricp_min_connections gauge
hikaricp_min_connections{pool="HikariPool-1",} 16.0
# HELP hikaricp_connection_usage_millis Connection usage (ms)
# TYPE hikaricp_connection_usage_millis summary
hikaricp_connection_usage_millis{pool="HikariPool-1",quantile="0.5",} 17.0
hikaricp_connection_usage_millis{pool="HikariPool-1",quantile="0.95",} 24.0
hikaricp_connection_usage_millis{pool="HikariPool-1",quantile="0.99",} 43.0
hikaricp_connection_usage_millis_count{pool="HikariPool-1",} 771.0
hikaricp_connection_usage_millis_sum{pool="HikariPool-1",} 14651.0
# HELP hikaricp_connection_acquired_nanos Connection acquired time (ns)
# TYPE hikaricp_connection_acquired_nanos summary
hikaricp_connection_acquired_nanos{pool="HikariPool-1",quantile="0.5",} 0.0
hikaricp_connection_acquired_nanos{pool="HikariPool-1",quantile="0.95",} 0.0
hikaricp_connection_acquired_nanos{pool="HikariPool-1",quantile="0.99",} 1000000.0
hikaricp_connection_acquired_nanos_count{pool="HikariPool-1",} 771.0
hikaricp_connection_acquired_nanos_sum{pool="HikariPool-1",} 2.6E7
# HELP hikaricp_connection_creation_millis Connection creation (ms)
# TYPE hikaricp_connection_creation_millis summary
hikaricp_connection_creation_millis{pool="HikariPool-1",quantile="0.5",} 72.0
hikaricp_connection_creation_millis{pool="HikariPool-1",quantile="0.95",} 150.0
hikaricp_connection_creation_millis{pool="HikariPool-1",quantile="0.99",} 150.0
hikaricp_connection_creation_millis_count{pool="HikariPool-1",} 15.0
hikaricp_connection_creation_millis_sum{pool="HikariPool-1",} 1454.0
```