### PR TITLE
Feature/revert linkfield title

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2557,7 +2557,7 @@ class MarcSubFieldHandler extends ConversionPart {
     Pattern matchUriToken = null
     Pattern splitValuePattern
     List<String> splitValueProperties
-    List<String> allowedRevertTypes
+    List<String> allowedTypesOnRevert
     Pattern castPattern
     String castProperty
     String rejoin
@@ -2652,8 +2652,8 @@ class MarcSubFieldHandler extends ConversionPart {
             joinEnd = subDfn.joinEnd
             allowEmpty = subDfn.allowEmpty
         }
-        if (subDfn.allowedRevertTypes) {
-            allowedRevertTypes = subDfn.allowedRevertTypes
+        if (subDfn.allowedTypesOnRevert) {
+            allowedTypesOnRevert = subDfn.allowedTypesOnRevert
         }
         if (subDfn.castPattern) {
             castPattern = Pattern.compile(subDfn.castPattern)
@@ -2882,7 +2882,7 @@ class MarcSubFieldHandler extends ConversionPart {
                 continue
             }
 
-            if (allowedRevertTypes) {
+            if (allowedTypesOnRevert) {
 
                 String revertForLink
                 if (link) {
@@ -2897,19 +2897,19 @@ class MarcSubFieldHandler extends ConversionPart {
                 def wrappingEntity = getWrappingEntity(entity, data, revertForLink)
                 if (wrappingEntity) {
                     String entityType = entity["@type"]
-                    if (!allowedRevertTypes.contains(entityType)) {
+                    if (!allowedTypesOnRevert.contains(entityType)) {
                         continue
                     }
 
-                    def pos = allowedRevertTypes.indexOf(entityType)
+                    def pos = allowedTypesOnRevert.indexOf(entityType)
 
                     // Get all existing @type values
                     List existingTypes = wrappingEntity.getValue().findResults { (String) it["@type"]?.value }
-                    List allowedExistingTypes = existingTypes.intersect(allowedRevertTypes)
+                    List allowedExistingTypes = existingTypes.intersect(allowedTypesOnRevert)
 
                     //If pos already 0 we are good to go - else check if a more appropriate type exists
                     if ((pos != 0) && allowedExistingTypes.size() > 1) {
-                        if (allowedExistingTypes.any { allowedRevertTypes.indexOf(it) < pos } ) {
+                        if (allowedExistingTypes.any { allowedTypesOnRevert.indexOf(it) < pos } ) {
                             continue
                         }
                     }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1446,7 +1446,7 @@
       "$t": {
         "about": "_:title",
         "property": "mainTitle",
-        "allowedRevertTypes": ["KeyTitle", "Title"],
+        "allowedTypesOnRevert": ["KeyTitle", "Title"],
         "TODO:targetMatch": "222, 245"
       },
       "$x": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISSN", "property": "value", "TODO:targetMatch": "022"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -16702,35 +16702,6 @@
               ]
             }
           }}
-        },
-        {
-          "source": {
-            "710": {"ind1": "2", "ind2": " ", "subfields": [
-              {"a": "Teologiska högskolan Stockholm."},
-              {"b": "Avdelningen för teologi."},
-              {"4": "org"}
-            ]}},
-          "result": {"mainEntity": {
-            "instanceOf": {
-              "@type": "Text",
-              "contribution" : [ {
-                "@type" : "Contribution",
-                "agent" : {
-                  "@type" : "Organization",
-                  "isPartOf" : {
-                    "@type" : "Organization",
-                    "name" : "Teologiska högskolan Stockholm."
-                  },
-                  "marc:subordinateUnit" : [ "Avdelningen för teologi." ]
-                },
-                "role" : [ {
-                  "@id" : "https://id.kb.se/relator/org",
-                  "@type" : "Role",
-                  "code" : "org"
-                } ]
-              } ]
-            }
-          }}
         }
       ]
     },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1446,8 +1446,8 @@
       "$t": {
         "about": "_:title",
         "property": "mainTitle",
-        "TODO:revertAllowedType": ["KeyTitle", "Title"],
-        "TODO:?revertOnLink": "hasTitle",
+        "allowedRevertTypes": ["KeyTitle", "Title"],
+        "revertForLink": "hasTitle",
         "TODO:targetMatch": "222, 245"
       },
       "$x": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISSN", "property": "value", "TODO:targetMatch": "022"},
@@ -16703,6 +16703,35 @@
               ]
             }
           }}
+        },
+        {
+          "source": {
+            "710": {"ind1": "2", "ind2": " ", "subfields": [
+              {"a": "Teologiska högskolan Stockholm."},
+              {"b": "Avdelningen för teologi."},
+              {"4": "org"}
+            ]}},
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "contribution" : [ {
+                "@type" : "Contribution",
+                "agent" : {
+                  "@type" : "Organization",
+                  "isPartOf" : {
+                    "@type" : "Organization",
+                    "name" : "Teologiska högskolan Stockholm."
+                  },
+                  "marc:subordinateUnit" : [ "Avdelningen för teologi." ]
+                },
+                "role" : [ {
+                  "@id" : "https://id.kb.se/relator/org",
+                  "@type" : "Role",
+                  "code" : "org"
+                } ]
+              } ]
+            }
+          }}
         }
       ]
     },
@@ -18416,24 +18445,92 @@
           }}
         },
         {
-          "name": "Should only revert KeyTitle",
-          "normalized": {"776": {"ind1": "0", "ind2": "8", "subfields": [
-            {"t": "Plattform 1"}
-          ]}},
+          "name": "Should only revert KeyTitle as 776 $t",
+          "normalized": [
+            {"245": {"ind1": "1", "ind2": "0", "subfields": [{"a": "Instance title"}]}},
+            {"776": {"ind1": "0", "ind2": "8", "subfields": [{"t": "Title 1"}, {"z": "9783527404704"}]}}
+          ],
           "result": {"mainEntity": {
+            "hasTitle": [{
+              "@type": "Title",
+              "mainTitle": "Instance title"
+            }],
             "otherPhysicalFormat": [{
               "@type": "Instance",
               "hasTitle": [{
                 "@type": "Title",
-                "mainTitle": "Plattform 2",
+                "mainTitle": "Title 2",
                 "subtitle": "för dig som arbetar med kakel och klinker"
               },{
                 "@type": "KeyTitle",
-                "mainTitle": "Plattform 1",
+                "mainTitle": "Title 1",
                 "qualifier": ["(Stockholm. Online)"]
               },{
                 "@type": "VariantTitle",
-                "mainTitle": "Plattform 3"
+                "mainTitle": "Title 3"
+              }],
+              "identifiedBy": [{
+                "@type": "ISBN",
+                "value": "9783527404704"
+              }]
+            }]
+          }}
+        },
+        {
+          "name": "Should only revert Title as 776 $t",
+          "normalized": [
+            {"245": {"ind1": "1", "ind2": "0", "subfields": [{"a": "Instance title"}]}},
+            {"776": {"ind1": "0", "ind2": "8", "subfields": [{"t": "Title 2"}]}}
+          ],
+          "result": {"mainEntity": {
+            "hasTitle": [{
+              "@type": "Title",
+              "mainTitle": "Instance title"
+            }],
+            "otherPhysicalFormat": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Title 2",
+                "subtitle": "för dig som arbetar med kakel och klinker"
+              },{
+                "@type": "SomeOtherTitle",
+                "mainTitle": "Title 1",
+                "qualifier": ["(Stockholm. Online)"]
+              },{
+                "@type": "VariantTitle",
+                "mainTitle": "Title 3"
+              }]
+            }]
+          }}
+        },
+        {
+          "name": "No appropriate title to revert - No 776 $t",
+          "normalized": [
+            {"245": {"ind1": "1", "ind2": "0", "subfields": [{"a": "Instance title"}]}},
+            {"776": {"ind1": "0", "ind2": "8", "subfields": [{"z": "9783527404704"}]}}
+          ],
+          "result": {"mainEntity": {
+            "hasTitle": [{
+              "@type": "Title",
+              "mainTitle": "Instance title"
+            }],
+            "otherPhysicalFormat": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "SpineTitle",
+                "mainTitle": "Title 2"
+              },{
+                "@type": "SomeOtherTitle",
+                "mainTitle": "Title 1",
+                "qualifier": ["(Stockholm. Online)"]
+              },{
+                "@type": "VariantTitle",
+                "mainTitle": "Title 3"
+              }],
+              "identifiedBy": [{
+                "@type": "ISBN",
+                "value": "9783527404704"
               }]
             }]
           }}

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1447,7 +1447,6 @@
         "about": "_:title",
         "property": "mainTitle",
         "allowedRevertTypes": ["KeyTitle", "Title"],
-        "revertForLink": "hasTitle",
         "TODO:targetMatch": "222, 245"
       },
       "$x": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISSN", "property": "value", "TODO:targetMatch": "022"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1443,7 +1443,13 @@
       "$n": {"about": "_:instance", "addLink": "hasNote", "resourceType": "Note", "property": "label",  "ignoreOnRevert": true},
       "$o": {"NOTE:subfield-count (Libris)": 0, "NOTE": "Cannot ignore this field since we import Mimer data with $o (We have lost $o data between 1.14.0 and 1.15.0). See LXL-1517"},
       "$s": {"about": "_:workTitle", "property": "mainTitle", "TODO:targetMatch": "240"},
-      "$t": {"about": "_:title", "property": "mainTitle", "TODO:targetMatch": "222, 245"},
+      "$t": {
+        "about": "_:title",
+        "property": "mainTitle",
+        "TODO:revertAllowedType": ["KeyTitle", "Title"],
+        "TODO:?revertOnLink": "hasTitle",
+        "TODO:targetMatch": "222, 245"
+      },
       "$x": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISSN", "property": "value", "TODO:targetMatch": "022"},
       "$y": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "CODEN", "property": "value", "TODO:targetMatch": "030"},
       "$w": {"aboutNew": "_:describedBy", "property": "controlNumber"},
@@ -18405,6 +18411,29 @@
                 "@type": "Title",
                 "mainTitle": "Entangled world",
                 "qualifier": "Original"
+              }]
+            }]
+          }}
+        },
+        {
+          "name": "Should only revert KeyTitle",
+          "normalized": {"776": {"ind1": "0", "ind2": "8", "subfields": [
+            {"t": "Plattform 1"}
+          ]}},
+          "result": {"mainEntity": {
+            "otherPhysicalFormat": [{
+              "@type": "Instance",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Plattform 2",
+                "subtitle": "för dig som arbetar med kakel och klinker"
+              },{
+                "@type": "KeyTitle",
+                "mainTitle": "Plattform 1",
+                "qualifier": ["(Stockholm. Online)"]
+              },{
+                "@type": "VariantTitle",
+                "mainTitle": "Plattform 3"
               }]
             }]
           }}

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -1415,6 +1415,7 @@
         "_:title": {
           "about": "_:instance",
           "addLink": "hasTitle", "resourceType": "Title",
+          "allowedTypesOnRevert": ["KeyTitle", "Title"],
           "embedded": true
         },
         "_:describedBy": {
@@ -1446,7 +1447,6 @@
       "$t": {
         "about": "_:title",
         "property": "mainTitle",
-        "allowedTypesOnRevert": ["KeyTitle", "Title"],
         "TODO:targetMatch": "222, 245"
       },
       "$x": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISSN", "property": "value", "TODO:targetMatch": "022"},


### PR DESCRIPTION
## Checklist
- [x] I have run integTest

## Description
For link fields (bib 760-78X): 
- Only one title should be exported to subfield t
- Only certain types are allowed to be exported to subfield t

The following should be exported (in order):
1. `hasTitle "@type": "KeyTitle"`
2. If no "KeyTitle", `hasTitle "@type": "Title"` should be exported
3. Other types of title should be ignored.

## Issue
[LXL-2308](https://jira.kb.se/browse/LXL-2308)