### PR TITLE
Add mappings for co-author to blank role script

### DIFF
--- a/whelktool/scripts/cleanups/2020/03/lxl-3056-link-blank-roles.groovy
+++ b/whelktool/scripts/cleanups/2020/03/lxl-3056-link-blank-roles.groovy
@@ -71,7 +71,15 @@ linker.addSubstitutions([
         'valokuvaaja (ekpressio)'                  : 'pht',  // Finnish: Photographer (expression)
         '(verfasser)'                              : 'aut',
 
-
+        'joint author' : 'aut',
+        'jt. author'   : 'aut',
+        'jt. auth'     : 'aut',
+        'coaut'        : 'aut',
+        'coauthor'     : 'aut',
+        'medförfattare': 'aut',
+        'medforf'      : 'aut',
+        'medforfatter' : 'aut',
+        
         '0th'     : 'oth', // Other
         '4aut'    : 'aut', // Author
         '4 aut'   : 'aut', // Author


### PR DESCRIPTION
Can be run after LXL-3099 'Add script for adding missing contribution.role "author"' (https://github.com/libris/librisxl/pull/601)