### PR TITLE
Feature/ignore on revert fixed fields

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1335,6 +1335,7 @@ class MarcFixedFieldHandler {
                 columns << new Column(this, obj, colNum.first, colNum.second,
                         obj['itemPos'] ?: colNums.size() > 1 ? i : null,
                         obj['fixedDefault'],
+                        obj['ignoreOnRevert'],
                         obj['matchAsDefault'])
 
                 if (colNum.second > fieldSize) {
@@ -1402,11 +1403,12 @@ class MarcFixedFieldHandler {
         int end
         Integer itemPos
         String fixedDefault
+        Boolean ignoreOnRevert = null
         Pattern matchAsDefault
         MarcFixedFieldHandler fixedFieldHandler
 
         Column(MarcFixedFieldHandler fixedFieldHandler, fieldDfn, int start, int end,
-               itemPos, fixedDefault, matchAsDefault = null) {
+               itemPos, fixedDefault, ignoreOnRevert, matchAsDefault = null) {
             super(fixedFieldHandler.ruleSet, "$fixedFieldHandler.tag-$start-$end", fieldDfn)
             this.fixedFieldHandler = fixedFieldHandler
             assert start > -1 && end >= start
@@ -1414,6 +1416,8 @@ class MarcFixedFieldHandler {
             this.end = end
             this.itemPos = (Integer) itemPos
             this.fixedDefault = fixedDefault
+            this.ignoreOnRevert = ignoreOnRevert
+
             if (fixedDefault) {
                 assert this.fixedDefault.size() == this.width
             }
@@ -1454,6 +1458,9 @@ class MarcFixedFieldHandler {
         @CompileStatic(SKIP)
         def revert(Map state, Map data) {
             def v = super.revert(state, data, null)
+            if (ignoreOnRevert && fixedDefault)
+                return fixedDefault
+
             if ((v == null || v.every { it == null }) && fixedDefault)
                 return fixedDefault
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1403,12 +1403,12 @@ class MarcFixedFieldHandler {
         int end
         Integer itemPos
         String fixedDefault
-        Boolean ignoreOnRevert = null
+        Boolean ignoreOnRevert
         Pattern matchAsDefault
         MarcFixedFieldHandler fixedFieldHandler
 
         Column(MarcFixedFieldHandler fixedFieldHandler, fieldDfn, int start, int end,
-               itemPos, fixedDefault, ignoreOnRevert, matchAsDefault = null) {
+               itemPos, fixedDefault, ignoreOnRevert = null, matchAsDefault = null) {
             super(fixedFieldHandler.ruleSet, "$fixedFieldHandler.tag-$start-$end", fieldDfn)
             this.fixedFieldHandler = fixedFieldHandler
             assert start > -1 && end >= start

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3478,6 +3478,7 @@
           "z": null
         },
         "reverseTokenMapOverrides": {
+          "NOTE": "N.B. Should not set to '|' unless all other pos are set to '|'. When all pos are set to '|' no 007 will be created by revert.",
           "TextInstance": "|"
         }
       },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3476,6 +3476,9 @@
           "t": "TextInstance",
           "v": "VideoRecording",
           "z": null
+        },
+        "reverseTokenMapOverrides": {
+          "TextInstance": "|"
         }
       },
       "tokenTypeMap": "[0]",
@@ -3838,7 +3841,9 @@
           "NOTE:LC": "hasNote",
           "link": "marc:motionPicCompleteness",
           "uriTemplate": "https://id.kb.se/marc/MotionPicCompletenessType-{_}",
-          "matchUriToken": "^[0123ci]$"
+          "matchUriToken": "^[0123ci]$",
+          "TODO:ignoreOnRevert": true,
+          "TODO:fixedDefault": " "
         },
         "[17:23]": {
           "NOTE:LC": "17-22 - Film inspection date - ignore",
@@ -3965,6 +3970,7 @@
           "addLink": "carrierType",
           "uriTemplate": "https://id.kb.se/marc/TextMaterialType-{_}",
           "matchUriToken": "^[abcd]$",
+          "ignoreOnRevert": true,
           "silentRevert": false
         }
       },
@@ -4207,9 +4213,9 @@
           }
         },
         {
-          "name": "@type TextInstance + RegularPrint",
+          "name": "@type TextInstance + RegularPrint should not be reverted",
           "source": {"007":"ta"},
-          "normalized": {"007":"ta                     "},
+          "normalized": [],
           "result": {
             "mainEntity": {
               "@type": "TextInstance",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3559,7 +3559,8 @@
         "[10]": {
           "link": "marc:qATarget",
           "uriTemplate": "https://id.kb.se/marc/ComputerQATargetType-{_}",
-          "matchUriToken": "^[ap]$"
+          "matchUriToken": "^[ap]$",
+          "ignoreOnRevert": true
         },
         "[11]": {
           "link": "marc:antecedent",
@@ -4077,14 +4078,15 @@
           }
         },
         {
-          "name": "@type Electronic + OpticalDisc",
-          "source": {"007":"co |g|   |||||"},
+          "name": "@type Electronic + OpticalDisc + TestImagesEtcPresent",
+          "source": {"007":"co |g|   |p|||"},
           "normalized": {"007":"co |g|   |||||         "},
           "result": {
             "mainEntity": {
               "@type": "Electronic",
               "carrierType": [{"@id": "https://id.kb.se/marc/ComputerMaterialType-o"}],
-              "hasDimensions": {"@id": "https://id.kb.se/marc/ComputerDimensionsType-g"}
+              "hasDimensions": {"@id": "https://id.kb.se/marc/ComputerDimensionsType-g"},
+              "marc:qATarget": {"@id": "https://id.kb.se/marc/ComputerQATargetType-p"}
             }
           }
         },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3838,12 +3838,10 @@
           "fixedDefault": "|"
         },
         "[16]": {
-          "NOTE:LC": "hasNote",
-          "link": "marc:motionPicCompleteness",
+          "link": "hasNote",
           "uriTemplate": "https://id.kb.se/marc/MotionPicCompletenessType-{_}",
           "matchUriToken": "^[0123ci]$",
-          "TODO:ignoreOnRevert": true,
-          "TODO:fixedDefault": " "
+          "ignoreOnRevert": true
         },
         "[17:23]": {
           "NOTE:LC": "17-22 - Film inspection date - ignore",
@@ -4191,11 +4189,11 @@
         {
           "name": "@type MovingImageInstance + Incomplete",
           "source": {"007":"m| |||||||||||||i"},
-          "normalized": {"007":"m| |||||||||||||i||||||"},
+          "normalized": {"007":"m| ||||||||||||||||||||"},
           "result": {
             "mainEntity": {
               "@type": "MovingImageInstance",
-              "marc:motionPicCompleteness": {
+              "hasNote": {
                 "@id" : "https://id.kb.se/marc/MotionPicCompletenessType-i"
               }
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3469,7 +3469,7 @@
           "h": "Microform",
           "k": "StillImageInstance",
           "m": "MovingImageInstance",
-          "o": "KitInstance",
+          "o": null,
           "q": "NotatedMusicInstance",
           "r": null,
           "s": "SoundRecording",
@@ -3853,9 +3853,7 @@
       },
       "KitInstance": {
         "[1]": {
-          "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
-          "silentRevert": false
+          "ignored": true
         }
       },
       "NotatedMusicInstance": {
@@ -4158,11 +4156,9 @@
         {
           "name": "@type KitInstance",
           "source": {"007":"o|"},
-          "normalized": {"007":"o|                     "},
+          "normalized": [],
           "result": {
-            "mainEntity": {
-              "@type": "KitInstance"
-            }
+            "mainEntity": {}
           }
         },
         {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3470,7 +3470,7 @@
           "k": "StillImageInstance",
           "m": "MovingImageInstance",
           "o": null,
-          "q": "NotatedMusicInstance",
+          "q": null,
           "r": null,
           "s": "SoundRecording",
           "t": "TextInstance",
@@ -3858,10 +3858,7 @@
       },
       "NotatedMusicInstance": {
         "[1]": {
-          "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
-          "TODO:tokenMap? (empty, just as KitMaterialType)": "NotatedMusicMaterialType",
-          "silentRevert": false
+          "ignored": true
         }
       },
       "RemoteSensingImage": {
@@ -4164,11 +4161,9 @@
         {
           "name": "@type NotatedMusicInstance",
           "source": {"007":"q|"},
-          "normalized": {"007":"q|                     "},
+          "normalized": [],
           "result": {
-            "mainEntity": {
-              "@type": "NotatedMusicInstance"
-            }
+            "mainEntity": {}
           }
         },
         {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -3471,7 +3471,7 @@
           "m": "MovingImageInstance",
           "o": "KitInstance",
           "q": "NotatedMusicInstance",
-          "r": "RemoteSensingImage",
+          "r": null,
           "s": "SoundRecording",
           "t": "TextInstance",
           "v": "VideoRecording",
@@ -3868,12 +3868,8 @@
       },
       "RemoteSensingImage": {
         "NOTE:LC": "007--REMOTE-SENSING IMAGE - nac",
-        "TODO": "drop this gracefully...",
         "[1]": {
-          "addLink": "carrierType",
-          "uriTemplate": "https://id.kb.se/marc/KitMaterialType-{_}",
-          "TODO:tokenMap? (empty, just as KitMaterialType)": "RemoteSensingImageMaterialType",
-          "silentRevert": false
+          "ignored": true
         },
         "[2]": null,
         "[3]": {
@@ -4182,11 +4178,9 @@
         {
           "name": "@type RemoteSensingImage",
           "source": {"007":"r| |||||||"},
-          "normalized": {"007":"r| |||||||             "},
+          "normalized": [],
           "result": {
-            "mainEntity": {
-              "@type": "RemoteSensingImage"
-            }
+            "mainEntity": {}
           }
         },
         {


### PR DESCRIPTION
## Checklist
- [x] I have run integTest
- [x] I have added/updated specs

## Description
1. Add functionality to be able to set ignoreOnRevert for certain positions in fixed fields
2. Ignore entire TextInstance 007 on revert
3. Change MovingImageInstance 007[16] to hasNote and ignore on revert
4. Set Electronic 007[10] to ignoreOnRevert
5. Ignore RemoteSensingImage 007 completely - both in import and export
6. Ignore KitInstance 007 completely - both in import and export
7. Ignore NotatedMusicInstance 007 completely - both in import and export

## Issue
[LXL-3114](https://jira.kb.se/browse/LXL-3114)