### PR TITLE
Add allowLinkOnRevert param to allow another property to revert to specific field

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -1876,6 +1876,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
     Map<String, Map> pendingResources
     List<String> pendingKeys
     String aboutAlias
+    //NOTE: allowLinkOnRevert as list may be preferable, but there is currently no case for it. Update if needed.
+    String allowLinkOnRevert
     List<String> onRevertPrefer
     Set<String> sharesGroupIdWith = new HashSet<String>()
     boolean silentRevert
@@ -1899,9 +1901,8 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         }
 
         aboutAlias = fieldDfn.aboutAlias
-
+        allowLinkOnRevert = fieldDfn.allowLinkOnRevert
         dependsOn = fieldDfn.dependsOn
-
         constructProperties = fieldDfn.constructProperties
 
         if (fieldDfn.uriTemplate) {
@@ -2280,6 +2281,11 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         def results = []
 
         def useLinks = []
+
+        if (allowLinkOnRevert) {
+            useLinks << [link: allowLinkOnRevert, resourceType: resourceType]
+        }
+
         if (computeLinks && computeLinks.mapping instanceof Map) {
             computeLinks.mapping.each { code, compLink ->
                 if (compLink in topEntity) {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18262,6 +18262,7 @@
       "aboutEntity": "?thing",
       "aboutAlias": "_:instance",
       "addLink": "otherPhysicalFormat",
+      "allowLinkOnRevert": "reproductionOf",
       "resourceType": "Instance",
       "i2": {"ignored": true, "marcDefault": "8"},
       "_spec": [
@@ -18515,6 +18516,34 @@
                 "@type": "ISBN",
                 "value": "9783527404704"
               }]
+            }]
+          }}
+        },
+        {
+          "name": "reproductionOf should revert to 776",
+          "normalized": {"776": {"ind1": "0", "ind2": "8", "subfields": [
+            {"a": "name of agent"},
+            {"t": "Title of reproduction"},
+            {"w": "00000"}
+          ]}},
+          "result": {"mainEntity": {
+            "reproductionOf": [{
+              "@type": "Instance",
+              "meta": [{"@type": "Record", "controlNumber": "00000"}],
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "Title of reproduction"
+              }],
+              "instanceOf": {
+                "@type": "Work",
+                "contribution" : [ {
+                  "@type": "PrimaryContribution",
+                  "agent": {
+                    "@type": "Agent",
+                    "label": "name of agent"
+                  }
+                }]
+              }
             }]
           }}
         }


### PR DESCRIPTION
## Checklist
- [x] I have run integTest

## Description
To enable another property to revert to a specific field. In this case, we want to allow `reproductionOf` to revert to bib 776 which is mapped to `otherPhysicalFormat`

## Issue
[LXL-3135](https://jira.kb.se/browse/LXL-3135)