### PR TITLE
Fix script for dropping all lddb tables

### DIFF
--- a/librisxl-tools/postgresql/drop-all-lddb-tables.plsql
+++ b/librisxl-tools/postgresql/drop-all-lddb-tables.plsql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+    EXECUTE (
+        SELECT 'DROP TABLE ' || string_agg(tablename, ', ')
+        FROM   pg_tables
+        WHERE  tablename LIKE 'lddb__' || '%'
+        AND    schemaname = current_schema()
+    );
+
+    DROP TABLE lddb;
+END$$;

--- a/librisxl-tools/postgresql/drop-tables-and-indexes-sql.sh
+++ b/librisxl-tools/postgresql/drop-tables-and-indexes-sql.sh
@@ -1,4 +1,0 @@
-# NO LONGER USED!
-#!/bin/bash
-awk '/^CREATE TABLE IF NOT EXISTS/ { print "DROP TABLE IF EXISTS " $6 ";" }' $(dirname $0)/tables.sql
-awk '/^CREATE INDEX/ { print "DROP INDEX IF EXISTS " $3 ";" }' $(dirname $0)/indexes.sql

--- a/librisxl-tools/scripts/move-lddb.sh
+++ b/librisxl-tools/scripts/move-lddb.sh
@@ -116,7 +116,7 @@ if [ -z $DESTHOST ]; then
         cat -
     }
 else
-    $TOOLDIR/postgresql/drop-tables-and-indexes-sql.sh | PGPASSWORD=$DESTPASSWORD psql -h $DESTHOST -U $DESTUSER $DESTDB
+    cat $TOOLDIR/postgresql/drop-all-lddb-tables.plsql | PGPASSWORD=$DESTPASSWORD psql -h $DESTHOST -U $DESTUSER $DESTDB
 
     handle_sql_dump() {
         PGPASSWORD=$DESTPASSWORD psql -h $DESTHOST -U $DESTUSER $DESTDB


### PR DESCRIPTION
The old version didn't handle new tables created by DB migrations. Drop
all tables starting with lddb__ instead. Indices are automatically dropped when dropping the tables.