### PR TITLE
Normalize new documents in the same way as updated

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -321,7 +321,8 @@ class Whelk {
      * NEVER use this to _update_ a document. Use storeAtomicUpdate() instead. Using this for new documents is fine.
      */
     boolean createDocument(Document document, String changedIn, String changedBy, String collection, boolean deleted, boolean index = true) {
-
+        normalize(document)
+        
         boolean detectCollisionsOnTypedIDs = false
         List<Tuple2<String, String>> collidingIDs = getIdCollisions(document, detectCollisionsOnTypedIDs)
         if (!collidingIDs.isEmpty()) {


### PR DESCRIPTION
Normalize when saving new documents. 
For example automatic imports and manual import from file.