### PR TITLE
This is a bandaid fix for the 040$a+APIX problem.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2004,6 +2004,16 @@ class PostgreSQLComponent {
         if (changedBy.startsWith('https://libris.kb.se/sys/globalchanges/')) {
             return getDescriptionChangerId('SEK')
         }
+        else if (changedBy == "MimerProd" || changedBy == "Mimer" ||
+                changedBy == "KBDIGI" || changedBy == "oden" || changedBy == "MimerProdReadonly") {
+            return LegacyIntegrationTools.legacySigelToUri("S")
+        }
+        else if (changedBy == "GUProd" || changedBy == "GU") {
+            return LegacyIntegrationTools.legacySigelToUri("G")
+        }
+        else if (changedBy == "umu") {
+            return LegacyIntegrationTools.legacySigelToUri("Um")
+        }
         else if (isHttpUri(changedBy)) {
             return changedBy
         }


### PR DESCRIPTION
A better fix for this would be to add new parameter that would
travel down from a POST-request or equivalent to the saving
code, so that creator-USER and creator-SIGEL could be separated.
That sort of change would require:

1. A (possibly) breaking set of changes to the public API.
2. Changes in the lxlviewer code.
3. changes everywhere the create-call is used.

These are not realistic changes to make at the moment.

This bandaid achives the same thing (as seen from outside) but
is hacky AND WILL BREAK DOWN if any of the APIX userNAMEs ever
change.

These usernames are kept in:
export-prod.libris.kb.se:/etc/tomcat/tomcat-users.xml