### PR TITLE
Make records in Libris have the equivalent of 003 set to SE-LIBR.

### DIFF
--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -282,6 +282,7 @@ class XL
     private Document convertToRDF(MarcRecord _marcRecord, String id)
     {
         MarcRecord marcRecord = cloneMarcRecord(_marcRecord);
+        LegacyIntegrationTools.makeRecordLibrisResident(marcRecord);
         while (marcRecord.getControlfields("001").size() > 0)
             marcRecord.getFields().remove(marcRecord.getControlfields("001").get(0));
         marcRecord.addField(marcRecord.createControlfield("001", id));

--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -13,6 +13,7 @@ import whelk.IdGenerator
 import whelk.Whelk
 import whelk.converter.MarcJSONConverter
 import whelk.converter.marc.MarcFrameConverter
+import whelk.util.LegacyIntegrationTools
 import whelk.util.WhelkFactory
 
 import javax.servlet.http.HttpServlet
@@ -416,8 +417,8 @@ class RemoteSearchAPI extends HttpServlet {
     String sanitizeMarcAndGenerateNewID(MarcRecord marcRecord) {
         List<Field> mutableFieldList = marcRecord.getFields()
 
-        // Replace any existing 001 fields, TODO: move 001 to 035$a instead?
         String generatedId = IdGenerator.generate()
+        LegacyIntegrationTools.makeRecordLibrisResident(marcRecord)
         if (marcRecord.getControlfields("001").size() != 0) {
             mutableFieldList.remove(marcRecord.getControlfields("001").get(0))
         }

--- a/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
@@ -1,6 +1,13 @@
 package whelk.util
 
 import groovy.transform.CompileStatic
+import se.kb.libris.util.marc.Controlfield
+import se.kb.libris.util.marc.Field
+import se.kb.libris.util.marc.MarcRecord
+import se.kb.libris.util.marc.Subfield
+import se.kb.libris.util.marc.impl.ControlfieldImpl
+import se.kb.libris.util.marc.impl.DatafieldImpl
+import se.kb.libris.util.marc.impl.SubfieldImpl
 import whelk.DateUtil
 import whelk.Document
 import whelk.IdGenerator
@@ -104,5 +111,36 @@ class LegacyIntegrationTools {
             uri = uri.replace("https:/", "https://")
         }
         return uri
+    }
+
+    /**
+     * Take a MARC record from another system, and make it a LIBRIS MARC record.
+     *
+     * After calling this on a record, you SHOULD IMMEDIATELY also set a new 001 on that record.
+     */
+    static void makeRecordLibrisResident(MarcRecord record) {
+        // Add new 035$a
+        Controlfield field003 = (Controlfield) record.getControlfields("003")[0] // non-repeatable
+        Controlfield field001 = (Controlfield) record.getControlfields("001")[0] // non-repeatable
+
+        boolean hasLibris035aAlready = false
+        record.getDatafields("035").each { f ->
+            f.getSubfields("a").each { sf ->
+                if (sf.getData().contains("(SE-LIBR)") || sf.getData().contains("(LIBRIS)"))
+                    hasLibris035aAlready = true
+            }
+        }
+
+        if (!hasLibris035aAlready && field001 != null && field003 != null && field001.getData()
+                != null && field003.getData() != null) {
+            Field field035 = new DatafieldImpl("035")
+            Subfield a = new SubfieldImpl("a".charAt(0), "(" + field003.getData() + ")" + field001.getData())
+            field035.addSubfield(a)
+            record.addField(field035)
+        }
+
+        // Replace 003
+        record.getFields("003").clear() // Remove MARC 003
+        record.addField(new ControlfieldImpl("003", "SE-LIBR"))
     }
 }


### PR DESCRIPTION
Previously, when we imported a MARC record from elsewhere, we left
the record's 003 (@graph,0,identifiedBy,N,{@type=SystemNumber}), and
only changed 003 when exporting the record. The practical consequence
of this is that whatever ID was in 001 when we imported the record, it
was discarded instead of placed in 035$a to facilitate future matching
in other databases.

This is now being corrected, so that pre-import IDs end up in 035$a
and 003 is being set immediately on import.