### PR TITLE
Dont return created on fail

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -533,6 +533,8 @@ class Crud extends HttpServlet {
         if (savedDoc != null) {
             sendCreateResponse(response, savedDoc.getURI().toString(),
                                savedDoc.getChecksum())
+        } else {
+            sendNotFound(response, request.getContextPath())
         }
     }
 
@@ -704,7 +706,10 @@ class Crud extends HttpServlet {
                 }
                 else {
                     log.debug("Saving NEW document ("+ doc.getId() +")")
-                    whelk.createDocument(doc, "xl", activeSigel, collection, false)
+                    boolean success = whelk.createDocument(doc, "xl", activeSigel, collection, false)
+                    if (!success) {
+                        return null
+                    }
                 }
 
                 log.debug("Saving document (${doc.getShortId()})")


### PR DESCRIPTION
Ok, ugly solution that solves https://jira.kb.se/browse/LXL-2035, i.e. no longer return 201 - created when trying to add holding to a record that has been deleted. 
BUT isn't https://jira.kb.se/browse/LXL-2938  implying: "Don't fix LXL-2035 since it needs to be broken for the imports to work"? @jannistsiroyannis 
I guess the preferred solution would only involve one type of failure handling instead of either throwing, returning a boolean or returning null.