### PR TITLE
API: Never return 304 NOT MODIFIED in embellished responses.

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -205,7 +205,7 @@ class Crud extends HttpServlet {
             sendNotFound(response, request.getPath())
         } else if (!doc && loc) {
             sendRedirect(request.getHttpServletRequest(), response, loc)
-        } else if (request.getIfNoneMatch().map({ etag -> etag == doc.getChecksum() }).orElse(false)) {
+        } else if (!request.shouldEmbellish() && isNotModified(request, doc)) {
             sendNotModified(response, doc)
         } else if (doc.deleted) {
             failedRequests.labels("GET", request.getPath(),
@@ -220,6 +220,10 @@ class Crud extends HttpServlet {
                     request.getPath(),
                     request.getContentType())
         }
+    }
+
+    private static boolean isNotModified(CrudGetRequest request, Document doc) {
+        request.getIfNoneMatch().map({ etag -> etag == doc.getChecksum() }).orElse(false)
     }
 
     private void sendNotModified(HttpServletResponse response, Document doc) {


### PR DESCRIPTION
Doing so can make clients see stale data if any linked documents have
changed since ETag is only for this resource.