### PR TITLE
Update bib249 script

### DIFF
--- a/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
+++ b/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
@@ -117,7 +117,7 @@ void process(bib) {
     else if (converted.size() == 0) {
         print(Script.broken, msg)
         Script.s.increment('Broken', "total")
-        // TODO: handle (temporarily disabled - rule needs to be verified)
+        // Corrected manually
         return
     }
     // MULTIPLE 249
@@ -134,6 +134,7 @@ void process(bib) {
                 msg.append("Existing hasPart:\n  ${work['hasPart']} \n")
                 print(Script.alreadyHasPart, msg)
                 Script.s.increment('Multiple 249', 'Already hasPart (unhandled)')
+                // Corrected manually
                 return
             }
 
@@ -141,9 +142,6 @@ void process(bib) {
 
             print(Script.multipleNoneExist, msg)
             Script.s.increment('Multiple 249', 'None existing (to hasPart)')
-
-            // TODO: handle (temporarily disabled - rule needs to be verified)
-            return
         }
         else {
             msg.append("Matches:\n  ${matches} \n")
@@ -152,15 +150,13 @@ void process(bib) {
                 msg.append("Existing hasPart:\n  ${work['hasPart']} \n")
                 print(Script.multipleSomeExistUnhandled, msg)
                 Script.s.increment('Multiple 249', "Some exist (unhandled)")
+                // Corrected manually
                 return
             }
             else {
                 setHasPart(work, converted)
                 print(Script.multipleSomeExistHandled, msg)
                 Script.s.increment('Multiple 249', "Some exist (to hasPart)")
-
-                // TODO: handle (temporarily disabled - rule needs to be verified)
-                return
             }
         }
     }

--- a/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
+++ b/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
@@ -140,6 +140,7 @@ void process(bib) {
 
             setHasPart(work, converted)
 
+            msg.append("hasPart:\n  ${work['hasPart']} \n")
             print(Script.multipleNoneExist, msg)
             Script.s.increment('Multiple 249', 'None existing (to hasPart)')
         }
@@ -155,6 +156,7 @@ void process(bib) {
             }
             else {
                 setHasPart(work, converted)
+                msg.append("hasPart:\n  ${work['hasPart']} \n")
                 print(Script.multipleSomeExistHandled, msg)
                 Script.s.increment('Multiple 249', "Some exist (to hasPart)")
             }
@@ -173,6 +175,23 @@ void setHasPart(Map work, List converted) {
                 'hasTitle': it
         ]
     }
+
+    if(work['language']) {
+        work['hasPart'].each {
+            it['language'] = work['language']
+        }
+    }
+
+    def primary = primaryContribution(work)
+    if(primary) {
+        work['hasPart'].each {
+            it['contribution'] = primary
+        }
+    }
+}
+
+Map primaryContribution(Map work) {
+    asList(work['contribution']).find { it['@type'] == 'PrimaryContribution' }
 }
 
 Map findMatchingTitles(Map ogTitle, Map workTitles) {

--- a/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
+++ b/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
@@ -100,7 +100,7 @@ void process(bib) {
             work['hasTitle'] = asList(work['hasTitle'])
             boolean variant = work['hasTitle'].any{ it['@type'] == 'Title' }
             if(variant) {
-                ogTitle['@type'] = 'VariantTitle'
+                ogTitle['@type'] = 'VariantTitle' // just for logging, never saved
             }
 
             work['hasTitle'].add(ogTitle)
@@ -110,7 +110,7 @@ void process(bib) {
             Script.s.increment('Single 249 to hasTitle', ogTitle['@type'])
 
             if (variant) {
-                // Corrected manually
+                // To be manually handled
                 return
             }
         }
@@ -119,7 +119,7 @@ void process(bib) {
     else if (converted.size() == 0) {
         print(Script.broken, msg)
         Script.s.increment('Broken', "total")
-        // Corrected manually
+        // To be manually handled
         return
     }
     // MULTIPLE 249
@@ -136,7 +136,7 @@ void process(bib) {
                 msg.append("Existing hasPart:\n  ${work['hasPart']} \n")
                 print(Script.alreadyHasPart, msg)
                 Script.s.increment('Multiple 249', 'Already hasPart (unhandled)')
-                // Corrected manually
+                // To be manually handled
                 return
             }
 
@@ -153,7 +153,7 @@ void process(bib) {
                 msg.append("Existing hasPart:\n  ${work['hasPart']} \n")
                 print(Script.multipleSomeExistUnhandled, msg)
                 Script.s.increment('Multiple 249', "Some exist (unhandled)")
-                // Corrected manually
+                // To be manually handled
                 return
             }
             else {

--- a/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
+++ b/whelktool/scripts/cleanups/2020/06/lxl-3103-bib-249.groovy
@@ -99,18 +99,20 @@ void process(bib) {
         else {
             work['hasTitle'] = asList(work['hasTitle'])
             boolean variant = work['hasTitle'].any{ it['@type'] == 'Title' }
-            if (variant) {
-                // TODO: handle (temporarily disabled - rule needs to be verified)
-                return
-
-                //ogTitle['@type'] = 'VariantTitle'
+            if(variant) {
+                ogTitle['@type'] = 'VariantTitle'
             }
 
             work['hasTitle'].add(ogTitle)
-
+            
             msg.append(" --> work['hasTitle']: ${work['hasTitle']}\n")
             print(variant ? Script.singleToVariantTitle : Script.singleToMainTitle, msg)
             Script.s.increment('Single 249 to hasTitle', ogTitle['@type'])
+
+            if (variant) {
+                // Corrected manually
+                return
+            }
         }
     }
     // ALL 249 BROKEN


### PR DESCRIPTION
Updated after suggestions from @ebengtsson. 
All cases are handled now (mechanically or manually cleaned up).
- Re-enable handling of multiple bib249
- Strip language from title, e.g. "Fidel & Che (engelska)" -> "Fidel & Che"
- Set language and contribution in hasPart works.

See LXL-3103 for discussion.