### PR TITLE
Fix NPE in reindex when depender deleted but still in ES index

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -229,7 +229,9 @@ class Whelk {
             // TODO: when types (auth, bib...) have been removed from elastic, do bulk index in chunks of size N here
             getAffectedIds(document).each { id ->
                 Document doc = storage.load(id)
-                elastic.index(doc, storage.getCollectionBySystemID(doc.shortId), this)
+                if (doc) { // might not exist because of batch jobs without indexing
+                    elastic.index(doc, storage.getCollectionBySystemID(doc.shortId), this)
+                }
             }
         }
 


### PR DESCRIPTION
Caused by whelktool script being run with --skip-index