### PR TITLE
Feature/move classification

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7171,7 +7171,7 @@
     "049": {"ignored": true, "NOTE": "OCLC - Local Holdings. Field 049 is not part of the standard MARC 21 format."},
 
     "050": {
-      "aboutEntity": "?work",
+      "aboutEntity": "?thing",
       "addLink": "classification",
       "resourceType": "ClassificationLcc",
       "i1": {"property": "marc:existenceInLCCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
@@ -7189,14 +7189,11 @@
           },
           "result": {
             "mainEntity": {
-              "instanceOf": {
-                "@type": "Text",
-                "classification": [{
-                  "@type": "ClassificationLcc",
-                  "code": "NB933.F44",
-                  "itemPortion": "T6"
-                }]
-              }
+              "classification": [{
+                "@type": "ClassificationLcc",
+                "code": "NB933.F44",
+                "itemPortion": "T6"
+              }]
             }
           }
         }
@@ -7215,7 +7212,7 @@
     },
     "052": {
       "NOTE:LC": "Is GeographicCoverage in BF2",
-      "aboutEntity": "?work",
+      "aboutEntity": "?thing",
       "addLink": "marc:hasGeographicClassification",
       "resourceType": "marc:GeographicClassification",
       "i1": {
@@ -7232,7 +7229,24 @@
       "$d": {"addProperty": "marc:populatedPlaceName"},
       "$0": {"property": "marc:recordControlNumber"},
       "$1": {"property": "marc:rwoURI"},
-      "$2": {"property": "marc:codeSource"}
+      "$2": {"property": "marc:codeSource"},
+      "_spec": [
+        {
+          "source": {
+            "052": {"ind1": " ", "ind2": " ", "subfields": [{"a": "6714"},{"b": "R7"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "marc:hasGeographicClassification": [{
+                "@type": "marc:GeographicClassification",
+                "marc:geographicClassificationAreaCode": "6714",
+                "marc:geographicClassificationSubareaCode": ["R7"],
+                "marc:i1codeSource": "marc:LibraryOfCongressClassification"
+              }]
+            }
+          }
+        }
+      ]
     },
     "055": {
       "NOTE:LC": "Is ClassificationLcc in BF2",
@@ -7304,7 +7318,7 @@
       ]
     },
     "060": {
-      "aboutEntity": "?work",
+      "aboutEntity": "?thing",
       "addLink": "classification",
       "resourceType": "ClassificationNlm",
       "i1": {"property": "marc:existenceInNlmCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
@@ -7320,14 +7334,11 @@
           },
           "result": {
             "mainEntity": {
-              "instanceOf": {
-                "@type": "Text",
-                "classification": [{
-                  "@type": "ClassificationNlm",
-                  "code": "W1",
-                  "itemPortion": "JO706M"
-                }]
-              }
+              "classification": [{
+                "@type": "ClassificationNlm",
+                "code": "W1",
+                "itemPortion": "JO706M"
+              }]
             }
           }
         }
@@ -7350,14 +7361,35 @@
       "$c": {"addProperty": "marc:alternateG0OrG1CharacterSet"}   
     },
     "070": {
-      "aboutEntity": "?work",
-      "link": "classification",
+      "aboutEntity": "?thing",
+      "addLink": "classification",
       "resourceType": "marc:NationalAgriculturalLibraryCallNumber",
-      "i1": {"marcDefault": " "},
+      "i1": null,
       "$a": {"addProperty": "classificationPortion"},
       "$b": {"property": "itemPortion"},
       "$0": {"property": "marc:recordControlNumber"},
-      "$1": {"property": "marc:rwoURI"}
+      "$1": {"ignore": true, "NOTE:LC": "nac"},
+      "_spec": [
+        {
+          "source": {
+            "070": {"ind1": "0", "ind2": " ", "subfields": [{"a": "QH301.A5"},{"b": "1981"}]}
+          },
+          "normalized": {
+            "070": {"ind1": " ", "ind2": " ", "subfields": [{"a": "QH301.A5"},{"b": "1981"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "classification": [
+                {
+                  "@type": "marc:NationalAgriculturalLibraryCallNumber",
+                  "classificationPortion": ["QH301.A5"],
+                  "itemPortion": "1981"
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "071": {
       "NOTE:LC": "071 - NATIONAL AGRICULTURAL LIBRARY COPY STATEMENT (R) nac",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7230,10 +7230,9 @@
       "$c": {"property": "marc:copyInformation"}
     },
     "052": {
-      "NOTE:LC": "Is GeographicCoverage in BF2",
       "aboutEntity": "?thing",
-      "addLink": "marc:hasGeographicClassification",
-      "resourceType": "marc:GeographicClassification",
+      "addLink": "geographicCoverage",
+      "resourceType": "GeographicCoverage",
       "i1": {
         "property": "marc:i1codeSource",
         "tokenMap": {
@@ -7243,7 +7242,7 @@
           "7": "marc:SourceSpecifiedInSubfield2"
         }
       },
-      "$a": {"property": "marc:geographicClassificationAreaCode"},
+      "$a": {"property": "label"},
       "$b": {"addProperty": "marc:geographicClassificationSubareaCode"},
       "$d": {"addProperty": "marc:populatedPlaceName"},
       "$0": {"property": "marc:recordControlNumber"},
@@ -7256,9 +7255,9 @@
           },
           "result": {
             "mainEntity": {
-              "marc:hasGeographicClassification": [{
-                "@type": "marc:GeographicClassification",
-                "marc:geographicClassificationAreaCode": "6714",
+              "geographicCoverage": [{
+                "@type": "GeographicCoverage",
+                "label": "6714",
                 "marc:geographicClassificationSubareaCode": ["R7"],
                 "marc:i1codeSource": "marc:LibraryOfCongressClassification"
               }]

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7174,7 +7174,7 @@
       "aboutEntity": "?thing",
       "addLink": "classification",
       "resourceType": "ClassificationLcc",
-      "i1": {"property": "marc:existenceInLCCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
+      "i1": {"ignored": true, "marcDefault": " "},
       "i2": {"property": "marc:assignedByLC", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "code", "TODO:repeatable": true},
       "$b": {"ignored": true},
@@ -7195,6 +7195,23 @@
               "classification": [{
                 "@type": "ClassificationLcc",
                 "code": "NB933.F44"
+              }]
+            }
+          }
+        },
+        {
+          "source": {
+            "050": {"ind1": "0", "ind2": "0", "subfields": [{"a": "DS751"},{"b": ".C4468 1994"}]}
+          },
+          "normalized": {
+            "050": {"ind1": " ", "ind2": "0", "subfields": [{"a": "DS751"}]}
+          },
+          "result": {
+            "mainEntity": {
+              "classification": [{
+                "@type": "ClassificationLcc",
+                "code": "DS751",
+                "marc:assignedByLC": true
               }]
             }
           }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -25295,15 +25295,67 @@
       "inherit": "bib",
       "aboutEntity": "?thing",
       "NOTE:local": "LIBRIS-definierat beståndsfält.",
+      "$b": {"property": "itemPortion"},
       "$m": null,
-      "$q": null
+      "$q": null,
+      "_spec": [
+        {
+          "name": "In contrast to bib, continue to map $b to itemPortion ",
+          "source": {
+            "082": {"ind1": " ", "ind2": " ", "subfields": [
+              {"a": "808"}, {"b": ".066"}, {"2": "21"}
+            ]}},
+          "normalized": {
+            "082": {"ind1": " ", "ind2": "4", "subfields": [
+              {"a": "808"}, {"b": ".066"}, {"2": "21"}
+            ]}},
+          "result": {"mainEntity": {
+            "@type": "Item",
+            "classification": [
+              {
+                "@type": "ClassificationDdc",
+                "code": "808",
+                "edition": "other",
+                "editionEnumeration": "21",
+                "itemPortion" : ".066"
+              }
+            ]
+          }}
+        }
+      ]
     },
     "084": {
       "inherit": "bib",
       "aboutEntity": "?thing",
-      "NOTE:local": "LIBRIS-definierat beståndsfält."
+      "NOTE:local": "LIBRIS-definierat beståndsfält.",
+      "$b": {"property": "itemPortion"},
+      "TODO:_spec": [
+        {
+          "TODO": "Add ignoreOnRevert. As it is now, it collides with 082. See bug issue LXL-3287",
+          "name": "In contrast to bib, continue to map $b to itemPortion.",
+          "source": {
+            "084": {"ind1": " ", "ind2": " ", "subfields": [
+              {"a": "Ncba/VP"}, {"b": "Nc"}, {"2": "kssb/8"}
+            ]}},
+          "result": {"mainEntity": {
+            "@type": "Item",
+            "classification": [
+              {
+                "@type": "Classification",
+                "code": "Ncba/VP",
+                "itemPortion": "Nc",
+                "inScheme": {
+                  "@id": "https://id.kb.se/term/kssb%2F8/",
+                  "@type": "ConceptScheme",
+                  "code": "kssb",
+                  "version": "8"
+                }
+              }
+            ]
+          }}
+        }
+      ]
     },
-
     "337": {"ignored": true, "NOTE:record-count": 0, "NOTE:": "Media only on work or instance"},
     "338": {"ignored": true, "NOTE:record-count": 0, "NOTE:": "Carrier only on instance"},
     "347": {"ignored": true, "NOTE:record-count": 0},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7522,7 +7522,7 @@
         "marcDefault": " "
       },
       "$a": {"property": "code"},
-      "$b": {"property": "marc:itemNumber"},
+      "$b": {"ignored": true},
       "$x": {"addProperty": "marc:commonAuxiliarySubdivision"},
       "$2": {"property": "marc:editionIdentifier"},
       "_spec": [
@@ -7589,7 +7589,7 @@
           "0": "dlc"
         }
       },
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$m": {"ignored": true, "NOTE:LC": "Standard or optional designation (NR) - nac"},
       "$6": {"property": "marc:fieldref"},
       "$8": {"property": "marc:groupid"},
@@ -7680,7 +7680,6 @@
           "normalized": {
             "082": {"ind1": " ", "ind2": "4", "subfields": [
               {"a": "808"},
-              {"b": ".066"},
               {"2": "21"}
             ]}},
           "result": {"mainEntity": {
@@ -7691,8 +7690,7 @@
                   "@type": "ClassificationDdc",
                   "code": "808",
                   "edition": "other",
-                  "editionEnumeration": "21",
-                  "itemPortion": ".066"
+                  "editionEnumeration": "21"
                 }
               ]
             }
@@ -7798,6 +7796,7 @@
       "TODO": "Should we deprecate this altogether? BF2=nac",
       "addLink": "additionalClassificationDdc",
       "include": ["classification-ddc"],
+      "$b": {"ignored": true},
       "$c": {"ignored": true, "NOTE:record-count": 1, "NOTE:local": "Används normalt ej"},
       "$m": {"ignored": true, "NOTE:record-count": 0, "NOTE:local": "Används normalt ej"},
       "$q": {"link": "source", "resourceType": "Source", "property": "label"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7177,7 +7177,7 @@
       "i1": {"property": "marc:existenceInLCCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
       "i2": {"property": "marc:assignedByLC", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "code", "TODO:repeatable": true},
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$0": {"property": "marc:recordControlNumber"},
       "$1": null,
       "$3": null,
@@ -7187,12 +7187,14 @@
           "source": {
             "050": {"ind1": " ", "ind2": "4", "subfields": [{"a": "NB933.F44"},{"b": "T6"}]}
           },
+          "normalized": {
+            "050": {"ind1": " ", "ind2": "4", "subfields": [{"a": "NB933.F44"}]}
+          },
           "result": {
             "mainEntity": {
               "classification": [{
                 "@type": "ClassificationLcc",
-                "code": "NB933.F44",
-                "itemPortion": "T6"
+                "code": "NB933.F44"
               }]
             }
           }
@@ -7272,7 +7274,7 @@
         "marcDefault": " "
       },
       "$a": {"property": "classificationPortion"},
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$1": {"ignored": true, "NOTE:LC": "nac"},
       "$2": {"ignored": true, "NOTE:LC": "nac"},
       "$6": {"ignored": true, "NOTE:LC": "ignore"},
@@ -7282,21 +7284,18 @@
             "055": {"ind1": "1", "ind2": "4", "subfields": [{"a": "K347.9444"},{"b": "C5164"}]}
           },
           "normalized": {
-            "055": {"ind1": " ", "ind2": " ", "subfields": [{"a": "K347.9444"},{"b": "C5164"}]}
+            "055": {"ind1": " ", "ind2": " ", "subfields": [{"a": "K347.9444"}]}
           },
           "result": {
             "mainEntity": {
               "classification": [{
                   "@type": "marc:ClassificationNumbersAssignedInCanada",
-                  "classificationPortion": "K347.9444",
-                  "itemPortion": "C5164"
+                  "classificationPortion": "K347.9444"
                 }
               ]
             }
           }
-        }
-      ],
-      "_spec": [
+        },
         {
           "source": {
             "055": {"ind1": "0", "ind2": "1", "subfields": [{"a": "HB31"}]}
@@ -7307,10 +7306,10 @@
           "result": {
             "mainEntity": {
               "classification": [{
-                  "@type": "marc:ClassificationNumbersAssignedInCanada",
-                  "classificationPortion": "HB31",
-                  "marc:typeCompletenessSourceOfClassCallNumber": "marc:CompleteLcClassNumberAssignedByLac"
-                }
+                "@type": "marc:ClassificationNumbersAssignedInCanada",
+                "classificationPortion": "HB31",
+                "marc:typeCompletenessSourceOfClassCallNumber": "marc:CompleteLcClassNumberAssignedByLac"
+              }
               ]
             }
           }
@@ -7324,20 +7323,19 @@
       "i1": {"property": "marc:existenceInNlmCollection", "marcDefault": " ", "tokenMap": {"0": true, "1": false}},
       "i2": {"property": "marc:assignedByNlm", "marcDefault": "4", "tokenMap": {"0": true}},
       "$a": {"property": "code"},
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$0": {"property": "marc:recordControlNumber"},
       "$1": null,
       "_spec": [
         {
           "source": {
-            "060": {"ind1": " ", "ind2": "4", "subfields": [{"a": "W1"},{"b": "JO706M"}]}
+            "060": {"ind1": " ", "ind2": "4", "subfields": [{"a": "W1"}]}
           },
           "result": {
             "mainEntity": {
               "classification": [{
                 "@type": "ClassificationNlm",
-                "code": "W1",
-                "itemPortion": "JO706M"
+                "code": "W1"
               }]
             }
           }
@@ -7366,7 +7364,7 @@
       "resourceType": "marc:NationalAgriculturalLibraryCallNumber",
       "i1": null,
       "$a": {"addProperty": "classificationPortion"},
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$0": {"property": "marc:recordControlNumber"},
       "$1": {"ignore": true, "NOTE:LC": "nac"},
       "_spec": [
@@ -7375,15 +7373,14 @@
             "070": {"ind1": "0", "ind2": " ", "subfields": [{"a": "QH301.A5"},{"b": "1981"}]}
           },
           "normalized": {
-            "070": {"ind1": " ", "ind2": " ", "subfields": [{"a": "QH301.A5"},{"b": "1981"}]}
+            "070": {"ind1": " ", "ind2": " ", "subfields": [{"a": "QH301.A5"}]}
           },
           "result": {
             "mainEntity": {
               "classification": [
                 {
                   "@type": "marc:NationalAgriculturalLibraryCallNumber",
-                  "classificationPortion": ["QH301.A5"],
-                  "itemPortion": "1981"
+                  "classificationPortion": ["QH301.A5"]
                 }
               ]
             }
@@ -7760,8 +7757,7 @@
               {"2": "23"}
             ]}},{
             "082": {"ind1": " ", "ind2": "4", "subfields": [
-              {"a": "E184.S23"},
-              {"b": "A685"}
+              {"a": "E184.S23"}
             ]}}],
           "TODO:result": {"mainEntity": {
             "instanceOf": {
@@ -7783,8 +7779,7 @@
             "classification": [
               {
                 "@type": "ClassificationDdc",
-                "code": "E184.S23",
-                "itemPortion": "A685"
+                "code": "E184.S23"
               }
             ]
           }}

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7882,7 +7882,7 @@
         "property": "code"
       },
       "NOTE:$2:codeList": "http://www.loc.gov/standards/sourcelist/classification.html",
-      "$b": {"property": "itemPortion"},
+      "$b": {"ignored": true},
       "$q": {"link": "source", "resourceType": "Source", "property": "label"},
       "$6": {"property": "marc:fieldref"},
       "$8": {"property": "marc:groupid"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7863,6 +7863,21 @@
       "$a": {"property": "code", "required": true},
       "match": [
         {
+          "NOTE": "For now, always map to instance when $a contains '/', no matter how the media extension code is",
+          "when": "$a =~ ^.*/.*$ & $2 =~ ^kssb/.+$",
+          "aboutEntity": "?thing",
+          "$2": {
+            "link": "inScheme",
+            "resourceType": "ConceptScheme",
+            "property": "code",
+            "uriTemplate": "https://id.kb.se/term/{_}/",
+            "uriTemplateDefaults": {"inScheme.code": "kssb"},
+            "splitValuePattern": "(\\w+)(?:/(5|6|7|8))?",
+            "splitValueProperties": ["code", "version"],
+            "rejoin": "/"
+          }
+        },
+        {
           "when": "$2 =~ ^kssb/.+$",
           "$2": {
             "link": "inScheme",
@@ -7909,6 +7924,50 @@
                 }
               ]
             }
+          }}
+        },
+        {
+          "name": "kssb classification with media extension should convert to Instance",
+          "source": {
+            "084": {"ind1": " ", "ind2": " ", "subfields": [
+              {"a": "Koafh-a.54/VK"},
+              {"2": "kssb/7"}
+            ]}},
+          "result": {"mainEntity": {
+            "classification": [
+              {
+                "@type": "Classification",
+                "code": "Koafh-a.54/VK",
+                "inScheme": {
+                  "@id": "https://id.kb.se/term/kssb%2F7/",
+                  "@type": "ConceptScheme",
+                  "code": "kssb",
+                  "version": "7"
+                }
+              }
+            ]
+          }}
+        },
+        {
+          "name": "kssb classification with media extension should convert to Instance",
+          "source": {
+            "084": {"ind1": " ", "ind2": " ", "subfields": [
+              {"a": "Fvea(x)/O,u"},
+              {"2": "kssb/8"}
+            ]}},
+          "result": {"mainEntity": {
+            "classification": [
+              {
+                "@type": "Classification",
+                "code": "Fvea(x)/O,u",
+                "inScheme": {
+                  "@id": "https://id.kb.se/term/kssb%2F8/",
+                  "@type": "ConceptScheme",
+                  "code": "kssb",
+                  "version": "8"
+                }
+              }
+            ]
           }}
         }
       ]

--- a/whelktool/scripts/2020/06/workify-classification.groovy
+++ b/whelktool/scripts/2020/06/workify-classification.groovy
@@ -122,12 +122,14 @@ boolean removeItemPortion(entity) {
 List copyMediaExtensionsDetails(entity, docId) {
     List copyToInstance = []
     if (entity.inScheme?.code == 'kssb' && entity['code'] && entity['code'].contains('/')) {
-        //log if more than 2 chars --> will be fixed manually
-        if (entity['code'].split("/")[1].size() > 2) {
+        //log if it does not follow practice --> will be fixed manually
+        def extensions = entity['code'].split("/")
+        if (extensions.size() == 2 && extensions[1].size() <= 2) {
+            copyToInstance << entity.clone()
+            entity['code'] = extensions[0]
+        } else {
             deviatedMediaExtensions.println("${docId}")
         }
-        copyToInstance << entity.clone()
-        entity['code'] = entity['code'].split("/")[0]
     }
     return copyToInstance
 }

--- a/whelktool/scripts/2020/06/workify-classification.groovy
+++ b/whelktool/scripts/2020/06/workify-classification.groovy
@@ -105,17 +105,14 @@ Map getWork(thing, work) {
 
 boolean removeItemPortion(entity) {
     boolean wasRemoved = false
-    //TODO: Should we remove all itemPortions or just some?
-    //if (ITEM_PORTION_TYPES.contains(entity[TYPE])) {
-        if (entity.containsKey('itemPortion')) {
-            entity.remove('itemPortion')
-            wasRemoved |= true
-        }
-        if (entity.containsKey('marc:itemNumber')) {
-            entity.remove('marc:itemNumber')
-            wasRemoved |= true
-        }
-    //}
+    if (entity.containsKey('itemPortion')) {
+        entity.remove('itemPortion')
+        wasRemoved |= true
+    }
+    if (entity.containsKey('marc:itemNumber')) {
+        entity.remove('marc:itemNumber')
+        wasRemoved |= true
+    }
     return wasRemoved
 }
 
@@ -124,7 +121,8 @@ List copyMediaExtensionsDetails(entity, docId) {
     if (entity.inScheme?.code == 'kssb' && entity['code'] && entity['code'].contains('/')) {
         //log if it does not follow practice --> will be fixed manually
         def extensions = entity['code'].split("/")
-        if (extensions.size() == 2 && extensions[1].size() <= 2) {
+        if (extensions.size() == 2 &&
+                (extensions[1].size() == 1 || extensions[1].size() == 2)) {
             copyToInstance << entity.clone()
             entity['code'] = extensions[0]
         } else {

--- a/whelktool/scripts/2020/06/workify-classification.groovy
+++ b/whelktool/scripts/2020/06/workify-classification.groovy
@@ -44,8 +44,9 @@ selectBySqlWhere(query) { data ->
         return failedIDs.println("Failed to process ${record[ID]} due to missing work entity")
     }
 
+    //Move and remodel marc:hasGeographicClassification
     if (work.containsKey('marc:hasGeographicClassification')) {
-        thing.put('marc:hasGeographicClassification', work['marc:hasGeographicClassification'])
+        thing.put('geographicCoverage', remodelGeographicClassifcation(work['marc:hasGeographicClassification']))
         work.remove('marc:hasGeographicClassification')
         changed = true
     }
@@ -100,6 +101,19 @@ Map getWork(thing, work) {
         return work
     }
     return null
+}
+
+List remodelGeographicClassifcation(object) {
+    if (object instanceof Map) {
+        object = [object]
+    }
+    List updatedEntities = object.collect {
+        it[(TYPE)] = 'GeographicCoverage'
+        it['label'] = it['marc:geographicClassificationAreaCode']
+        it.remove('marc:geographicClassificationAreaCode')
+        return it
+    }
+    return updatedEntities
 }
 
 List copyMediaExtensionsDetails(entity, docId) {

--- a/whelktool/scripts/2020/06/workify-classification.groovy
+++ b/whelktool/scripts/2020/06/workify-classification.groovy
@@ -121,8 +121,7 @@ List copyMediaExtensionsDetails(entity, docId) {
     if (entity.inScheme?.code == 'kssb' && entity['code'] && entity['code'].contains('/')) {
         //log if it does not follow practice --> will be fixed manually
         def extensions = entity['code'].split("/")
-        if (extensions.size() == 2 &&
-                (extensions[1].size() == 1 || extensions[1].size() == 2)) {
+        if (extensions.size() == 2 && extensions[1] =~ /^[A-Za-z]{1,2}(,u(f|g)?)?$/) {
             copyToInstance << entity.clone()
             entity['code'] = extensions[0]
         } else {

--- a/whelktool/scripts/2020/06/workify-classification.groovy
+++ b/whelktool/scripts/2020/06/workify-classification.groovy
@@ -126,7 +126,7 @@ List copyMediaExtensionsDetails(entity, docId) {
             copyToInstance << entity.clone()
             entity['code'] = extensions[0]
         } else {
-            deviatedMediaExtensions.println("${docId}")
+            deviatedMediaExtensions.println("${docId} with code ${entity['code']}")
         }
     }
     return copyToInstance


### PR DESCRIPTION
## Checklist:
- [x] I have run integ testes
- [x] I have dry-runned script
- [x] Updated domain of geographicCoverage (https://github.com/libris/definitions/pull/221)
- [x] Updated display card for Instance (to also include classification) (https://github.com/libris/definitions/pull/222)
- [x] Updated snippets and templates (https://github.com/libris/lxlviewer/pull/671)

## Description
This moves certain classifications from work to instance, remove spec properties and handle SAB classification with media extensions

Move (https://jira.kb.se/browse/LXL-3254):
- classification ClassificationLcc (bib 050)
- marc:hasGeographicClassification marc:GeographicClassification (bib 052)
- classification ClassificationNlm (bib 060)
- classification marc:NationalAgriculturalLibraryCallNumber (bib 070)

Remove (https://jira.kb.se/browse/LXL-3256 and https://jira.kb.se/browse/LXL-3293):
- marc:existenceInLCCollection (ind1) from classification ClassificationLcc (bib 050)
- all occurrences of itemPortion / marc:itemNumber (bib). Add mapping of itemPortion to hold 082 and hold 082

SAB classification:
- workify classification Classification (bib 084) with inScheme set to SAB and code that contains media extension (https://jira.kb.se/browse/LXL-3258)

### Tickets involved
https://jira.kb.se/browse/LXL-3254 
https://jira.kb.se/browse/LXL-3256
https://jira.kb.se/browse/LXL-3258
https://jira.kb.se/browse/LXL-3293

### PR involved
https://github.com/libris/definitions/pull/221
https://github.com/libris/definitions/pull/222
https://github.com/libris/lxlviewer/pull/671