### PR TITLE
Make in-memory card caching work across processes. Make it default.

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000012-notify-cards-changed.plsql
+++ b/librisxl-tools/postgresql/migrations/00000012-notify-cards-changed.plsql
@@ -1,0 +1,42 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+   
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 11;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 12;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+   CREATE OR REPLACE FUNCTION lddb__notify_card()
+       RETURNS trigger AS $$
+   DECLARE
+   BEGIN
+       PERFORM pg_notify('lddb__cards_changed', OLD.id);
+       RETURN NEW;
+   END;
+   $$ LANGUAGE plpgsql;
+
+   CREATE TRIGGER lddb__notify_card
+       AFTER UPDATE OR DELETE ON lddb__cards
+       FOR EACH ROW
+       EXECUTE PROCEDURE lddb__notify_card();
+
+END$$;
+
+COMMIT;

--- a/librisxl-tools/postgresql/migrations/00000012-notify-cards-changed.plsql
+++ b/librisxl-tools/postgresql/migrations/00000012-notify-cards-changed.plsql
@@ -26,8 +26,12 @@ BEGIN
    CREATE OR REPLACE FUNCTION lddb__notify_card()
        RETURNS trigger AS $$
    DECLARE
+       row RECORD;
    BEGIN
-       PERFORM pg_notify('lddb__cards_changed', OLD.id);
+       FOR row IN SELECT iri FROM lddb__identifiers WHERE id = OLD.id
+       LOOP
+           PERFORM pg_notify('lddb__cards_changed', row.iri);
+       END LOOP;
        RETURN NEW;
    END;
    $$ LANGUAGE plpgsql;

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -62,7 +62,7 @@ class Embellisher {
         Iterable<Map> previousLevelDocs = start + docs
 
         for (String lens : embellishLevels) {
-            docs = fetchNonVisited(lens, iris, visitedIris)
+            docs = fetchNonVisited(lens, iris, visitedIris).collect()
             docs += fetchNonVisited(lens, getCloseLinks(docs), visitedIris)
 
             previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -40,20 +40,16 @@ class Whelk {
 
     URI baseUri = null
 
-    // useCache may be set to true only when doing initial imports (temporary processes with the rest of Libris down).
-    // Any other use of this results in a "local" cache, which will not be invalidated when data changes elsewhere,
-    // resulting in potential serving of stale data.
-
     // TODO: encapsulate and configure (LXL-260)
     String vocabContextUri = "https://id.kb.se/vocab/context"
     String vocabDisplayUri = "https://id.kb.se/vocab/display"
     String vocabUri = "https://id.kb.se/vocab/"
 
-    static Whelk createLoadedCoreWhelk(String propName = "secret", boolean useCache = false) {
+    static Whelk createLoadedCoreWhelk(String propName = "secret", boolean useCache = true) {
         return createLoadedCoreWhelk(PropertyLoader.loadProperties(propName), useCache)
     }
 
-    static Whelk createLoadedCoreWhelk(Properties configuration, boolean useCache = false) {
+    static Whelk createLoadedCoreWhelk(Properties configuration, boolean useCache = true) {
         Whelk whelk = new Whelk(useCache ? new CachingPostgreSQLComponent(configuration) : new PostgreSQLComponent(configuration))
         if (configuration.baseUri) {
             whelk.baseUri = new URI((String) configuration.baseUri)
@@ -65,11 +61,11 @@ class Whelk {
         return whelk
     }
 
-    static Whelk createLoadedSearchWhelk(String propName = "secret", boolean useCache = false) {
+    static Whelk createLoadedSearchWhelk(String propName = "secret", boolean useCache = true) {
         return createLoadedSearchWhelk(PropertyLoader.loadProperties(propName), useCache)
     }
 
-    static Whelk createLoadedSearchWhelk(Properties configuration, boolean useCache = false) {
+    static Whelk createLoadedSearchWhelk(Properties configuration, boolean useCache = true) {
         Whelk whelk = new Whelk(configuration, useCache)
         if (configuration.baseUri) {
             whelk.baseUri = new URI((String) configuration.baseUri)
@@ -93,7 +89,7 @@ class Whelk {
         log.info("Started with storage: $storage")
     }
 
-    Whelk(Properties conf, useCache = false) {
+    Whelk(Properties conf, useCache = true) {
         this(useCache ? new CachingPostgreSQLComponent(conf) : new PostgreSQLComponent(conf), new ElasticSearch(conf))
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -132,7 +132,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                     .findAll { it.getName() == CARD_CHANGED_NOTIFICATION }
                     .each {
                         cardCache.invalidate(it.getParameter())
-                        log.info("Card changed, invalidating cache: {}", it.getParameter())
+                        log.debug("Card changed, invalidating cache: {}", it.getParameter())
                     }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache
 import groovy.util.logging.Log4j2 as Log
 import org.postgresql.PGConnection
 import whelk.Document
+import whelk.exception.WhelkRuntimeException
 
 import java.sql.Connection
 import java.sql.Statement
@@ -93,7 +94,8 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
             statement.execute("LISTEN $CARD_CHANGED_NOTIFICATION")
         }
         catch (Exception e) {
-            log.error("Error checking notifications: $e", e)
+            log.error("Error listening for notifications: $e", e)
+            throw new WhelkRuntimeException(e)
         }
         finally {
             close(statement, connection)
@@ -127,7 +129,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                     .findAll { it.getName() == CARD_CHANGED_NOTIFICATION }
                     .each {
                         cardCache.invalidate(it.getParameter())
-                        log.debug("Card changed, invalidating cache: {}", it.getParameter())
+                        log.info("Card changed, invalidating cache: {}", it.getParameter())
                     }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -124,7 +124,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
             }
 
             notifications
-                    .findAll() { it.getName() == CARD_CHANGED_NOTIFICATION }
+                    .findAll { it.getName() == CARD_CHANGED_NOTIFICATION }
                     .each {
                         cardCache.invalidate(it.getParameter())
                         log.debug("Card changed, invalidating cache: {}", it.getParameter())

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -4,18 +4,25 @@ import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
 import groovy.util.logging.Log4j2 as Log
+import org.postgresql.PGConnection
 import whelk.Document
 
 import java.sql.Connection
+import java.sql.Statement
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 @Log
 class CachingPostgreSQLComponent extends PostgreSQLComponent {
+    private static final String CARD_CHANGED_NOTIFICATION = "lddb__cards_changed"
     private static final int CARD_CACHE_MAX_SIZE = 250_000
     private LoadingCache<String, Map> cardCache
+    private ScheduledThreadPoolExecutor notificationTimer = new ScheduledThreadPoolExecutor(1)
 
     CachingPostgreSQLComponent(Properties properties) {
         super(properties)
         initCaches()
+        startNotificationListener()
     }
 
     @Override
@@ -75,5 +82,53 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                         return iris.collectEntries { [it, cards.get(irisToIds.get(it) ?: "NON-EXISTING")] }
                     }
                 })
+    }
+
+    private void startNotificationListener() {
+        Connection connection = null
+        Statement statement = null
+        try {
+            connection = getConnection()
+            statement = connection.createStatement()
+            statement.execute("LISTEN $CARD_CHANGED_NOTIFICATION")
+        }
+        catch (Exception e) {
+            log.error("Error checking notifications: $e", e)
+        }
+        finally {
+            close(statement, connection)
+        }
+
+        notificationTimer.scheduleWithFixedDelay(this.&checkNotifications, 1, 1, TimeUnit.SECONDS)
+    }
+
+    private void checkNotifications() {
+        Connection connection = null
+        try {
+            connection = getConnection()
+            checkNotifications(connection)
+        }
+        catch (Exception e) {
+            log.error("Error checking notifications: $e", e)
+        }
+        finally {
+            close(connection)
+        }
+    }
+
+    private void checkNotifications(Connection connection) {
+        connection.unwrap(PGConnection).with { pgConnection ->
+            def notifications = pgConnection.getNotifications()
+            if (!notifications) {
+                return
+            }
+
+            notifications
+                    .findAll() { it.getName() == CARD_CHANGED_NOTIFICATION }
+                    .each {
+                        cardCache.invalidate(it.getParameter())
+                        log.debug("Card changed, invalidating cache: ${it.getParameter()}")
+                    }
+        }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -127,7 +127,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                     .findAll() { it.getName() == CARD_CHANGED_NOTIFICATION }
                     .each {
                         cardCache.invalidate(it.getParameter())
-                        log.debug("Card changed, invalidating cache: ${it.getParameter()}")
+                        log.debug("Card changed, invalidating cache: {}", it.getParameter())
                     }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -7,6 +7,7 @@ import groovy.util.logging.Log4j2 as Log
 import org.postgresql.PGConnection
 import whelk.Document
 import whelk.exception.WhelkRuntimeException
+import whelk.util.Metrics
 
 import java.sql.Connection
 import java.sql.Statement
@@ -83,6 +84,8 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                         return iris.collectEntries { [it, cards.get(irisToIds.get(it) ?: "NON-EXISTING")] }
                     }
                 })
+
+        Metrics.cacheMetrics.addCache('cardCache', cardCache)
     }
 
     private void startNotificationListener() {

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -7,10 +7,10 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListenableFutureTask
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import groovy.util.logging.Log4j2 as Log
-import io.prometheus.client.guava.cache.CacheMetricsCollector
 import whelk.Document
 import whelk.Link
 import whelk.exception.MissingMainIriException
+import whelk.util.Metrics
 
 import java.util.concurrent.Callable
 import java.util.concurrent.Executor
@@ -23,8 +23,6 @@ import java.util.function.Supplier
 class DependencyCache {
     private static final int CACHE_SIZE = 10_000
     private static final int REFRESH_INTERVAL_MINUTES = 5
-
-    private static final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register()
 
     PostgreSQLComponent storage
 
@@ -46,8 +44,8 @@ class DependencyCache {
     DependencyCache(PostgreSQLComponent storage) {
         this.storage = storage
 
-        cacheMetrics.addCache('dependersCache', dependersCache)
-        cacheMetrics.addCache('dependencyCache', dependenciesCache)
+        Metrics.cacheMetrics.addCache('dependersCache', dependersCache)
+        Metrics.cacheMetrics.addCache('dependencyCache', dependenciesCache)
     }
 
     Set<String> getDependenciesOfType(String iri, String typeOfRelation) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -735,16 +735,17 @@ class PostgreSQLComponent {
     }
 
     void refreshDerivativeTables(Document doc, Connection connection, boolean deleted) {
-        saveIdentifiers(doc, connection, deleted)
-        saveDependencies(doc, connection)
-
         if (jsonld) {
+            // This needs to happen before identifiers are updated so that notifications for old IRIs can be sent.
             if (deleted) {
                 deleteCard(doc, connection)
             } else {
                 updateCard(new CardEntry(doc), connection)
             }
         }
+
+        saveIdentifiers(doc, connection, deleted)
+        saveDependencies(doc, connection)
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/util/Metrics.java
+++ b/whelk-core/src/main/groovy/whelk/util/Metrics.java
@@ -1,0 +1,7 @@
+package whelk.util;
+
+import io.prometheus.client.guava.cache.CacheMetricsCollector;
+
+public class Metrics {
+    public static final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register();
+}


### PR DESCRIPTION
Use Postgresql's LISTEN/NOTIFY mechanism to signal when cards are updated and the in-memory cache has to be invalidated.
Enable card caching by default.

(One potential problem (?) I see is that each process will be spammed with notifications of its own updates)