### PR TITLE
Feature/cache embellish again

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/Utils.java
+++ b/apix_server/src/main/java/whelk/apixserver/Utils.java
@@ -119,7 +119,7 @@ public class Utils
         String xlShortId = s_whelk.getStorage().getSystemIdByIri(xlUri);
         if (xlShortId == null)
             return null;
-        Document document = s_whelk.loadEmbellished(xlShortId);
+        Document document = s_whelk.loadExportEmbellished(xlShortId);
 
         if (document.getDeleted())
             return null;

--- a/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
+++ b/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
@@ -23,7 +23,7 @@ BEGIN
 
 
    -- ACTUAL SCHEMA CHANGES HERE:
-   CREATE TABLE IF NOT EXISTS lddb__embellished (
+   CREATE TABLE IF NOT EXISTS lddb__export_embellished (
       id text not null unique primary key,
       data jsonb not null
    );

--- a/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
+++ b/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
@@ -4,9 +4,9 @@ DO $$DECLARE
    -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
    
    -- The version you expect the database to have _before_ the migration
-   old_version numeric := 3;
+   old_version numeric := 11;
    -- The version the database should have _after_ the migration
-   new_version numeric := 4;
+   new_version numeric := 12;
 
    -- hands off
    existing_version numeric;

--- a/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
+++ b/librisxl-tools/postgresql/migrations/00000012-reinstate-embellish-cache.plpsql
@@ -1,0 +1,33 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+   
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 3;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 4;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+   CREATE TABLE IF NOT EXISTS lddb__embellished (
+      id text not null unique primary key,
+      data jsonb not null
+   );
+
+END$$;
+
+COMMIT;

--- a/marc_export/integtest/test.py
+++ b/marc_export/integtest/test.py
@@ -29,7 +29,7 @@ def reset():
     queueSql("delete from lddb__identifiers where id in (select id from lddb where changedIn = $$integtest$$);")
     queueSql("delete from lddb__versions where changedIn = $$integtest$$;")
     queueSql("delete from lddb__dependencies where id in (select id from lddb where changedIn = $$integtest$$);")
-    queueSql("delete from lddb__embellished;")
+    queueSql("delete from lddb__export_embellished;")
     queueSql("delete from lddb where changedIn = $$integtest$$;")
 
 def newBib(jsonstring, agent, systemid, timestring):

--- a/marc_export/integtest/test.py
+++ b/marc_export/integtest/test.py
@@ -29,6 +29,7 @@ def reset():
     queueSql("delete from lddb__identifiers where id in (select id from lddb where changedIn = $$integtest$$);")
     queueSql("delete from lddb__versions where changedIn = $$integtest$$;")
     queueSql("delete from lddb__dependencies where id in (select id from lddb where changedIn = $$integtest$$);")
+    queueSql("delete from lddb__embellished;")
     queueSql("delete from lddb where changedIn = $$integtest$$;")
 
 def newBib(jsonstring, agent, systemid, timestring):

--- a/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
@@ -10,7 +10,6 @@ import se.kb.libris.util.marc.io.MarcXmlRecordWriter;
 import whelk.Document;
 import whelk.JsonLd;
 import whelk.Whelk;
-import whelk.component.PostgreSQLComponent;
 import whelk.converter.marc.JsonLD2MarcXMLConverter;
 import whelk.util.MarcExport;
 import whelk.util.ThreadPool;
@@ -132,7 +131,7 @@ public class MarcCliExport
             while (resultSet.next())
             {
                 String id = resultSet.getString("id");
-                Document doc = m_whelk.loadEmbellished(id);
+                Document doc = m_whelk.loadExportEmbellished(id);
 
                 String marcXml = null;
                 try
@@ -225,7 +224,7 @@ public class MarcCliExport
                     continue;
                 }
 
-                Document document = m_whelk.loadEmbellished(systemID);
+                Document document = m_whelk.loadExportEmbellished(systemID);
 
                 Vector<MarcRecord> result = MarcExport.compileVirtualMarcRecord(batch.profile, document, m_whelk, m_toMarcXmlConverter);
                 if (result == null) // A conversion error will already have been logged.

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -135,7 +135,7 @@ public class ProfileExport
 
         if (collection.equals("bib") && updateShouldBeExported(id, collection, profile, from, until, created, deleted, connection))
         {
-            exportDocument(m_whelk.loadEmbellished(id), profile,
+            exportDocument(m_whelk.loadExportEmbellished(id), profile,
                     output, exportedIDs, deleteMode, doVirtualDeletions, deletedNotifications);
         }
         else if (collection.equals("auth") && updateShouldBeExported(id, collection, profile, from, until, created, deleted, connection))
@@ -144,7 +144,7 @@ public class ProfileExport
             for (Tuple2 depender : dependers)
             {
                 String dependerId = (String) depender.getFirst();
-                Document dependerDoc = m_whelk.loadEmbellished(dependerId);
+                Document dependerDoc = m_whelk.loadExportEmbellished(dependerId);
                 String dependerCollection = LegacyIntegrationTools.determineLegacyCollection(dependerDoc, m_whelk.getJsonld());
                 if (dependerCollection == null || !dependerCollection.equals("bib"))
                     continue;
@@ -177,7 +177,7 @@ public class ProfileExport
                 // itemOfSystemId _can_ be null, if the bib linked record is deleted (no thing-uri left in the id table)
                 if (itemOfSystemId != null) {
                     exportDocument(
-                            m_whelk.loadEmbellished(itemOfSystemId)
+                            m_whelk.loadExportEmbellished(itemOfSystemId)
                             , profile, output, exportedIDs, deleteMode, doVirtualDeletions, deletedNotifications);
                 } else {
                     logger.info("Not exporting {} ({}) for {} because of missing itemOf systemID", id,

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -143,7 +143,7 @@ public class ResponseCommon
     {
         if (embellish)
         {
-            document = OaiPmh.s_whelk.loadEmbellished(document.getShortId());
+            document = OaiPmh.s_whelk.loadExportEmbellished(document.getShortId());
         }
 
         if (!onlyIdentifiers)
@@ -261,7 +261,7 @@ public class ResponseCommon
                     continue;
                 if (!OaiPmh.s_whelk.getStorage().getCollectionBySystemID(systemID).equals("auth"))
                     continue;
-                Document auth = OaiPmh.s_whelk.loadEmbellished(systemID);
+                Document auth = OaiPmh.s_whelk.loadExportEmbellished(systemID);
 
                 writer.writeStartElement("auth");
                 writer.writeAttribute("id", auth.getShortId());

--- a/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
@@ -101,7 +101,7 @@ class LegacyMarcAPI extends HttpServlet {
             id = LegacyIntegrationTools.fixUri(id)
             library = LegacyIntegrationTools.fixUri(library)
             String systemId = whelk.storage.getSystemIdByIri(id)
-            Document rootDocument = whelk.loadEmbellished(systemId)
+            Document rootDocument = whelk.loadExportEmbellished(systemId)
             if (rootDocument == null) {
                 String message = "The supplied \"id\"-parameter must refer to an existing bibliographic record."
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, message)

--- a/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
@@ -98,7 +98,7 @@ class RecordRelationAPI extends HttpServlet {
         else if (returnMode.equals("embellished_record")) {
             List<Map> records = new ArrayList<>(result.size())
             for (String resultId : result) {
-                records.add( whelk.loadEmbellished(resultId).data )
+                records.add( whelk.loadExportEmbellished(resultId).data )
             }
             jsonString = PostgreSQLComponent.mapper.writeValueAsString(records)
         }

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -15,6 +15,7 @@ class Embellisher {
     JsonLd jsonld
     List<String> embellishLevels = DEFAULT_EMBELLISH_LEVELS
     List<String> closeRelations = DEFAULT_CLOSE_RELATIONS
+    boolean includeReverseRelations
 
     Function<Iterable<String>, Iterable<Map>> getDocs
     Function<Iterable<String>, Iterable<Map>> getCards
@@ -45,6 +46,10 @@ class Embellisher {
         this.closeRelations = closeRelations.collect()
     }
 
+    void setIncludeReverseRelations(boolean includeReverse) {
+        this.includeReverseRelations = includeReverse
+    }
+
     private List getEmbellishData(Document document) {
         if (document.getThingIdentifiers().isEmpty()) {
             return []
@@ -65,15 +70,19 @@ class Embellisher {
             docs = fetchNonVisited(lens, iris, visitedIris)
             docs += fetchNonVisited(lens, getCloseLinks(docs), visitedIris)
 
-            previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
+            if (includeReverseRelations) {
+                previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
+            }
             previousLevelDocs = docs
 
             result.addAll(docs)
 
             iris = getAllLinks(docs)
         }
-        // Last level: add reverse links, but not the documents linking here
-        previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
+        if (includeReverseRelations) {
+            // Last level: add reverse links, but not the documents linking here
+            previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
+        }
 
         return result
     }

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -15,7 +15,7 @@ class Embellisher {
     JsonLd jsonld
     List<String> embellishLevels = DEFAULT_EMBELLISH_LEVELS
     List<String> closeRelations = DEFAULT_CLOSE_RELATIONS
-    boolean includeReverseRelations
+    boolean includeReverseRelations = true
 
     Function<Iterable<String>, Iterable<Map>> getDocs
     Function<Iterable<String>, Iterable<Map>> getCards

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -408,9 +408,7 @@ class Whelk {
     }
 
     Document loadEmbellished(String systemId) {
-        Document doc = getDocument(systemId)
-        embellish(doc)
-        return doc
+        return storage.loadEmbellished(systemId, this.&embellish)
     }
 
     List<Document> getAttachedHoldings(List<String> thingIdentifiers) {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -396,23 +396,24 @@ class Whelk {
         }
     }
 
-    void embellish(Document document, List<String> levels = null) {
+    void embellish(Document document, List<String> levels = null, boolean includeReverseRelations = true) {
         def docsByIris = { List<String> iris -> bulkLoad(iris).values().collect{ it.data } }
         Embellisher e = new Embellisher(jsonld, docsByIris, storage.&getCards, relations.&getByReverse)
 
         if(levels) {
             e.setEmbellishLevels(levels)
         }
+        e.setIncludeReverseRelations(includeReverseRelations)
 
         e.embellish(document)
     }
 
-    Document loadEmbellished(String systemId) {
-        return storage.loadEmbellished(systemId, this.&embellish)
+    Document loadExportEmbellished(String systemId) {
+        return storage.loadExportEmbellished(systemId, this.&embellish)
     }
 
     List<Document> getAttachedHoldings(List<String> thingIdentifiers) {
-        return storage.getAttachedHoldings(thingIdentifiers).collect(this.&loadEmbellished)
+        return storage.getAttachedHoldings(thingIdentifiers).collect(this.&loadExportEmbellished)
     }
 
     void normalize(Document doc) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -406,6 +406,7 @@ class PostgreSQLComponent {
         finally {
             try {resultSet.close()} catch (Exception e) { /* ignore */ }
             try {selectStatement.close()} catch (Exception e) { /* ignore */ }
+            try {connection.close()} catch (Exception e) { /* ignore */ }
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -366,7 +366,7 @@ class PostgreSQLComponent {
     }
 
     private void cacheEmbellishedDocument(String id, Document embellishedDocument, Connection connection) {
-        PreparedStatement preparedStatement
+        PreparedStatement preparedStatement = null
 
         try {
             preparedStatement = connection.prepareStatement(INSERT_EMBELLISHED_DOCUMENT)
@@ -376,8 +376,7 @@ class PostgreSQLComponent {
             preparedStatement.execute()
         }
         finally {
-            if (preparedStatement != null)
-                preparedStatement.close()
+            close(preparedStatement)
         }
     }
 
@@ -389,8 +388,8 @@ class PostgreSQLComponent {
      */
     Document loadExportEmbellished(String id, Closure embellish) {
         Connection connection = getConnection()
-        PreparedStatement selectStatement
-        ResultSet resultSet
+        PreparedStatement selectStatement = null
+        ResultSet resultSet = null
 
         try {
             selectStatement = connection.prepareStatement(GET_EMBELLISHED_DOCUMENT)
@@ -408,9 +407,7 @@ class PostgreSQLComponent {
             return document
         }
         finally {
-            try {resultSet.close()} catch (Exception e) { /* ignore */ }
-            try {selectStatement.close()} catch (Exception e) { /* ignore */ }
-            try {connection.close()} catch (Exception e) { /* ignore */ }
+            close(resultSet, selectStatement, connection)
         }
     }
 
@@ -429,9 +426,8 @@ class PostgreSQLComponent {
             return
         }
 
-        PreparedStatement preparedStatement
+        PreparedStatement preparedStatement = null
         try {
-
             String query = EVICT_EMBELLISHED_DEPENDERS
             String replacement = "'" + jsonld.NON_DEPENDANT_RELATIONS.join("', '") + "'"
             query = query.replace("€", replacement)
@@ -442,8 +438,7 @@ class PostgreSQLComponent {
             preparedStatement.execute()
         }
         finally {
-            if (preparedStatement != null)
-                preparedStatement.close()
+            close(preparedStatement)
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -105,10 +105,10 @@ class PostgreSQLComponent {
             "SELECT id, data FROM lddb__versions WHERE id = ? AND checksum = ?"
 
     private static final String GET_EMBELLISHED_DOCUMENT =
-            "SELECT data from lddb__embellished where id = ?"
+            "SELECT data from lddb__export_embellished where id = ?"
 
     private static final String INSERT_EMBELLISHED_DOCUMENT =
-            "INSERT INTO lddb__embellished (id, data) VALUES (?,?)"
+            "INSERT INTO lddb__export_embellished (id, data) VALUES (?,?)"
 
     private static final String EVICT_EMBELLISHED_DEPENDERS = """
             WITH RECURSIVE deps(i) AS (
@@ -118,7 +118,7 @@ class PostgreSQLComponent {
               FROM lddb__dependencies d
               INNER JOIN deps deps1 ON d.dependsonid = i AND d.relation NOT IN (€)
             )
-            DELETE FROM lddb__embellished where id in (SELECT i FROM deps)
+            DELETE FROM lddb__export_embellished where id in (SELECT i FROM deps)
             """
 
     private static final String GET_DOCUMENT_VERSION_BY_MAIN_ID = """
@@ -383,7 +383,7 @@ class PostgreSQLComponent {
      * If there isn't an embellished version cached already, one will be created
      * (lazy caching).
      */
-    Document loadEmbellished(String id, Closure embellish) {
+    Document loadExportEmbellished(String id, Closure embellish) {
         Connection connection = getConnection()
         PreparedStatement selectStatement
         ResultSet resultSet
@@ -399,7 +399,7 @@ class PostgreSQLComponent {
 
             // Cache-miss, embellish and store
             Document document = load(id, connection)
-            embellish(document)
+            embellish(document, null, false)
             cacheEmbellishedDocument(id, document, connection)
             return document
         }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -415,13 +415,12 @@ class PostgreSQLComponent {
 
         // On average once every 500000 calls, clear the whole cache instead, to keep it from growing.
         if (random.nextInt(500000) == 0xDEAD) {
-            PreparedStatement preparedStatement
+            PreparedStatement preparedStatement = null
             try {
                 preparedStatement = connection.prepareStatement(CLEAR_EMBELLISHED)
                 preparedStatement.execute()
             } finally {
-                if (preparedStatement != null)
-                    preparedStatement.close()
+               close(preparedStatement)
             }
             return
         }


### PR DESCRIPTION
Det här är en annan variant för att snabba upp exporter (jämför med https://github.com/libris/librisxl/pull/696).

Dvs, att återinföra den gamla embellished cachen, och evicta den rakt av om någonting i trädet ändrats (oaktat chips/cards/whatever).


En halvstor export från min lokala miljö tar på develop:
real	6m2,245s
Med dom här ändringarna reduceras det till:
real	2m54,414s

Så, det är en mer än halvering av tiden.