### PR TITLE
Apply inverses on revert

### DIFF
--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -392,6 +392,30 @@ class MarcFrameConverterSpec extends Specification {
         resultWithoutDollars != null
     }
 
+    def "should apply inverses"() {
+        Closure applyInverses = converter.conversion.&applyInverses
+        given:
+        def record = ['@id': null, controlNumber: "123"]
+        def thing = [
+            '@id': '1',
+            '@reverse': [
+                'broader': [['@id': '2'], ['@id': '3']]
+            ]
+        ]
+        when:
+        applyInverses(record, thing)
+        def revMap = thing.remove('@reverse')
+        then:
+        thing['narrower'] == [['@id': '2'], ['@id': '3']]
+
+        when: 'adding inverses to existing accumulates results'
+        thing['@reverse'] = revMap
+        applyInverses(record, thing)
+        thing.remove('@reverse')
+        then:
+        thing['narrower'] == [['@id': '2'], ['@id': '3'], ['@id': '2'], ['@id': '3']]
+    }
+
     void assertJsonEquals(result, expected) {
         def resultJson = json(result)
         def expectedJson = json(expected)


### PR DESCRIPTION
This is for LXL-3309. The gist of it is:

In MarcFrameConverter, if post-processing is turned on, go through the reverse map, look up key term in vocabIndex, and if the property has an owl:inverseOf, find the first value of that whose term is in vocabIndex, and add that property term to the thing as a regular property with all the incoming subjects as objects.

I've added a unit test, but this needs practical testing and considerations. For this to work at all, we need to ensure that the embellished data sent to revert also contains `@reverse` (and if it doesn't already, ensure that it isn't too costly to enable).

See LXL-3309 for more details and discussions about domain (e.g. to utilize this for removing redundant `hasReproduction` if those are generated from incoming `reproductionOf` links).