### PR TITLE
When a record changes, evict one level of dependencies.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -15,7 +15,6 @@ class Embellisher {
     JsonLd jsonld
     List<String> embellishLevels = DEFAULT_EMBELLISH_LEVELS
     List<String> closeRelations = DEFAULT_CLOSE_RELATIONS
-    boolean includeReverseRelations = true
 
     Function<Iterable<String>, Iterable<Map>> getDocs
     Function<Iterable<String>, Iterable<Map>> getCards
@@ -46,10 +45,6 @@ class Embellisher {
         this.closeRelations = closeRelations.collect()
     }
 
-    void setIncludeReverseRelations(boolean includeReverse) {
-        this.includeReverseRelations = includeReverse
-    }
-
     private List getEmbellishData(Document document) {
         if (document.getThingIdentifiers().isEmpty()) {
             return []
@@ -70,19 +65,16 @@ class Embellisher {
             docs = fetchNonVisited(lens, iris, visitedIris)
             docs += fetchNonVisited(lens, getCloseLinks(docs), visitedIris)
 
-            if (includeReverseRelations) {
-                previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
-            }
+            previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
             previousLevelDocs = docs
 
             result.addAll(docs)
 
             iris = getAllLinks(docs)
         }
-        if (includeReverseRelations) {
-            // Last level: add reverse links, but not the documents linking here
-            previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
-        }
+
+        // Last level: add reverse links, but not the documents linking here
+        previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
 
         return result
     }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -396,14 +396,13 @@ class Whelk {
         }
     }
 
-    void embellish(Document document, List<String> levels = null, boolean includeReverseRelations = true) {
+    void embellish(Document document, List<String> levels = null) {
         def docsByIris = { List<String> iris -> bulkLoad(iris).values().collect{ it.data } }
         Embellisher e = new Embellisher(jsonld, docsByIris, storage.&getCards, relations.&getByReverse)
 
         if(levels) {
             e.setEmbellishLevels(levels)
         }
-        e.setIncludeReverseRelations(includeReverseRelations)
 
         e.embellish(document)
     }


### PR DESCRIPTION
Jag tror INTE vi vill använda detta. Men se det som ett sätt att bolla ideer.

Förmodligen fungerar Olovs ide med att indexera cachen på ingående rader mycket bättre. Den är ju elegantare på det sätt att den fungerar "automatiskt" hur än embellish ändras i framtiden.

Det gör inte den här varianten, som istället är beroende av vissa antaganden, som kanske inte ens är sanna idag nämligen att:
1. reverselänkar tas bara in vid embellishroten (inte nånstans längre upp längs grenarna)
2. att en reverselänk alltid är ett löv.

Men i fall den andra varianten skulle visa sig problematisk och ovan två antaganden är sanna (över tid), så skulle det här också lösa problemet (och ändå tillåta reverserelationer i revert etc).