### PR TITLE
Include reverse relations in embellish cache

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/Utils.java
+++ b/apix_server/src/main/java/whelk/apixserver/Utils.java
@@ -119,7 +119,7 @@ public class Utils
         String xlShortId = s_whelk.getStorage().getSystemIdByIri(xlUri);
         if (xlShortId == null)
             return null;
-        Document document = s_whelk.loadExportEmbellished(xlShortId);
+        Document document = s_whelk.loadEmbellished(xlShortId);
 
         if (document.getDeleted())
             return null;

--- a/librisxl-tools/postgresql/migrations/00000013-add-referenced-ids-to-embellish-cache.plsql
+++ b/librisxl-tools/postgresql/migrations/00000013-add-referenced-ids-to-embellish-cache.plsql
@@ -1,0 +1,37 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+   
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 12;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 13;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+   DROP TABLE IF EXISTS lddb__export_embellished;
+   DROP TABLE IF EXISTS lddb__embellished;
+   CREATE TABLE lddb__embellished (
+      id text NOT NULL UNIQUE primary key,
+      data jsonb NOT NULL,
+      ids text[] NOT NULL
+   );
+
+   CREATE INDEX ON lddb__embellished USING gin (ids);
+
+END$$;
+
+COMMIT;

--- a/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
@@ -131,7 +131,7 @@ public class MarcCliExport
             while (resultSet.next())
             {
                 String id = resultSet.getString("id");
-                Document doc = m_whelk.loadExportEmbellished(id);
+                Document doc = m_whelk.loadEmbellished(id);
 
                 String marcXml = null;
                 try
@@ -224,7 +224,7 @@ public class MarcCliExport
                     continue;
                 }
 
-                Document document = m_whelk.loadExportEmbellished(systemID);
+                Document document = m_whelk.loadEmbellished(systemID);
 
                 Vector<MarcRecord> result = MarcExport.compileVirtualMarcRecord(batch.profile, document, m_whelk, m_toMarcXmlConverter);
                 if (result == null) // A conversion error will already have been logged.

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -135,7 +135,7 @@ public class ProfileExport
 
         if (collection.equals("bib") && updateShouldBeExported(id, collection, profile, from, until, created, deleted, connection))
         {
-            exportDocument(m_whelk.loadExportEmbellished(id), profile,
+            exportDocument(m_whelk.loadEmbellished(id), profile,
                     output, exportedIDs, deleteMode, doVirtualDeletions, deletedNotifications);
         }
         else if (collection.equals("auth") && updateShouldBeExported(id, collection, profile, from, until, created, deleted, connection))
@@ -144,7 +144,7 @@ public class ProfileExport
             for (Tuple2 depender : dependers)
             {
                 String dependerId = (String) depender.getFirst();
-                Document dependerDoc = m_whelk.loadExportEmbellished(dependerId);
+                Document dependerDoc = m_whelk.loadEmbellished(dependerId);
                 String dependerCollection = LegacyIntegrationTools.determineLegacyCollection(dependerDoc, m_whelk.getJsonld());
                 if (dependerCollection == null || !dependerCollection.equals("bib"))
                     continue;
@@ -177,7 +177,7 @@ public class ProfileExport
                 // itemOfSystemId _can_ be null, if the bib linked record is deleted (no thing-uri left in the id table)
                 if (itemOfSystemId != null) {
                     exportDocument(
-                            m_whelk.loadExportEmbellished(itemOfSystemId)
+                            m_whelk.loadEmbellished(itemOfSystemId)
                             , profile, output, exportedIDs, deleteMode, doVirtualDeletions, deletedNotifications);
                 } else {
                     logger.info("Not exporting {} ({}) for {} because of missing itemOf systemID", id,

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -143,7 +143,7 @@ public class ResponseCommon
     {
         if (embellish)
         {
-            document = OaiPmh.s_whelk.loadExportEmbellished(document.getShortId());
+            document = OaiPmh.s_whelk.loadEmbellished(document.getShortId());
         }
 
         if (!onlyIdentifiers)
@@ -261,7 +261,7 @@ public class ResponseCommon
                     continue;
                 if (!OaiPmh.s_whelk.getStorage().getCollectionBySystemID(systemID).equals("auth"))
                     continue;
-                Document auth = OaiPmh.s_whelk.loadExportEmbellished(systemID);
+                Document auth = OaiPmh.s_whelk.loadEmbellished(systemID);
 
                 writer.writeStartElement("auth");
                 writer.writeAttribute("id", auth.getShortId());

--- a/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.groovy
@@ -101,7 +101,7 @@ class LegacyMarcAPI extends HttpServlet {
             id = LegacyIntegrationTools.fixUri(id)
             library = LegacyIntegrationTools.fixUri(library)
             String systemId = whelk.storage.getSystemIdByIri(id)
-            Document rootDocument = whelk.loadExportEmbellished(systemId)
+            Document rootDocument = whelk.loadEmbellished(systemId)
             if (rootDocument == null) {
                 String message = "The supplied \"id\"-parameter must refer to an existing bibliographic record."
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, message)

--- a/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
@@ -98,7 +98,7 @@ class RecordRelationAPI extends HttpServlet {
         else if (returnMode.equals("embellished_record")) {
             List<Map> records = new ArrayList<>(result.size())
             for (String resultId : result) {
-                records.add( whelk.loadExportEmbellished(resultId).data )
+                records.add( whelk.loadEmbellished(resultId).data )
             }
             jsonString = PostgreSQLComponent.mapper.writeValueAsString(records)
         }

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -15,7 +15,6 @@ class Embellisher {
     JsonLd jsonld
     List<String> embellishLevels = DEFAULT_EMBELLISH_LEVELS
     List<String> closeRelations = DEFAULT_CLOSE_RELATIONS
-    boolean includeReverseRelations = true
 
     Function<Iterable<String>, Iterable<Map>> getDocs
     Function<Iterable<String>, Iterable<Map>> getCards
@@ -46,10 +45,6 @@ class Embellisher {
         this.closeRelations = closeRelations.collect()
     }
 
-    void setIncludeReverseRelations(boolean includeReverse) {
-        this.includeReverseRelations = includeReverse
-    }
-
     private List getEmbellishData(Document document) {
         if (document.getThingIdentifiers().isEmpty()) {
             return []
@@ -70,19 +65,15 @@ class Embellisher {
             docs = fetchNonVisited(lens, iris, visitedIris)
             docs += fetchNonVisited(lens, getCloseLinks(docs), visitedIris)
 
-            if (includeReverseRelations) {
-                previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
-            }
+            previousLevelDocs.each { insertInverseCards(lens, it, docs, visitedIris) }
             previousLevelDocs = docs
 
             result.addAll(docs)
 
             iris = getAllLinks(docs)
         }
-        if (includeReverseRelations) {
-            // Last level: add reverse links, but not the documents linking here
-            previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
-        }
+        // Last level: add reverse links, but not the documents linking here
+        previousLevelDocs.each { insertInverseCards(embellishLevels.last(), it, [], visitedIris) }
 
         return result
     }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -396,24 +396,23 @@ class Whelk {
         }
     }
 
-    void embellish(Document document, List<String> levels = null, boolean includeReverseRelations = true) {
+    void embellish(Document document, List<String> levels = null) {
         def docsByIris = { List<String> iris -> bulkLoad(iris).values().collect{ it.data } }
         Embellisher e = new Embellisher(jsonld, docsByIris, storage.&getCards, relations.&getByReverse)
 
         if(levels) {
             e.setEmbellishLevels(levels)
         }
-        e.setIncludeReverseRelations(includeReverseRelations)
 
         e.embellish(document)
     }
 
-    Document loadExportEmbellished(String systemId) {
-        return storage.loadExportEmbellished(systemId, this.&embellish)
+    Document loadEmbellished(String systemId) {
+        return storage.loadEmbellished(systemId, this.&embellish)
     }
 
     List<Document> getAttachedHoldings(List<String> thingIdentifiers) {
-        return storage.getAttachedHoldings(thingIdentifiers).collect(this.&loadExportEmbellished)
+        return storage.getAttachedHoldings(thingIdentifiers).collect(this.&loadEmbellished)
     }
 
     void normalize(Document doc) {


### PR DESCRIPTION
- Include reverse relations in embellish cache.
- Add an indexed column with ids referenced in the entry to make eviction easier and faster.