### PR TITLE
Use 'full' lens when calculating reverse links for doc

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -138,7 +138,7 @@ class Embellisher {
             }
 
             theThing[JsonLd.REVERSE_KEY][relation] = irisLinkingHere.collect { [(JsonLd.ID_KEY): it] }
-            if(applyLens) {
+            if (applyLens) {
                 cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
             }
         }

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -211,9 +211,11 @@ class JsonLd {
             }
         }
 
-        lensesById.values().each { Map lens ->
-            lens.put('showProperties', flattenedProps(lens))
-            lens.remove('fresnel:extends')
+        displayData['lensGroups']?.values()?.each { group ->
+            group.get('lenses')?.values()?.each { lens ->
+                lens.put('showProperties', flattenedProps(lens))
+                lens.remove('fresnel:extends')
+            }
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -183,7 +183,9 @@ class JsonLd {
         def lensesById = [:]
         displayData['lensGroups']?.values()?.each { group ->
             group.get('lenses')?.values()?.each { lens ->
-                lensesById[lens['@id']] = lens
+                if (lens['@id']) {
+                    lensesById[lens['@id']] = lens
+                }
             }
         }
 

--- a/whelk-core/src/test/groovy/EmbellishSpec.groovy
+++ b/whelk-core/src/test/groovy/EmbellishSpec.groovy
@@ -42,6 +42,21 @@ class EmbellishSpec extends Specification{
                                            'fresnel:extends': ['@id': 'Y-chips'],
                                            'showProperties' : ['fresnel:super', 'py2']
                                      ],
+                             ]],
+                     'full':
+                             ['lenses': [
+                                     'R': ['@type'          : 'fresnel:Lens',
+                                           'fresnel:extends': ['@id': 'R-cards'],
+                                           'showProperties' : ['fresnel:super']
+                                     ],
+                                     'X': ['@type'          : 'fresnel:Lens',
+                                           'fresnel:extends': ['@id': 'X-cards'],
+                                           'showProperties' : ['fresnel:super']
+                                     ],
+                                     'Y': ['@type'          : 'fresnel:Lens',
+                                           'fresnel:extends': ['@id': 'Y-cards'],
+                                           'showProperties' : ['fresnel:super']
+                                     ],
                              ]]]]
 
     /*

--- a/whelk-core/src/test/groovy/JsonLdSpec.groovy
+++ b/whelk-core/src/test/groovy/JsonLdSpec.groovy
@@ -348,8 +348,7 @@ class JsonLdSpec extends Specification {
                                  ]],
                          "cards":
                                  ["lenses": [
-                                         "Z": ["@type"          : "fresnel:Lens",
-                                               "@id"            : "Z-cards",
+                                         "Z": ["@type"          : "fresnel:Lens",  // no @id
                                                "fresnel:extends": ["@id": "X-chips"],
                                                "showProperties" : ["z1", "z2", "z3"]
                                          ],


### PR DESCRIPTION
This includes two fixes:
- Display lenses without `@id` didn't get any inherited properties
- Embellisher used lens of first embellish level instead of `full` when adding `@reverse` for starting document