### PR TITLE
API: Add _applyInverseOf parameter to CRUD GET

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -248,6 +248,11 @@ class Crud extends HttpServlet {
         if (request.shouldEmbellish()) {
             doc = doc.clone() // FIXME: this is because ETag calculation is done on non-embellished doc...
             whelk.embellish(doc)
+
+            // reverse links are inserted by embellish, so can only do this when embellished
+            if (request.shouldApplyInverseOf()) {
+                doc.applyInverses(whelk.jsonld)
+            }
         }
 
         if (request.getLens() != Lens.NONE) {

--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -58,6 +58,10 @@ class CrudGetRequest {
         return getBoolParameter("framed").orElse(contentType == MimeTypes.JSON)
     }
 
+    boolean shouldApplyInverseOf() {
+        return getBoolParameter("_applyInverseOf").orElse(false)
+    }
+
     View getView() {
         return view
     }

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -791,6 +791,12 @@ class Document {
         }
     }
 
+    void applyInverses(JsonLd jsonld) {
+        Map thing = get(thingPath)
+        jsonld.applyInverses(thing)
+        thing.remove(JsonLd.REVERSE_KEY)
+    }
+
     String getChecksum() {
         long checksum = calculateCheckSum(data, 1)
         return Long.toString(checksum)

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -565,6 +565,26 @@ class JsonLd {
         return true
     }
 
+    @TypeChecked(TypeCheckingMode.SKIP)
+    void applyInverses(Map thing) {
+        thing['@reverse']?.each { rel, subjects ->
+            Map relDescription = vocabIndex[rel]
+            // NOTE: resilient in case we add inverseOf as a direct term
+            def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
+            List revIds = asList(inverseOf)?.collect {
+                toTermKey((String) it['@id'])
+            }
+            String rev = revIds.find { it in vocabIndex }
+            if (rev) {
+                asList(thing.get(rev, [])).addAll(subjects)
+            }
+        }
+    }
+
+    static List asList(o) {
+        return (o instanceof List) ? (List) o : o != null ? [o] : []
+    }
+
     static List<List<String>> findPaths(Map obj, String key, String value) {
         return findPaths(obj, key, [value].toSet())
     }

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -567,12 +567,12 @@ class JsonLd {
 
     @TypeChecked(TypeCheckingMode.SKIP)
     void applyInverses(Map thing) {
-        thing['@reverse']?.each { rel, subjects ->
+        thing[REVERSE_KEY]?.each { rel, subjects ->
             Map relDescription = vocabIndex[rel]
             // NOTE: resilient in case we add inverseOf as a direct term
             def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
             List revIds = asList(inverseOf)?.collect {
-                toTermKey((String) it['@id'])
+                toTermKey((String) it[ID_KEY])
             }
             String rev = revIds.find { it in vocabIndex }
             if (rev) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -471,21 +471,8 @@ class MarcConversion {
     }
 
     void applyInverses(Map record, Map thing) {
-        JsonLd ld = converter.ld
-        thing['@reverse']?.each { rel, subjects ->
-            Map relDescription = ld.vocabIndex[rel]
-            // NOTE: resilient in case we add inverseOf as a direct term
-            def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
-            List revIds = Util.asList(inverseOf)?.collect {
-                ld.toTermKey(it['@id'])
-            }
-            String rev = revIds.find { it in ld.vocabIndex }
-            if (rev) {
-                Util.asList(thing.get(rev, [])).addAll(subjects)
-            }
-        }
+        converter.ld.applyInverses(thing)
     }
-
 }
 
 class MarcRuleSet {


### PR DESCRIPTION
Add `_applyInverseOf` parameter to CRUD GET
When `_applyInverseOf=true`, reverse relations in the document get evaluated to their inverse relation.
e.g. `@reverse/broader` becomes `narrower`

This is so that we can display them on id.kb.se, see https://github.com/libris/lxlviewer/pull/688

We don't want docs PUT back in in their expanded form by mistake. So this is a "private" parameter only for internal use (and filtered by the python backend). 