### PR TITLE
Fix the work as bib problem for exports.

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -210,6 +210,18 @@ public class ProfileExport
     {
         String profileName = profile.getProperty("name", "unknown");
 
+        /*
+        From a MARC perspective stuff that's now placed in the "work" section used to be a part of
+        the MARC "bib" dataset.
+
+        In order for the authupdate/bibupdate (on/off) etc settings to match what MARC-people expect,
+        changes in work-records need to be evaluated using the bib settings, even though work-records
+        within XL are really classified as "auth".
+
+        In other words, a change in a work, should result in an export, _even though_ authupdate=off.
+
+        hence:
+         */
         String usingCollectionRules = collection;
         if (collection == "auth" && workDerivativeTypes.contains(mainEntityType))
         {

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -210,24 +210,25 @@ public class ProfileExport
     {
         String profileName = profile.getProperty("name", "unknown");
 
+        String usingCollectionRules = collection;
         if (collection == "auth" && workDerivativeTypes.contains(mainEntityType))
         {
-            collection = "bib";
+            usingCollectionRules = "bib";
         }
 
-        if (profile.getProperty(collection+"create", "ON").equalsIgnoreCase("OFF") && created) {
+        if (profile.getProperty(usingCollectionRules+"create", "ON").equalsIgnoreCase("OFF") && created) {
             logger.debug("Not exporting created {} ({}) for {}", id, collection, profileName);
             return false; // Created records not requested
         }
-        if (profile.getProperty(collection+"update", "ON").equalsIgnoreCase("OFF") && !created) {
+        if (profile.getProperty(usingCollectionRules+"update", "ON").equalsIgnoreCase("OFF") && !created) {
             logger.debug("Not exporting updated {} ({}) for {}", id, collection, profileName);
             return false; // Updated records not requested
         }
-        if (profile.getProperty(collection+"delete", "ON").equalsIgnoreCase("OFF") && deleted) {
+        if (profile.getProperty(usingCollectionRules+"delete", "ON").equalsIgnoreCase("OFF") && deleted) {
             logger.debug("Not exporting deleted {} ({}) for {}", id, collection, profileName);
             return false; // Deleted records not requested
         }
-        Set<String> operators = profile.getSet(collection+"operators");
+        Set<String> operators = profile.getSet(usingCollectionRules+"operators");
         if ( !operators.isEmpty() )
         {
             Set<String> operatorsInInterval = getAllChangedBy(id, from, until, connection);
@@ -236,7 +237,7 @@ public class ProfileExport
                 operatorsInInterval.retainAll(operators);
                 // The intersection between chosen-operators and operators that changed the record is []
                 if (operatorsInInterval.isEmpty()) {
-                    logger.debug("Not exporting {} ({}) for {} because of operator settings", id, collection,
+                    logger.debug("Not exporting {} ({}) for {} because of operator settings", id, usingCollectionRules,
                             profileName);
                     return false; // Updates from this operator/changedBy not requested
                 }

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -223,7 +223,7 @@ public class ProfileExport
         hence:
          */
         String usingCollectionRules = collection;
-        if (collection == "auth" && workDerivativeTypes.contains(mainEntityType))
+        if (collection.equals("auth") && workDerivativeTypes.contains(mainEntityType))
         {
             usingCollectionRules = "bib";
         }


### PR DESCRIPTION
For the benefit of the  auth{update|create|delete} settings in the MARC export,
we consider derivatives of "Work" to be bib instead of auth, in order to not
needlessly cause breakage for libraries that do want work updates but not "auth"
updates.