### PR TITLE
Don´t revert auth 042 $9 when inCollection is uniformWorkTitle

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -21108,6 +21108,14 @@
       ]
     },
     "042": {
+      "match": [{
+          "when": {
+            "NOTE": "Drop uniformWorkTitle",
+            "onRevert": {"inCollection": {"@id": "https://id.kb.se/term/uniformWorkTitle"}}
+          },
+          "$9": {"ignoreOnRevert": true}
+        }
+      ],
       "NOTE:local": "ANVÄNDS NORMALT EJ I AUKTORITETSFORMATET",
       "NOTE:record-count": 34043,
       "$a": {"addLink": "descriptionAuthentication", "resourceType": "DescriptionAuthentication", "property": "code"},
@@ -21116,7 +21124,53 @@
         "resourceType": "TermCollection",
         "uriTemplate": "https://id.kb.se/term/{_}",
         "property": "code"
-      }
+      },
+      "_spec": [{
+        "name": "Do not produce subfield $9 with value 'uniformWorkTitle'",
+        "normalized": {
+          "042": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "xxx"}
+          ]}},
+        "result": {"mainEntity": {
+          "@type" : "Work",
+          "descriptionAuthentication": [
+            {
+              "@type": "DescriptionAuthentication",
+              "code": "xxx"
+            }
+          ],
+          "inCollection": [
+            {
+              "@id": "https://id.kb.se/term/uniformWorkTitle",
+              "@type": "TermCollection",
+              "code": "uniformWorkTitle"
+            }
+          ]
+        }}
+      },{
+        "name": "Produce subfield $9",
+        "normalized": {
+          "042": {"ind1": " ", "ind2": " ", "subfields": [
+            {"a": "xxx"},
+            {"9": "fack"}
+          ]}},
+        "result": {"mainEntity": {
+          "@type" : "Identity",
+          "descriptionAuthentication": [
+            {
+              "@type": "DescriptionAuthentication",
+              "code": "xxx"
+            }
+          ],
+          "inCollection": [
+            {
+              "@id": "https://id.kb.se/term/zzz",
+              "@type": "TermCollection",
+              "code": "fack"
+            }
+          ]
+        }}
+      }]
     },
     "043": {
       "aboutEntity": "?thing",


### PR DESCRIPTION
## Checklist:

- [x] I have run integTests
- [ ] Script to add `inCollection` `uniformWorkTitle` to auth-Works (from Marc21)

## Description:

With https://github.com/libris/definitions/pull/235 we add temporary collection for old MARC works - but we do not want them to be converted to auth `042 $9 uniformWorkTitle `

## Issues:

[LXL-3357](https://jira.kb.se/browse/LXL-3357)

## PR involved:

https://github.com/libris/definitions/pull/235