### PR TITLE
Fix dependency cache invalidation

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -58,6 +58,14 @@ class DependencyCache {
         return dependersCache.getUnchecked(new Link(iri: iri, relation: typeOfRelation))
     }
 
+    void invalidate(Document createdDoc) {
+        createdDoc.getThingIdentifiers().each {fromIri ->
+            createdDoc.getExternalRefs().each { link ->
+                invalidate(fromIri, link)
+            }
+        }
+    }
+
     void invalidate(Document preUpdateDoc, Document postUpdateDoc) {
         Set thingIris = new HashSet<>()
         thingIris.addAll(preUpdateDoc.getThingIdentifiers())

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -59,7 +59,7 @@ class DependencyCache {
     }
 
     void invalidate(Document createdDoc) {
-        createdDoc.getThingIdentifiers().each {fromIri ->
+        createdDoc.getThingIdentifiers().each { fromIri ->
             createdDoc.getExternalRefs().each { link ->
                 invalidate(fromIri, link)
             }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -731,9 +731,10 @@ class PostgreSQLComponent {
         try
         {
             connection.setAutoCommit(false)
-
-            Document result = storeAtomicUpdate(doc, minorUpdate, changedIn, changedBy, oldChecksum, connection)
+            List<Runnable> postCommitActions = []
+            Document result = storeAtomicUpdate(doc, minorUpdate, changedIn, changedBy, oldChecksum, connection, postCommitActions)
             connection.commit()
+            postCommitActions.each {it.run() }
             return result
         }
         finally {
@@ -763,7 +764,8 @@ class PostgreSQLComponent {
         }
     }
 
-    Document storeAtomicUpdate(Document doc, boolean minorUpdate, String changedIn, String changedBy, String oldChecksum, Connection connection) {
+    Document storeAtomicUpdate(Document doc, boolean minorUpdate, String changedIn, String changedBy,
+                                       String oldChecksum, Connection connection, List<Runnable> postCommitActions) {
         String id = doc.shortId
         log.debug("Saving (atomic update) ${id}")
 
@@ -825,13 +827,13 @@ class PostgreSQLComponent {
                 SortedSet<String> idsLinkingToOldId = getDependencyData(id, GET_DEPENDERS, connection)
                 for (String dependerId : idsLinkingToOldId) {
                     Document depender = load(dependerId, connection)
-                    storeAtomicUpdate(depender, true, changedIn, changedBy, depender.getChecksum(), connection)
+                    storeAtomicUpdate(depender, true, changedIn, changedBy, depender.getChecksum(), connection, postCommitActions)
                 }
             }
 
             refreshDerivativeTables(doc, connection, deleted)
 
-            dependencyCache.invalidate(preUpdateDoc, doc)
+            postCommitActions << { dependencyCache.invalidate(preUpdateDoc, doc) }
 
             log.debug("Saved document ${doc.getShortId()} with timestamps ${doc.created} / ${doc.modified}")
         } catch (PSQLException psqle) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -734,7 +734,7 @@ class PostgreSQLComponent {
             List<Runnable> postCommitActions = []
             Document result = storeAtomicUpdate(doc, minorUpdate, changedIn, changedBy, oldChecksum, connection, postCommitActions)
             connection.commit()
-            postCommitActions.each {it.run() }
+            postCommitActions.each { it.run() }
             return result
         }
         finally {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -618,6 +618,8 @@ class PostgreSQLComponent {
                 doc.setModified((Date) status['modified'])
             }
 
+            dependencyCache.invalidate(doc)
+
             log.debug("Saved document ${doc.getShortId()} with timestamps ${doc.created} / ${doc.modified}")
             return true
         } catch (PSQLException psqle) {


### PR DESCRIPTION
- Invalidate when creating new document
- Fix potential race where cache might be re-populated with old data because `invalidate` is called before commit of updated document.