### PR TITLE
Do not fail to remove recently changed records from Elastic.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -185,7 +185,7 @@ class ElasticSearch {
         log.debug("Deleting object with identifier ${toElasticId(identifier)}.")
         def dsl = ["query":["term":["_id":toElasticId(identifier)]]]
         def response = client.performRequest('POST',
-                "/${indexName}/_delete_by_query?conflicts=proceed",
+                "/${indexName}/_delete_by_query",
                 JsonOutput.toJson(dsl)).second
         Map responseMap = mapper.readValue(response, Map)
         log.debug("Response: ${responseMap.deleted} of ${responseMap.total} " +


### PR DESCRIPTION
When a record has (very) recently been updated, it cannot be deleted
until Elastic has decided that it (internally) is done with it, even though
it already answered that it was earlier. When this happens you get a
conflicting version-error. When such an error is registered, we should
retry - until the delete is successful.