### PR TITLE
CRUD API: Trim whitespace from strings in incoming document

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -497,6 +497,7 @@ class Crud extends HttpServlet {
 
         Document newDoc = new Document(requestBody)
         newDoc.normalizeUnicode()
+        newDoc.trimStrings()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         // TODO https://jira.kb.se/browse/LXL-1263
         newDoc.setControlNumber(newDoc.getShortId())
@@ -635,6 +636,7 @@ class Crud extends HttpServlet {
 
         Document updatedDoc = new Document(requestBody)
         updatedDoc.normalizeUnicode()
+        updatedDoc.trimStrings()
         updatedDoc.setId(documentId)
 
         log.debug("Checking permissions for ${updatedDoc}")

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -3,6 +3,7 @@ package whelk
 
 import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
+import whelk.util.DocumentUtil
 import whelk.util.LegacyIntegrationTools
 import whelk.util.PropertyLoader
 import whelk.util.Unicode
@@ -88,6 +89,14 @@ class Document {
         String json = mapper.writeValueAsString(data)
         if (!Unicode.isNormalized(json)) {
             data = mapper.readValue(Unicode.normalize(json), Map)
+        }
+    }
+
+    void trimStrings() {
+        DocumentUtil.traverse(data) { value, path ->
+            if (value instanceof String && value != value.trim()) {
+                return new DocumentUtil.Replace(value.trim())
+            }
         }
     }
 


### PR DESCRIPTION
Done at the API level since this is mostly an issue with manual cataloguing and there might be some (unlikely) reason we want to be able to store these kinds of strings.

See LXL-2551