### PR TITLE
Make multi-wildcard searches possible.

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -120,7 +120,7 @@ class Crud extends HttpServlet {
                             "no elastic component is configured.")
             return
         } catch (InvalidQueryException e) {
-            log.error("Invalid query: ${queryParameters}", e)
+            log.warn("Invalid query: ${queryParameters}")
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             response.sendError(HttpServletResponse.SC_BAD_REQUEST,

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -11,6 +11,7 @@ import se.kb.libris.utils.isbn.IsbnParser
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
+import whelk.exception.InvalidQueryException
 import whelk.util.DocumentUtil
 import whelk.util.Unicode
 
@@ -333,9 +334,12 @@ class ElasticSearch {
         Tuple2<Integer, String> response = client.performRequest('POST',
                 queryUrl,
                 JsonOutput.toJson(jsonDsl))
+
         int statusCode = response.first
         String responseBody = response.second
-        if (statusCode != 200) {
+        if (statusCode == 400) {
+            throw new InvalidQueryException("")
+        } else if (statusCode != 200) {
             log.warn("Unexpected response from ES: ${statusCode} ${responseBody}")
             return [:]
         }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -496,8 +496,6 @@ class ESQuery {
         if (queryString.findAll('\\"').size() % 2 != 0) {
             throw new whelk.exception.InvalidQueryException("Unbalanced quotation marks")
         }
-
-        // The following chars are ES operators and need to be escaped to be used as literals: \+-=|&><!(){}[]^"~*?:/
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -78,7 +78,7 @@ class ESQuery {
     @CompileStatic(TypeCheckingMode.SKIP)
     Map getESQuery(Map<String, String[]> queryParameters) {
         // Legit params and their uses:
-        //   q - query_string
+        //   q - query string, will be used as query_string or simple_query_string
         String q
         //   _limit, _offset - pagination
         int limit

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -71,10 +71,10 @@ class ESQuerySpec extends Specification {
         ['foo': ['bar', 'baz']] | [['bool': ['must': [
                                                 ['bool': [
                                                     'should': [
-                                                        ['simple_query_string': ['query': 'bar',
+                                                        ['query_string': ['query': 'bar',
                                                                                  'fields': ['foo'],
                                                                                  'default_operator': 'AND']],
-                                                        ['simple_query_string': ['query': 'baz',
+                                                        ['query_string': ['query': 'baz',
                                                                                  'fields': ['foo'],
                                                                                  'default_operator': 'AND']]
                                                     ]
@@ -89,10 +89,10 @@ class ESQuerySpec extends Specification {
         where:
         key   | vals           | result
         'foo' | ['bar', 'baz'] | ['bool': ['should': [
-                                              ['simple_query_string': ['query': 'bar',
+                                              ['query_string': ['query': 'bar',
                                                                        'fields': ['foo'],
                                                                        'default_operator': 'AND']],
-                                              ['simple_query_string': ['query': 'baz',
+                                              ['query_string': ['query': 'baz',
                                                                        'fields': ['foo'],
                                                                        'default_operator': 'AND']]]]]
     }

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -71,16 +71,31 @@ class ESQuerySpec extends Specification {
         ['foo': ['bar', 'baz']] | [['bool': ['must': [
                                                 ['bool': [
                                                     'should': [
-                                                        ['query_string': ['query': 'bar',
+                                                        ['simple_query_string': ['query': 'bar',
                                                                                  'fields': ['foo'],
                                                                                  'default_operator': 'AND']],
-                                                        ['query_string': ['query': 'baz',
+                                                        ['simple_query_string': ['query': 'baz',
                                                                                  'fields': ['foo'],
                                                                                  'default_operator': 'AND']]
                                                     ]
                                                 ]]
                                             ]]
                                   ]]
+
+        ['foo': ['*bar', 'baz']] | [['bool': ['must': [
+                                                ['bool': [
+                                                    'should': [
+                                                        ['query_string'        : ['query': '*bar',
+                                                                                 'fields': ['foo'],
+                                                                                 'default_operator': 'AND']],
+                                                        ['simple_query_string' : ['query': 'baz',
+                                                                                 'fields': ['foo'],
+                                                                                 'default_operator': 'AND']]
+                                                    ]
+                                                ]]
+                                            ]]
+                                   ]]
+
     }
 
     def "should create bool filter"(String key, String[] vals, Map result) {
@@ -89,10 +104,17 @@ class ESQuerySpec extends Specification {
         where:
         key   | vals           | result
         'foo' | ['bar', 'baz'] | ['bool': ['should': [
-                                              ['query_string': ['query': 'bar',
+                                              ['simple_query_string': ['query': 'bar',
                                                                        'fields': ['foo'],
                                                                        'default_operator': 'AND']],
-                                              ['query_string': ['query': 'baz',
+                                              ['simple_query_string': ['query': 'baz',
+                                                                       'fields': ['foo'],
+                                                                       'default_operator': 'AND']]]]]
+        'foo' | ['bar', '*baz'] | ['bool': ['should': [
+                                              ['simple_query_string': ['query': 'bar',
+                                                                       'fields': ['foo'],
+                                                                       'default_operator': 'AND']],
+                                              ['query_string'       : ['query': '*baz',
                                                                        'fields': ['foo'],
                                                                        'default_operator': 'AND']]]]]
     }
@@ -216,5 +238,19 @@ class ESQuerySpec extends Specification {
         then:
         emptyExpected == es.hideKeywordFields(emptyEsResponse)
         expected == es.hideKeywordFields(esResponse)
+    }
+    
+    def "should recognize leading wildcard queries"() {
+        expect:
+        ESQuery.isSimple(query) == result
+
+        where:
+        query       | result
+        "*"         | true
+        "*   "      | true
+        "*foo"      | false
+        "foo *bar"  | false
+        "foo* bar"  | true
+        "foo* *bar" | false
     }
 }


### PR DESCRIPTION
For example "*kol*" should match "skolor".
To do this, we're switching all instances of simple query strings, to
query strings (ES nomenclature).

Side-effects of this are:
1. Queries can now fail (must be handled)
2. Character escaping becomes necessary in implict filters.
3. Character escaping will also be necessary in the "search box" if such
   chars are ever used there.