### PR TITLE
Whelktool: Add default reports

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/Statistics.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Statistics.groovy
@@ -80,4 +80,7 @@ class Statistics {
         return this
     }
 
+    boolean isEmpty() {
+        c.isEmpty()
+    }
 }

--- a/whelktool/scripts/examples/statistics.groovy
+++ b/whelktool/scripts/examples/statistics.groovy
@@ -1,0 +1,6 @@
+// See STATISTICS.txt in report dir
+incrementStats('category', 'name', 'example')
+
+selectByCollection('auth') {
+    incrementStats('type', it.graph[1]['@type'])
+}

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -440,10 +440,10 @@ class WhelkTool {
     }
 
     private void doDeletion(DocumentItem item) {
-        deletedLog.println(item.doc.shortId)
         if (!dryRun) {
             whelk.remove(item.doc.shortId, changedIn, scriptJobUri)
         }
+        deletedLog.println(item.doc.shortId)
     }
 
     private boolean doRevertToTime(DocumentItem item) {
@@ -491,10 +491,10 @@ class WhelkTool {
         Document doc = item.doc
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
-        modifiedLog.println(doc.shortId)
         if (!dryRun) {
             whelk.storeAtomicUpdate(doc, !item.loud, changedIn, scriptJobUri, item.preUpdateChecksum, !skipIndex)
         }
+        modifiedLog.println(doc.shortId)
     }
 
     private void doSaveNew(DocumentItem item) {
@@ -502,12 +502,12 @@ class WhelkTool {
         doc.setControlNumber(doc.getShortId())
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
-        createdLog.println(doc.shortId)
         if (!dryRun) {
             if (!whelk.createDocument(doc, changedIn, scriptJobUri,
                     LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld()), false, !skipIndex))
                 throw new WhelkException("Failed to save a new document. See general whelk log for details.")
         }
+        createdLog.println(doc.shortId)
     }
 
     private boolean confirmNextStep(String inJsonStr, Document doc) {


### PR DESCRIPTION
Reduce boilerplate in whelktool scripts
* Automatically create `MODIFIED.txt`, `CREATED.txt`, `DELETED.txt` with ids of touched records.
* Add a new method `incrementStats` that if used logs to `STATISTICS.txt`

This also opens up for more automated rollback/revert of whelktool runs.

Often we want to log some more information about modified records. That is done in the same way as today, i.e. by manually creating a report writer.