### PR TITLE
ES: Add keyword field for prefLabel to enable sorting on it

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -209,6 +209,15 @@
                     }
                 }
             },
+            "prefLabel": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword"
+                    }
+                },
+                "copy_to": "_all"
+            },
             "_links": {
                 "type": "keyword",
                 "copy_to": "_all"


### PR DESCRIPTION
Use both text and keyword so that we still have full-text search for `prefLabel`.
Whelk automatically uses `prefLabel.keyword` for sorting.

Tested locally.