### PR TITLE
Feature/extend validator statistics

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
@@ -87,7 +87,7 @@ class JsonLdValidator {
     private void checkIsNotNestedGraph(String key, value, validation) {
         if (key == jsonLd.GRAPH_KEY) {
             if (validation.seenGraph) {
-                handleError(new Error(Error.Type.NESTED_GRAPH, key, value?.toString()), validation)
+                handleError(new Error(Error.Type.NESTED_GRAPH, key, value), validation)
             }
             validation.seenGraph = true
         }
@@ -109,7 +109,7 @@ class JsonLdValidator {
 
     private boolean isUnexpected(String key, value, validation) { //Rename me
         if ((key == jsonLd.ID_KEY || key == jsonLd.TYPE_KEY) && !(value instanceof String)) {
-            handleError(new Error(Error.Type.UNEXPECTED, key, value?.toString()), validation)
+            handleError(new Error(Error.Type.UNEXPECTED, key, value), validation)
             return true
         } else {
             return false
@@ -131,16 +131,16 @@ class JsonLdValidator {
     private void verifyVocabTerm(String key, value, validation) {
         if ((key == jsonLd.TYPE_KEY || isVocabTerm(key))
                 && !jsonLd.vocabIndex.containsKey(value?.toString())) {
-            handleError(new Error(Error.Type.UNKNOWN_VOCAB_VALUE, key, value?.toString()), validation)
+            handleError(new Error(Error.Type.UNKNOWN_VOCAB_VALUE, key, value), validation)
         }
     }
 
     private void validateRepeatability(String key, value, validation) {
         boolean expectRepeat = key == jsonLd.GRAPH_KEY || key in jsonLd.getRepeatableTerms()
         if (expectRepeat && !isRepeated(value)) {
-            handleError(new Error(Error.Type.ARRAY_EXPECTED, key, value?.toString()), validation)
+            handleError(new Error(Error.Type.ARRAY_EXPECTED, key, value), validation)
         } else if (!expectRepeat && isRepeated(value)) {
-            handleError(new Error(Error.Type.UNEXPECTED_ARRAY, key, value?.toString()), validation)
+            handleError(new Error(Error.Type.UNEXPECTED_ARRAY, key, value), validation)
         }
     }
 
@@ -152,9 +152,9 @@ class JsonLdValidator {
         if (firstValue && termDefinition
                 && termDefinition[jsonLd.TYPE_KEY] == 'ObjectProperty') {
             if (!isVocabTerm(key) && !valueIsObject) {
-                handleError(new Error(Error.Type.OBJECT_TYPE_EXPECTED, key, value?.toString()) , validation)
+                handleError(new Error(Error.Type.OBJECT_TYPE_EXPECTED, key, value) , validation)
             } else if (isVocabTerm(key) && valueIsObject) {
-                handleError(new Error(Error.Type.VOCAB_STRING_EXPECTED, key, value?.toString()), validation)
+                handleError(new Error(Error.Type.VOCAB_STRING_EXPECTED, key, value), validation)
             }
         }
     }
@@ -219,9 +219,9 @@ class JsonLdValidator {
         List path
 
         private final String key
-        private final String value
+        private final Object value
 
-        Error(Type type, String key, String value = "") {
+        Error(Type type, String key, Object value = "") {
             this.type = type
             this.key = key
             this.value = value

--- a/whelktool/scripts/analysis/extended-validator-statistics.groovy
+++ b/whelktool/scripts/analysis/extended-validator-statistics.groovy
@@ -1,0 +1,99 @@
+import whelk.JsonLdValidator
+import whelk.JsonLdValidator.Error as JsonError
+import whelk.util.Statistics
+import whelk.util.DocumentUtil
+
+class Script {
+    static PrintWriter report
+    static Statistics s = new Statistics(6).printOnShutdown()
+    static JsonLdValidator v
+    static boolean isInitialized = false
+    static Set<String> expectsSetsWithConflicts = new HashSet<>()
+}
+
+Script.report = getReportWriter("report.txt")
+
+selectByCollection('bib') { rec ->
+    synchronized (this) {
+        if (!Script.isInitialized) {
+            Script.v = JsonLdValidator.from(rec.whelk.jsonld)
+            Script.v.skipUndefined()
+            Script.isInitialized = true
+        }
+    }
+
+    try {
+        process(rec)
+    }
+    catch(Exception e) {
+        System.err.println("${rec.doc.shortId} $e")
+        e.printStackTrace()
+    }
+}
+
+void process(rec) {
+    Set<String> pathsToConflictingSetTerms = getPathsToConflictingSetTerms(rec)
+    pathsToConflictingSetTerms.each {
+        Script.s.increment("Term with conflicting repeatability", it, rec.doc.getShortId())
+    }
+
+    List<JsonError> errors = Script.v.validateAll(rec.doc.data)
+
+    errors.each {
+        String valsize = ''
+        if (it.value instanceof List) {
+            valsize = ":${representSize(it.value.size())}"
+        }
+        String message = "path: ${representPath(it.path)}${valsize}"
+        if (it.type == JsonError.Type.UNKNOWN_VOCAB_VALUE ||
+            it.type == JsonError.Type.UNEXPECTED) {
+            message += " value: ${it.value}"
+        }
+        if (message in pathsToConflictingSetTerms) {
+            message += ' (KNOWN)'
+        }
+        Script.s.increment(it.getDescription(), message, rec.doc.getShortId())
+    }
+    if (errors) {
+        Script.report.println(rec.doc.shortId)
+    }
+}
+
+String representPath(List path) {
+    return path.join('.')
+        .replaceAll(/^@graph\.0/, 'record')
+        .replaceAll(/^@graph\.1/, 'instance')
+        .replaceAll(/^@graph\.2/, 'work')
+        .replaceAll(/\.\d+/, '[]')
+}
+
+String representSize(int size) {
+    size > 4 ? '5+' : size > 1 ? '2+' : size.toString()
+}
+
+Set<String> getPathsToConflictingSetTerms(rec) {
+    if (Script.expectsSetsWithConflicts.size() == 0) {
+        synchronized (Script.expectsSetsWithConflicts) {
+            rec.whelk.marcFrameConverter.conversion.badRepeats.each {
+                Script.expectsSetsWithConflicts << it.term
+            }
+        }
+    }
+    Set<String> pathsToSetsWithList = new HashSet<>()
+    DocumentUtil.traverse(rec.doc.data, { value, path ->
+        if (!path) {
+            return
+        }
+        String key = path.last()
+        if (key in Script.expectsSetsWithConflicts) {
+            String valsize = ''
+            if (value instanceof List) {
+                valsize = ":${representSize(value.size())}"
+            }
+            String message = "path: ${representPath(path)}${valsize}"
+            pathsToSetsWithList << message
+        }
+        return
+    })
+    return pathsToSetsWithList
+}

--- a/whelktool/scripts/analysis/validator-statistics.groovy
+++ b/whelktool/scripts/analysis/validator-statistics.groovy
@@ -1,99 +1,46 @@
 import whelk.JsonLdValidator
 import whelk.JsonLdValidator.Error as JsonError
 import whelk.util.Statistics
-import whelk.util.DocumentUtil
 
 class Script {
     static PrintWriter report
     static Statistics s = new Statistics(6).printOnShutdown()
     static JsonLdValidator v
     static boolean isInitialized = false
-    static Set<String> expectsSetsWithConflicts = new HashSet<>()
 }
 
 Script.report = getReportWriter("report.txt")
 
-selectByCollection('bib') { rec ->
+selectByCollection('bib') { bib ->
     synchronized (this) {
         if (!Script.isInitialized) {
-            Script.v = JsonLdValidator.from(rec.whelk.jsonld)
+            Script.v = JsonLdValidator.from(bib.whelk.jsonld)
             Script.v.skipUndefined()
             Script.isInitialized = true
         }
     }
 
     try {
-        process(rec)
+        process(bib)
     }
     catch(Exception e) {
-        System.err.println("${rec.doc.shortId} $e")
+        System.err.println("${bib.doc.shortId} $e")
         e.printStackTrace()
     }
 }
 
-void process(rec) {
-    Set<String> pathsToConflictingSetTerms = getPathsToConflictingSetTerms(rec)
-    pathsToConflictingSetTerms.each {
-        Script.s.increment("Term with conflicting repeatability", it, rec.doc.getShortId())
-    }
-
-    List<JsonError> errors = Script.v.validateAll(rec.doc.data)
+void process(bib) {
+    List<JsonError> errors = Script.v.validateAll(bib.doc.data)
 
     errors.each {
-        String valsize = ''
-        if (it.value instanceof List) {
-            valsize = ":${representSize(it.value.size())}"
-        }
-        String message = "path: ${representPath(it.path)}${valsize}"
+        def message = "key: " + it.key
         if (it.type == JsonError.Type.UNKNOWN_VOCAB_VALUE ||
             it.type == JsonError.Type.UNEXPECTED) {
-            message += " value: ${it.value}"
+            message = message + " value: " + it.value
         }
-        if (message in pathsToConflictingSetTerms) {
-            message += ' (KNOWN)'
-        }
-        Script.s.increment(it.getDescription(), message, rec.doc.getShortId())
+        Script.s.increment(it.getDescription(), message, bib.doc.getShortId())
     }
     if (errors) {
-        Script.report.println(rec.doc.shortId)
+        Script.report.println(bib.doc.shortId)
     }
-}
-
-String representPath(List path) {
-    return path.join('.')
-        .replaceAll(/^@graph\.0/, 'record')
-        .replaceAll(/^@graph\.1/, 'instance')
-        .replaceAll(/^@graph\.2/, 'work')
-        .replaceAll(/\.\d+/, '[]')
-}
-
-String representSize(int size) {
-    size > 4 ? '5+' : size > 1 ? '2+' : size.toString()
-}
-
-Set<String> getPathsToConflictingSetTerms(rec) {
-    if (Script.expectsSetsWithConflicts.size() == 0) {
-        synchronized (Script.expectsSetsWithConflicts) {
-            rec.whelk.marcFrameConverter.conversion.badRepeats.each {
-                Script.expectsSetsWithConflicts << it.term
-            }
-        }
-    }
-    Set<String> pathsToSetsWithList = new HashSet<>()
-    DocumentUtil.traverse(rec.doc.data, { value, path ->
-        if (!path) {
-            return
-        }
-        String key = path.last()
-        if (key in Script.expectsSetsWithConflicts) {
-            String valsize = ''
-            if (value instanceof List) {
-                valsize = ":${representSize(value.size())}"
-            }
-            String message = "path: ${representPath(path)}${valsize}"
-            pathsToSetsWithList << message
-        }
-        return
-    })
-    return pathsToSetsWithList
 }

--- a/whelktool/scripts/analysis/validator-statistics.groovy
+++ b/whelktool/scripts/analysis/validator-statistics.groovy
@@ -1,12 +1,14 @@
 import whelk.JsonLdValidator
 import whelk.JsonLdValidator.Error as JsonError
 import whelk.util.Statistics
+import whelk.util.DocumentUtil
 
 class Script {
     static PrintWriter report
     static Statistics s = new Statistics(6).printOnShutdown()
     static JsonLdValidator v
     static boolean isInitialized = false
+    static Set<String> expectsSetsWithConflicts = new HashSet<>()
 }
 
 Script.report = getReportWriter("report.txt")
@@ -30,17 +32,68 @@ selectByCollection('bib') { bib ->
 }
 
 void process(bib) {
+    Set<String> pathsToConflictingSetTerms = getPathsToConflictingSetTerms(bib)
+    pathsToConflictingSetTerms.each {
+        Script.s.increment("Term with conflicting repeatability", it, bib.doc.getShortId())
+    }
+
     List<JsonError> errors = Script.v.validateAll(bib.doc.data)
 
     errors.each {
-        def message = "key: " + it.key
+        String valsize = ''
+        if (it.value instanceof List) {
+            valsize = ":${representSize(it.value.size())}"
+        }
+        String message = "path: ${representPath(it.path)}${valsize}"
         if (it.type == JsonError.Type.UNKNOWN_VOCAB_VALUE ||
             it.type == JsonError.Type.UNEXPECTED) {
-            message = message + " value: " + it.value
+            message += " value: ${it.value}"
+        }
+        if (message in pathsToConflictingSetTerms) {
+            message += ' (KNOWN)'
         }
         Script.s.increment(it.getDescription(), message, bib.doc.getShortId())
     }
     if (errors) {
         Script.report.println(bib.doc.shortId)
     }
+}
+
+String representPath(List path) {
+    return path.join('.')
+        .replaceAll(/^@graph\.0/, 'record')
+        .replaceAll(/^@graph\.1/, 'instance')
+        .replaceAll(/^@graph\.2/, 'work')
+        .replaceAll(/\.\d+/, '[]')
+}
+
+String representSize(int size) {
+    size > 4 ? '5+' : size > 1 ? '2+' : size.toString()
+}
+
+Set<String> getPathsToConflictingSetTerms(bib) {
+    if (Script.expectsSetsWithConflicts.size() == 0) {
+        synchronized (Script.expectsSetsWithConflicts) {
+            bib.whelk.marcFrameConverter.conversion.badRepeats.each {
+                Script.expectsSetsWithConflicts << it.term
+            }
+        }
+    }
+    Set<String> pathsToSetsWithList = new HashSet<>()
+    DocumentUtil.traverse(bib.doc.data, { value, path ->
+        if (!path) {
+            return
+        }
+        String key = path.last()
+        if (key in Script.expectsSetsWithConflicts) {
+            String valsize = ''
+            if (value instanceof List) {
+                valsize = ":${representSize(value.size())}"
+            }
+            String message = "path: ${representPath(path)}${valsize}"
+            pathsToSetsWithList << message
+        }
+        return
+    })
+    return pathsToSetsWithList
 }


### PR DESCRIPTION
This is mainly for adding known irregular terms to the validator statistics report.

Specifically, this now collects all terms that are sometimes, but not always, used as repeatable (set-container) terms from the MarcFrameConverter, and list all paths to these.

It also reports full paths on validation errors, and marks those that are known as problematic (from MarcFrameConverter as per above), so we may ignore them and treat those that are unknown separately (this might be because their sources aren't MARC21, or that they've been edited or processed).

The paths are also annotated with "1", "2+" or "5+" to represent one, more than one or more than four list items respectively.