### PR TITLE
Feature/lxl 3440 update virtuoso triples continuously 2

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000015-add-sparql-queue.plsql
+++ b/librisxl-tools/postgresql/migrations/00000015-add-sparql-queue.plsql
@@ -1,0 +1,31 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+   
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 14;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 15;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+   CREATE TABLE IF NOT EXISTS lddb__sparql_q (
+       pk serial PRIMARY KEY,
+       id text not null
+   );
+END$$;
+
+COMMIT;

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -16,7 +16,7 @@ import whelk.JsonLdValidator
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.exception.ElasticIOException
-import whelk.exception.ElasticStatusException
+import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.InvalidQueryException
 import whelk.exception.ModelValidationException
 import whelk.exception.StaleUpdateException
@@ -107,7 +107,7 @@ class Crud extends HttpServlet {
             Map results = search.doSearch(queryParameters)
             def jsonResult = mapper.writeValueAsString(results)
             sendResponse(response, jsonResult, "application/json")
-        } catch (ElasticIOException | ElasticStatusException e) {
+        } catch (ElasticIOException | UnexpectedHttpStatusException e) {
             log.error("Attempted elastic query, but failed: $e", e)
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -96,7 +96,7 @@ class Whelk {
             timezone = ZoneId.of((String) configuration.timezone)
         }
         loadCoreData()
-        initSparqlUpdater(configuration)
+        sparqlUpdater = SparqlUpdater.build(storage, jsonld.context, configuration)
     }
 
     synchronized MarcFrameConverter getMarcFrameConverter() {
@@ -117,21 +117,6 @@ class Whelk {
         loadVocabData()
         setJsonld(new JsonLd(contextData, displayData, vocabData))
         log.info("Loaded with core data")
-    }
-
-    void initSparqlUpdater(Properties props) {
-        String sparqlCrudUrl = props.getProperty("sparqlCrudUrl")
-        if (sparqlCrudUrl) {
-            Virtuoso virtuoso = new Virtuoso(
-                    jsonld.context,
-                    SparqlUpdater.buildHttpClient(),
-                    sparqlCrudUrl,
-                    props.getProperty("sparqlUser"),
-                    props.getProperty("sparqlPass"))
-
-            this.sparqlUpdater = new SparqlUpdater(storage, virtuoso)
-            storage.sparqlQueueEnabled = true
-        }
     }
 
     void setJsonld(JsonLd jsonld) {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -9,7 +9,6 @@ import whelk.component.DocumentNormalizer
 import whelk.component.ElasticSearch
 import whelk.component.PostgreSQLComponent
 import whelk.component.SparqlUpdater
-import whelk.component.Virtuoso
 import whelk.converter.marc.MarcFrameConverter
 import whelk.exception.StorageCreateFailedException
 import whelk.filter.LinkFinder
@@ -332,9 +331,7 @@ class Whelk {
                 elastic.index(document, this)
                 reindexAffected(document, new TreeSet<>(), document.getExternalRefs())
             }
-            if (sparqlUpdater) {
-                sparqlUpdater.poke()
-            }
+            sparqlUpdater?.pollNow()
         }
         return success
     }
@@ -356,9 +353,7 @@ class Whelk {
         }
 
         reindex(updated, preUpdateDoc)
-        if (sparqlUpdater) {
-            sparqlUpdater.poke()
-        }
+        sparqlUpdater?.pollNow()
     }
 
     Document storeAtomicUpdate(Document doc, boolean minorUpdate, String changedIn, String changedBy, String oldChecksum, boolean index = true) {
@@ -372,9 +367,7 @@ class Whelk {
         if (index) {
             reindex(updated, preUpdateDoc)
         }
-        if (sparqlUpdater) {
-            sparqlUpdater.poke()
-        }
+        sparqlUpdater?.pollNow()
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -26,7 +26,7 @@ import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
 import whelk.exception.ElasticIOException
-import whelk.exception.ElasticStatusException
+import whelk.exception.UnexpectedHttpStatusException
 
 import java.time.Duration
 import java.util.function.Function
@@ -109,7 +109,7 @@ class ElasticClient {
     }
 
     String performRequest(String method, String path, String body, String contentType0 = null)
-        throws ElasticIOException, ElasticStatusException {
+        throws ElasticIOException, UnexpectedHttpStatusException {
         try {
             def nodes = cycleNodes()
             if (useCircuitBreaker) {
@@ -119,7 +119,7 @@ class ElasticClient {
                 nodes.next().performRequest(method, path, body, contentType0)
             }
         }
-        catch (ElasticStatusException e) {
+        catch (UnexpectedHttpStatusException e) {
             throw e
         }
         catch (Exception e) {
@@ -161,7 +161,7 @@ class ElasticClient {
                 return resultBody
             }
             else {
-                throw new ElasticStatusException(resultBody, statusCode)
+                throw new UnexpectedHttpStatusException(resultBody, statusCode)
             }
         }
 

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -11,7 +11,7 @@ import se.kb.libris.utils.isbn.IsbnParser
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
-import whelk.exception.ElasticStatusException
+import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.InvalidQueryException
 import whelk.util.DocumentUtil
 import whelk.util.LegacyIntegrationTools
@@ -80,7 +80,7 @@ class ElasticSearch {
         Map response
         try {
             response = mapper.readValue(client.performRequest('GET', "/${indexName}/_mappings", ''), Map)
-        } catch (ElasticStatusException e) {
+        } catch (UnexpectedHttpStatusException e) {
             log.warn("Got unexpected status code ${e.statusCode} when getting ES mappings: ${e.message}", e)
             return [:]
         }
@@ -196,7 +196,7 @@ class ElasticSearch {
     }
 
     static boolean isBadRequest(Exception e) {
-        e instanceof ElasticStatusException && e.getStatusCode() == 400
+        e instanceof UnexpectedHttpStatusException && e.getStatusCode() == 400
     }
 
     void remove(String identifier) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1396,6 +1396,8 @@ class PostgreSQLComponent {
     }
 
     /**
+     * Take <num> items in order from the queue and pass them one by one to the handler.
+     * If the handler fails on any item, all items remain in the queue.
      *
      * @param handler Document handler
      * @param num Number of documents to take in one batch
@@ -1405,8 +1407,7 @@ class PostgreSQLComponent {
     boolean sparqlQueueTake(QueueHandler handler, int num, DataSource connectionPool) {
         Connection connection = null
         try {
-            // Take <num> items in order from the queue table.
-            // Items are locked and then finally removed from the queue when we commit the transaction.
+            // Items (rows) are locked and then finally removed from the queue when we commit the transaction.
             // If the handler fails on any item, the transaction is cancelled and all items remain in the queue.
             // SKIP LOCKED in the query guarantees that we will take the first <num> unlocked rows.
             connection = connectionPool.getConnection()

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -59,11 +59,7 @@ class PostgreSQLComponent {
 
     interface QueueHandler {
         enum Result { HANDLED, FAIL_RETRY, FAIL_REQUEUE }
-        /**
-         *
-         * @param doc Document from queue
-         * @return true if success
-         */
+        
         Result handle(Document doc)
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
@@ -31,7 +31,7 @@ class SparqlUpdater {
 
     // HTTP timeout parameters
     private static final int CONNECT_TIMEOUT_MS = 5 * 1000
-    private static final int READ_TIMEOUT_MS = 60 * 1000
+    private static final int READ_TIMEOUT_MS = 5 * 1000
 
     // Number of items to take from queue each time
     private static final int QUEUE_TAKE_NUM = 1

--- a/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
@@ -1,0 +1,107 @@
+package whelk.component
+
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import groovy.transform.CompileStatic
+import groovy.util.logging.Log4j2 as Log
+import org.apache.http.client.HttpClient
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.impl.conn.PoolingClientConnectionManager
+import org.apache.http.params.HttpConnectionParams
+import org.apache.http.params.HttpParams
+import whelk.Document
+
+import javax.sql.DataSource
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+@Log
+@CompileStatic
+class SparqlUpdater {
+    private static final long PERIODIC_CHECK_MS = 30 * 1000
+
+    private static final int NUM_WORKERS = 2
+    private static final int MAX_CONNECTION_POOL_SIZE = 8
+
+    // HTTP timeout parameters
+    private static final int CONNECT_TIMEOUT_MS = 5 * 1000
+    private static final int READ_TIMEOUT_MS = 60 * 1000
+
+    // Number of items to take from queue each time
+    private static final int QUEUE_TAKE_NUM = 1
+
+    private final ExecutorService executorService = buildExecutorService()
+    private final Runnable task
+    private final Timer timer = new Timer()
+
+    SparqlUpdater(PostgreSQLComponent storage, Virtuoso sparql) {
+        int poolSize = Math.min(NUM_WORKERS, MAX_CONNECTION_POOL_SIZE)
+        DataSource connectionPool = storage.createAdditionalConnectionPool(this.getClass().getSimpleName(), poolSize)
+
+        PostgreSQLComponent.QueueHandler handler = { Document doc ->
+            try {
+                if (doc.deleted) {
+                    sparql.deleteNamedGraph(doc)
+                }
+                else {
+                    sparql.insertNamedGraph(doc)
+                }
+                return true
+            }
+            catch (Exception e) {
+                log.warn("Failed, will retry: $e")
+                return false
+            }
+        }
+
+        task = {
+            try {
+                // Run as long as there might be docs in the queue and we haven't failed
+                if (storage.sparqlQueueTake(handler, QUEUE_TAKE_NUM, connectionPool)) {
+                    poke()
+                }
+            }
+            catch (Exception e) {
+                log.warn("Error executing task: $e", e)
+            }
+        }
+
+        timer.scheduleAtFixedRate({ poke() }, PERIODIC_CHECK_MS, PERIODIC_CHECK_MS)
+    }
+
+    /**
+     * Force polling SPARQL update queue now
+     */
+    void poke() {
+        executorService.submit(task)
+    }
+
+    private ExecutorService buildExecutorService() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("${getClass().getSimpleName()}-%d")
+                .build()
+
+        // A fixed-sized pool which allows queuing the same number of tasks as the pool size and drops additional tasks.
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(NUM_WORKERS, NUM_WORKERS, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingDeque<>(NUM_WORKERS), threadFactory, new ThreadPoolExecutor.DiscardPolicy())
+        return MoreExecutors.getExitingExecutorService(executor, 5, TimeUnit.SECONDS)
+    }
+
+    static HttpClient buildHttpClient() {
+        PoolingClientConnectionManager cm = new PoolingClientConnectionManager()
+        int poolSize = Math.min(NUM_WORKERS, MAX_CONNECTION_POOL_SIZE)
+        cm.setMaxTotal(poolSize)
+        cm.setDefaultMaxPerRoute(poolSize)
+
+        HttpClient httpClient = new DefaultHttpClient(cm)
+        HttpParams httpParams = httpClient.getParams()
+
+        HttpConnectionParams.setConnectionTimeout(httpParams, CONNECT_TIMEOUT_MS)
+        HttpConnectionParams.setSoTimeout(httpParams, READ_TIMEOUT_MS)
+
+        return httpClient
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/SparqlUpdater.groovy
@@ -77,7 +77,7 @@ class SparqlUpdater {
     void poke() {
         executorService.submit(task)
     }
-    
+
     static HttpClient buildHttpClient() {
         PoolingClientConnectionManager cm = new PoolingClientConnectionManager()
         cm.setMaxTotal(poolSize())

--- a/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpPut
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.BasicCredentialsProvider
+import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.util.EntityUtils
 import whelk.Document
 import whelk.converter.JsonLdToTurtle
@@ -25,19 +26,20 @@ class Virtuoso {
     private String sparqlCrudEndpoint
 
     private HttpClient httpClient
-
     private Map jsonldContext
+    private String user
+    private String pass
 
-    Virtuoso(Map jsonldContext, HttpClient httpClient, String endpoint, String user, String pass) {
-        Preconditions.checkNotNull(jsonldContext)
-        Preconditions.checkNotNull(httpClient)
-        Preconditions.checkNotNull(endpoint)
-        Preconditions.checkNotNull(user)
-        Preconditions.checkNotNull(pass)
+    Virtuoso(Map jsonldContext, String endpoint, String user, String pass) {
+        this.jsonldContext = Preconditions.checkNotNull(jsonldContext)
+        this.sparqlCrudEndpoint = Preconditions.checkNotNull(endpoint)
+        this.user = Preconditions.checkNotNull(user)
+        this.pass = Preconditions.checkNotNull(pass)
 
-        this.jsonldContext = jsonldContext
-        this.sparqlCrudEndpoint = endpoint
+        setHttpClient(new DefaultHttpClient())
+    }
 
+    void setHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient
         setCredentials(httpClient, user, pass)
     }

--- a/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
@@ -57,9 +57,6 @@ class Virtuoso {
             if (!(e instanceof UnexpectedHttpStatusException)) {
                 Metrics.clientCounter.labels(Virtuoso.class.getSimpleName(), method, e.getMessage()).inc()
             }
-            else {
-                log.warn(convertToTurtle(doc, jsonldContext))
-            }
             throw e
         }
         finally {
@@ -98,7 +95,8 @@ class Virtuoso {
         }
         else {
             String body = EntityUtils.toString(response.getEntity())
-            String msg = "Failed to $method ${doc.getCompleteId()}, got: $statusLine\n$body"
+            String ttl = convertToTurtle(doc, jsonldContext)
+            String msg = "Failed to $method ${doc.getCompleteId()}, got: $statusLine\n$body\nsent:\n$ttl"
 
             // From experiments:
             // - Virtuoso responds with 500 for broken documents
@@ -108,7 +106,7 @@ class Virtuoso {
             }
             else {
                 // Cannot recover from these
-                log.warn("$msg\nsent:\n${convertToTurtle(doc, jsonldContext)}")
+                log.warn("$msg")
             }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
@@ -13,7 +13,6 @@ import org.apache.http.client.methods.HttpPut
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.BasicCredentialsProvider
-import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.util.EntityUtils
 import whelk.Document
 import whelk.converter.JsonLdToTurtle
@@ -28,19 +27,11 @@ class Virtuoso {
 
     private HttpClient httpClient
     private Map jsonldContext
-    private String user
-    private String pass
 
-    Virtuoso(Map jsonldContext, String endpoint, String user, String pass) {
+    Virtuoso(Map jsonldContext, HttpClient httpClient, String endpoint, String user, String pass) {
         this.jsonldContext = Preconditions.checkNotNull(jsonldContext)
         this.sparqlCrudEndpoint = Preconditions.checkNotNull(endpoint)
-        this.user = Preconditions.checkNotNull(user)
-        this.pass = Preconditions.checkNotNull(pass)
 
-        setHttpClient(new DefaultHttpClient())
-    }
-
-    void setHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient
         setCredentials(httpClient, user, pass)
     }

--- a/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
@@ -1,38 +1,44 @@
 package whelk.component
 
+import com.google.common.base.Preconditions
 import groovy.util.logging.Log4j2 as Log
 import org.apache.http.HttpResponse
 import org.apache.http.StatusLine
 import org.apache.http.auth.AuthScope
 import org.apache.http.auth.UsernamePasswordCredentials
 import org.apache.http.client.CredentialsProvider
+import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpDelete
 import org.apache.http.client.methods.HttpPut
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.BasicCredentialsProvider
-import org.apache.http.impl.client.DefaultHttpClient
-import org.apache.http.client.HttpClient
 import org.apache.http.util.EntityUtils
 import whelk.Document
 import whelk.converter.JsonLdToTurtle
+import whelk.exception.UnexpectedHttpStatusException
 
 import java.nio.charset.StandardCharsets
 
 @Log
 class Virtuoso {
-
     private String sparqlCrudEndpoint
 
     private HttpClient httpClient
 
-    Map jsonldContext
+    private Map jsonldContext
 
-    Virtuoso(String endpoint, String user, String pass) {
+    Virtuoso(Map jsonldContext, HttpClient httpClient, String endpoint, String user, String pass) {
+        Preconditions.checkNotNull(jsonldContext)
+        Preconditions.checkNotNull(httpClient)
+        Preconditions.checkNotNull(endpoint)
+        Preconditions.checkNotNull(user)
+        Preconditions.checkNotNull(pass)
+
+        this.jsonldContext = jsonldContext
         this.sparqlCrudEndpoint = endpoint
 
-        this.httpClient = new DefaultHttpClient()
-
+        this.httpClient = httpClient
         setCredentials(httpClient, user, pass)
     }
 
@@ -46,8 +52,12 @@ class Virtuoso {
 
     private void updateNamedGraph(String method, Document doc) {
         HttpRequestBase request = buildRequest(method, doc)
-        HttpResponse response = performRequest(request)
-        handleResponse(response, method, doc.completeId())
+        try {
+            handleResponse(httpClient.execute(request), method, doc.getCompleteId())
+        }
+        finally {
+            request.releaseConnection()
+        }
     }
 
     private String createGraphCrudURI(String docURI) {
@@ -55,7 +65,7 @@ class Virtuoso {
     }
 
     private HttpRequestBase buildRequest(String method, Document doc) {
-        String graphCrudURI = createGraphCrudURI(doc.completeId())
+        String graphCrudURI = createGraphCrudURI(doc.getCompleteId())
 
         if (method == 'DELETE') {
             return new HttpDelete(graphCrudURI)
@@ -69,29 +79,25 @@ class Virtuoso {
         }
     }
 
-    private HttpResponse performRequest(HttpRequestBase request) {
-        HttpResponse response = httpClient.execute(request)
-        request.releaseConnection()
-        return response
-    }
-
     private static void handleResponse(HttpResponse response, String method, String docURI) {
         StatusLine statusLine = response.getStatusLine()
         int statusCode = statusLine.getStatusCode()
-        //String body = EntityUtils.toString(response.getEntity())
-        if (method == 'PUT') {
-            if (statusCode == 201) {
-                log.info("New named graph " + docURI + " created successfully")
-            } else if (statusCode == 200) {
-                log.info("Named graph " + docURI + " updated successfully")
-            } else {
-                log.warn("Failed to named create/update graph " + docURI + ", response was " + statusLine.toString())
+
+        if ((statusCode >= 200 && statusCode < 300) || (method == 'DELETE' && statusCode == 404)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Succeeded to $method $docURI, got: $statusLine")
             }
-        } else if (method == 'DELETE') {
-            if (response.getStatusLine().getStatusCode() == 200) {
-                log.info("Named graph " + docURI + " deleted successfully")
-            } else {
-                log.warn("Failed to delete named graph " + docURI + ", response was " + statusLine.toString())
+        }
+        else {
+            String body = EntityUtils.toString(response.getEntity())
+            String msg = "Failed to $method $docURI, got: $statusLine\n$body"
+
+            if (statusCode >= 500 || statusCode == 429) {
+                throw new UnexpectedHttpStatusException(msg, statusCode)
+            }
+            else {
+                // Cannot recover from these
+                log.warn(msg)
             }
         }
     }
@@ -113,5 +119,4 @@ class Virtuoso {
         provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(sparqlUser, sparqlPassword))
         client.setCredentialsProvider(provider)
     }
-
 }

--- a/whelk-core/src/main/groovy/whelk/util/Metrics.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Metrics.groovy
@@ -1,0 +1,21 @@
+package whelk.util
+
+import io.prometheus.client.Counter
+import io.prometheus.client.Summary
+
+class Metrics {
+    static final Summary clientTimer = Summary.build()
+            .labelNames("target", "method")
+            .quantile(0.5, 0.05)
+            .quantile(0.95, 0.01)
+            .quantile(0.99, 0.001)
+            .name("client_requests_latency_seconds")
+            .help("External request latency in seconds.")
+            .register()
+
+    static final Counter clientCounter = Counter.build()
+            .labelNames("target", "method", "status")
+            .name("client_call_status")
+            .help("External response status.")
+            .register()
+}

--- a/whelk-core/src/main/groovy/whelk/util/Tools.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Tools.groovy
@@ -1,14 +1,12 @@
 package whelk.util
 
-import java.text.*
-import java.util.concurrent.*
-import java.util.concurrent.atomic.*
-import org.codehaus.jackson.map.*
 
-import whelk.*
+import org.codehaus.jackson.map.ObjectMapper
+import whelk.Document
+
+import java.text.Normalizer
 
 class Tools {
-
     static ObjectMapper staticMapper = new ObjectMapper()
 
     /**

--- a/whelk-core/src/main/java/whelk/exception/UnexpectedHttpStatusException.java
+++ b/whelk-core/src/main/java/whelk/exception/UnexpectedHttpStatusException.java
@@ -1,9 +1,9 @@
 package whelk.exception;
 
-public class ElasticStatusException extends WhelkRuntimeException {
+public class UnexpectedHttpStatusException extends WhelkRuntimeException {
     private int statusCode;
 
-    public ElasticStatusException(String msg, int statusCode) {
+    public UnexpectedHttpStatusException(String msg, int statusCode) {
         super(msg);
         this.statusCode = statusCode;
     }


### PR DESCRIPTION
- Add a persistent queue for documents to be updated in Virtuoso. 
  - Implemented as a postgres table (using SKIP LOCKED).
  - Every Whelk instance that has `sparqlCrudUrl` set in `secret-properties` will read from the queue and post changed documents to Virtuoso. We probably want to limit this to some service(s).
- Add basic metrics to the Virtuoso client.
- Retry Virtuoso update for transient problems (network failure and PUT 404)