### PR TITLE
Don't include lddb__embellished data when dumping lddb (not needed + …

### DIFF
--- a/librisxl-tools/scripts/move-lddb.sh
+++ b/librisxl-tools/scripts/move-lddb.sh
@@ -127,7 +127,7 @@ REPLACEID="s!\(\(\"@id\": \"\|\t\)https://libris\)\(-\w\+\)\?\(.kb.se/[bcdfghjkl
 
 # Using `--schema=public` excludes e.g. extensions.
 #-T lddb__versions
-PGPASSWORD=$SOURCEPASSWORD pg_dump --schema=public -h $SOURCEHOST -U $SOURCEUSER $SOURCEDB |
+PGPASSWORD=$SOURCEPASSWORD pg_dump --schema=public --exclude-table-data=lddb__embellished -h $SOURCEHOST -U $SOURCEUSER $SOURCEDB |
     ( read; cat - |
     sed "$REPLACEID" |
     handle_sql_dump )


### PR DESCRIPTION
…blocks truncate).

It is a cache table and should not be copied.
When the cache is "full" it is truncated by a random writer. Including it in the dump might block this thread which in turn blocks all readers and writers (for now marc_export threads).
Even though the postgres documentation says "pg_dump does not block other users accessing the database (readers or writers)" [1] it might block truncate [2].

[1] https://www.postgresql.org/docs/9.5/app-pgdump.html
[2] https://blog.dbi-services.com/when-we-do-a-pg_dump-and-right-afterwards-truncate-a-table-which-is-in-the-dump-what-happens/