### PR TITLE
Replace use of deprecated Apache HttpClient methods

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -14,17 +14,17 @@ import io.prometheus.client.CollectorRegistry
 import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
+import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.client.methods.HttpPut
 import org.apache.http.client.methods.HttpRequestBase
-import org.apache.http.client.params.ClientPNames
+import org.apache.http.conn.HttpClientConnectionManager
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.StringEntity
-import org.apache.http.impl.client.DefaultHttpClient
-import org.apache.http.impl.conn.PoolingClientConnectionManager
-import org.apache.http.params.HttpConnectionParams
-import org.apache.http.params.HttpParams
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.http.util.EntityUtils
 import whelk.exception.ElasticIOException
 import whelk.exception.UnexpectedHttpStatusException
@@ -61,30 +61,39 @@ class ElasticClient {
     Retry globalRetry
 
     static ElasticClient withDefaultHttpClient(List<String> elasticHosts) {
-        PoolingClientConnectionManager cm = new PoolingClientConnectionManager()
+        HttpClientConnectionManager cm = new PoolingHttpClientConnectionManager()
         cm.setMaxTotal(CONNECTION_POOL_SIZE)
         cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_HOST)
 
-        HttpClient httpClient = new DefaultHttpClient(cm)
-        HttpParams httpParams = httpClient.getParams()
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECT_TIMEOUT_MS)
+                .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS)
+                .setSocketTimeout(READ_TIMEOUT_MS)
+                .build()
 
-        HttpConnectionParams.setConnectionTimeout(httpParams, CONNECT_TIMEOUT_MS)
-        HttpConnectionParams.setSoTimeout(httpParams, READ_TIMEOUT_MS)
-        httpParams.setParameter(ClientPNames.CONN_MANAGER_TIMEOUT, new Long(READ_TIMEOUT_MS));
-
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(cm)
+                .setDefaultRequestConfig(requestConfig)
+                .build()
+        
         return new ElasticClient(httpClient, elasticHosts, true)
     }
 
     static ElasticClient withBulkHttpClient(List<String> elasticHosts) {
-        PoolingClientConnectionManager cm = new PoolingClientConnectionManager()
+        HttpClientConnectionManager cm = new PoolingHttpClientConnectionManager()
         cm.setMaxTotal(CONNECTION_POOL_SIZE)
         cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_HOST)
 
-        HttpClient httpClient = new DefaultHttpClient(cm)
-        HttpParams httpParams = httpClient.getParams()
-        HttpConnectionParams.setConnectionTimeout(httpParams, 0)
-        HttpConnectionParams.setSoTimeout(httpParams, READ_TIMEOUT_MS * 20)
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(0)
+                .setSocketTimeout(READ_TIMEOUT_MS * 20)
+                .build()
 
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(cm)
+                .setDefaultRequestConfig(requestConfig)
+                .build()
+        
         return new ElasticClient(httpClient, elasticHosts, false)
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/Virtuoso.groovy
@@ -121,8 +121,8 @@ class Virtuoso {
             // 401 should be retried (can be fixed by correcting credentials in configuration)
             // From experiments:
             // - Virtuoso responds with 500 for broken documents
-            // - PUT fails sporadically with 404
-            if (statusCode == 401 || statusCode == 404) {
+            // - PUT fails sporadically with 404 NOT FOUND and 501 NOT IMPLEMENTED
+            if (statusCode == 401 || statusCode == 404 || statusCode == 501) {
                 throw new UnexpectedHttpStatusException(msg, statusCode)
             }
             else {


### PR DESCRIPTION
They are deprecated since HttpClient 4.3.

* Refactor `SparqlUpdater`+`Virtuoso` a little bit.
* Handle random 501 NOT IMPLEMENTED from Virtuoso
