### PR TITLE
Search: Add "slice-by-relation" for o-search

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Relations.groovy
+++ b/whelk-core/src/main/groovy/whelk/Relations.groovy
@@ -30,6 +30,10 @@ class Relations {
         relations.each { result.addAll(storage.getByReverseRelation(iri, it)) }
         return result
     }
+    
+    Map<String, Long> getReverseCountByRelation(String iri) {
+        storage.getIncomingLinkCountByRelation(iri)
+    }
 
     private boolean isReachable(String fromIri, String toIri, List<String> relations) {
         Set<String> visited = []

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -544,7 +544,7 @@ class ESQuery {
                     boolean isSimple = isSimple(val)
                     clauses.add([(isSimple ? 'simple_query_string' : 'query_string'): [
                             'query'           : isSimple ? val : escapeNonSimpleQueryString(val),
-                            'fields'          : [field],
+                            'fields'          : [isWildFieldLocation(field) ? '*' + field : field],
                             'default_operator': 'AND'
                     ]])
                 }
@@ -553,7 +553,11 @@ class ESQuery {
 
         return ['bool': ['should': clauses]]
     }
-
+    
+    private static boolean isWildFieldLocation(String field) {
+        field.startsWith('.')
+    }
+    
     private static boolean parseBoolean(String parameterName, String value) {
         if (value.toLowerCase() == 'true') {
             true


### PR DESCRIPTION
Add facets for relation type in "things-that-link-here" search results.

Example: 
Find incoming links for "Astrid Lindgren". Returns two new slices "agent" and "subject":
`/find?o=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it`
```
...
  "stats": {
    "sliceByDimension": {
      "@type": {
        "dimension": "@type",
        "observation": [
          {
            "totalItems": 7,
            "view": {
              "@id": "/find?_limit=200&o=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it&@type=Instance"
            },
            "object": {
              "@id": "https://id.kb.se/vocab/Instance",
              "@type": "Class",
              "isDefinedBy": {
                "@id": "https://id.kb.se/vocab/"
              },
              "labelByLang": {
                "en": "Instance",
                "sv": "Instans"
              }
            }
          },
          {
            "totalItems": 1,
            "view": {
              "@id": "/find?_limit=200&o=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it&@type=Print"
            },
            "object": {
              "@id": "https://id.kb.se/vocab/Print",
              "@type": "Class",
              "isDefinedBy": {
                "@id": "https://id.kb.se/vocab/"
              },
              "labelByLang": {
                "en": "Printed",
                "sv": "Tryck"
              }
            }
          }
        ]
      },
      "@reverse": {
        "dimension": "@reverse",
        "observation": [
          {
            "totalItems": 6,
            "view": {
              "@id": "/find?_limit=200&.agent.@id=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it"
            },
            "object": {
              "@id": "https://id.kb.se/vocab/agent",
              "@type": "ObjectProperty",
              "isDefinedBy": {
                "@id": "https://id.kb.se/vocab/"
              },
              "labelByLang": {
                "en": "Associated agent",
                "sv": "agent"
              }
            }
          },
          {
            "totalItems": 2,
            "view": {
              "@id": "/find?_limit=200&.subject.@id=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it"
            },
            "object": {
              "@id": "https://id.kb.se/vocab/subject",
              "@type": "ObjectProperty",
              "isDefinedBy": {
                "@id": "https://id.kb.se/vocab/"
              },
              "labelByLang": {
                "en": [
                  "Subject",
                  "subject"
                ],
                "sv": "ämne"
              }
            }
          }
        ]
      }
    }
```

* The view link for the facet flips the o-search to a regular `<property.@id>=<id>` filter query
* Added a syntax for "wild location" for fields in filter queries. e.g. `.language.@id` (leading `.`) will search all `language.@id` fields anywhere in doc. Are we happy with this syntax?
* Is the dimension name "`sliceByDimension.@reverse`" correct?
* Number of incoming links per relation is calculated on the fly at the moment. So the facets are only generated for docs with less than 500k lincoming links as this is reasonably fast.