### PR TITLE
Search: Add slice-by-relation for o-search

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -352,7 +352,12 @@ class SearchUtils {
     }
 
     /**
-     * Group together instanceOf.x and x 
+     * Group together instanceOf.x and x
+     * 
+     * Meaning there will be one predicate/facet for e.g. 'subject' and 'instanceOf.subject' called 'subject'.
+     * That is, it will match both works and instances with local works.
+     * Calling the relation 'subject' is of course not completely correct (it hides instanceOf) but the idea is that 
+     * it is more practical for now.
      */
     static List<Tuple2<List<String>, Long>> groupRelations(Map<String, Long> counts) {
         Map<String, Long> blankWork = [:]

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -164,7 +164,7 @@ class SearchUtils {
             mappings << [
                     'variable' : 'p',
                     'object'   : reverseObject,
-                    'predicate': null,
+                    'predicate': ld.toChip(lookup(predicates.first())),
                     'up'       : [(JsonLd.ID_KEY): upUrl],
             ]
         }
@@ -414,6 +414,13 @@ class SearchUtils {
 
         if (entry) {
             return entry
+        } else if (itemId.contains('.')) {
+            def chain = itemId.split('\\.').findAll {it != JsonLd.ID_KEY}
+            return [
+                    'propertyChainAxiom': chain.collect(this.&lookup),
+                    'label': chain.join(' '),
+                    '_key': itemId,  // lxlviewer has some propertyChains of its own defined, this is used to match them 
+            ]
         } else {
             return [(JsonLd.ID_KEY): itemId, 'label': itemId]
         }
@@ -655,6 +662,8 @@ class SearchUtils {
                 
         return new Tuple2(result, pageParams)
     }
+    
+    
 
     /*
      * Return a list of reserved query params

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -164,7 +164,7 @@ class SearchUtils {
             mappings << [
                     'variable' : 'p',
                     'object'   : reverseObject,
-                    'predicate': null,  //'predicate': termChip, (valueProp): value]
+                    'predicate': null,
                     'up'       : [(JsonLd.ID_KEY): upUrl],
             ]
         }

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -417,7 +417,7 @@ class JsonLd {
                 def graphIndex = (Integer) path[0]
                 List p = path.findAll { !(it instanceof Integer) } // filter out list indices
                 if (graphIndex == 0) {
-                    p.add(0, 'meta')
+                    p.add(0, RECORD_KEY)
                 }
                 else if (graphIndex > 1) {
                     p.add(0, graphIndex) // Normally there should only be @graph,0 and @graph,1

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -323,7 +323,7 @@ class JsonLd {
 
     static Set<Link> getExternalReferences(Map jsonLd) {
         Set<Link> allReferences = getAllReferences(jsonLd)
-        Set<Link> localObjects = getLocalObjects(jsonLd)
+        Set<String> localObjects = getLocalObjects(jsonLd)
         Set<Link> externalRefs = allReferences.findAll { !localObjects.contains(it.getIri()) }
         // NOTE: this is necessary because some documents contain references to
         // bnodes that don't exist (in that document).

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.exception.FramingException
 import whelk.exception.WhelkRuntimeException
+import whelk.util.DocumentUtil
 
 import java.util.regex.Matcher
 
@@ -407,56 +408,33 @@ class JsonLd {
     }
 
     static Set<Link> getAllReferences(Map jsonLd) {
-        List items
-        if (jsonLd.containsKey(GRAPH_KEY)) {
-            items = jsonLd.get(GRAPH_KEY)
-        } else {
+        if (!jsonLd.containsKey(GRAPH_KEY)) {
             throw new FramingException("Missing '@graph' key in input")
         }
-        return getAllReferencesFromList(null, items)
-    }
-
-    private static Set<Link> getRefs(String parentKey, Object o) {
-        if(o instanceof Map) {
-            return getAllReferencesFromMap(parentKey, o)
-        } else if (o instanceof List){
-            return getAllReferencesFromList(parentKey, o)
-        } else {
-            return Collections.emptySet()
-        }
-    }
-
-    private static Set<Link> getAllReferencesFromMap(String parentKey, Map item) {
-        Set<Link> refs = []
-
-        if (isReference(item)) {
-            refs.add(new Link(iri: item[ID_KEY], relation: parentKey))
-            return refs
-        } else {
-            item.each { key, value ->
-                if (key != JSONLD_ALT_ID_KEY) {
-                    refs.addAll(getRefs((String) key, value))
+        Set<Link> result = new HashSet<>() 
+        DocumentUtil.traverse(jsonLd[GRAPH_KEY]) { value, path ->
+            if (value instanceof Map && isReference(value) && !path.contains(JSONLD_ALT_ID_KEY)) {
+                def graphIndex = (Integer) path[0]
+                List p = path.findAll { !(it instanceof Integer) } // filter out list indices
+                if (graphIndex == 0) {
+                    p.add(0, 'meta')
                 }
+                else if (graphIndex > 1) {
+                    p.add(0, graphIndex) // Normally there should only be @graph,0 and @graph,1
+                }
+                result.add(new Link(relation: p.join('.'), iri: value[ID_KEY]))
             }
+            return DocumentUtil.NOP
         }
-
-        return refs
+        return result
     }
-
+    
     private static boolean isReference(Map map) {
         if(map.get(ID_KEY) && map.size() == 1) {
             return true
         } else {
             return false
         }
-    }
-
-    private static Set<Link> getAllReferencesFromList(String parentKey, List items) {
-        Set<Link> result = []
-        items.each { item ->
-            result.addAll(getRefs(parentKey, item))
-        }
-        return result
     }
 
     boolean softMerge(Map<String, Object> obj, Map<String, Object> into) {

--- a/whelk-core/src/main/groovy/whelk/Relations.groovy
+++ b/whelk-core/src/main/groovy/whelk/Relations.groovy
@@ -30,6 +30,10 @@ class Relations {
         relations.each { result.addAll(storage.getByReverseRelation(iri, it)) }
         return result
     }
+    
+    Map<String, Long> getReverseCountByRelation(String iri) {
+        storage.getIncomingLinkCountByRelation(iri)
+    }
 
     private boolean isReachable(String fromIri, String toIri, List<String> relations) {
         Set<String> visited = []

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1024,7 +1024,7 @@ class PostgreSQLComponent {
         doc.getExternalRefs()
             .findAll{ it.iri.startsWith("http") }
             .each { link ->
-                linksByIri.computeIfAbsent(link.iri, { iri -> new HashSet<>()}).add(link)
+                linksByIri.computeIfAbsent(link.iri, { iri -> new HashSet<>() }).add(link)
             }
 
         getSystemIds(linksByIri.keySet(), connection) { String iri, String systemId, boolean deleted ->
@@ -1450,11 +1450,13 @@ class PostgreSQLComponent {
                 }
                 batch = rigInsertStatement(batch, doc, now, changedIn, changedBy, collection, false)
                 batch.addBatch()
-                boolean leaveCacheAlone = true
-                refreshDerivativeTables(doc, connection, false, leaveCacheAlone)
             }
             batch.executeBatch()
             ver_batch.executeBatch()
+            docs.each { doc ->
+                boolean leaveCacheAlone = true
+                refreshDerivativeTables(doc, connection, false, leaveCacheAlone)
+            }
             clearEmbellishedCache(connection)
             connection.commit()
             log.debug("Stored ${docs.size()} documents in collection ${collection} (versioning: ${versioning})")

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1938,6 +1938,7 @@ class PostgreSQLComponent {
         def result = new TreeMap<String, Long>()
         try {
             preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_COUNT_BY_RELATION)
+
             preparedStatement.setString(1, iri)
             rs = preparedStatement.executeQuery()
             while (rs.next()) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1271,6 +1271,14 @@ class PostgreSQLComponent {
         return cardEntry.getCard().data
     }
 
+    // Temporary method for changing lddb__dependencies.relation to full "path" of relation
+    // e.g. agent -> instanceOf.contribution.agent
+    void recalculateDependencies(Document doc) {
+        getConnection().withCloseable { connection ->
+            saveDependencies(doc, connection)
+        }
+    }
+    
     private void saveDependencies(Document doc, Connection connection) {
         List dependencies = _calculateDependenciesSystemIDs(doc, connection)
 

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -544,7 +544,7 @@ class ESQuery {
                     boolean isSimple = isSimple(val)
                     clauses.add([(isSimple ? 'simple_query_string' : 'query_string'): [
                             'query'           : isSimple ? val : escapeNonSimpleQueryString(val),
-                            'fields'          : [field],
+                            'fields'          : [isWildFieldLocation(field) ? '*' + field : field],
                             'default_operator': 'AND'
                     ]])
                 }
@@ -553,7 +553,11 @@ class ESQuery {
 
         return ['bool': ['should': clauses]]
     }
-
+    
+    private static boolean isWildFieldLocation(String field) {
+        field.startsWith('.')
+    }
+    
     private static boolean parseBoolean(String parameterName, String value) {
         if (value.toLowerCase() == 'true') {
             true

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -551,7 +551,7 @@ class ESQuery {
                     boolean isSimple = isSimple(val)
                     clauses.add([(isSimple ? 'simple_query_string' : 'query_string'): [
                             'query'           : isSimple ? val : escapeNonSimpleQueryString(val),
-                            'fields'          : [isWildFieldLocation(field) ? '*' + field : field],
+                            'fields'          : [field],
                             'default_operator': 'AND'
                     ]])
                 }
@@ -560,11 +560,7 @@ class ESQuery {
 
         return ['bool': ['should': clauses]]
     }
-    
-    private static boolean isWildFieldLocation(String field) {
-        field.startsWith('.')
-    }
-    
+
     private static boolean parseBoolean(String parameterName, String value) {
         if (value.toLowerCase() == 'true') {
             true

--- a/whelk-core/src/test/groovy/DocumentSpec.groovy
+++ b/whelk-core/src/test/groovy/DocumentSpec.groovy
@@ -183,7 +183,10 @@ class DocumentSpec extends Specification {
                                  "someValue": 1],
                                 ["someOtherValue": 2]]]
         Document doc = new Document(input)
-        Set expected = [new Link("/externalBar", "bar"), new Link("/externalBaz", "baz")]
+        Set expected = [
+                new Link("/externalBar", "meta.bar"),
+                new Link("/externalBaz", "meta.extra.baz")
+        ]
         expect:
         assert doc.getExternalRefs() == expected
 

--- a/whelk-core/src/test/groovy/JsonLdSpec.groovy
+++ b/whelk-core/src/test/groovy/JsonLdSpec.groovy
@@ -49,7 +49,8 @@ class JsonLdSpec extends Specification {
                 ],
                 ['@id': '/second',
                     'foo': '/foo',
-                    'some': 'value'],
+                    'some': 'value',
+                    'bar': ['@id': '/ext1']],
                 ['@id': '/third',
                     'external': ['@id': '/external']],
                 ['@id': '/fourth',
@@ -58,7 +59,10 @@ class JsonLdSpec extends Specification {
                 ['@graph': ['@id': '/some_other_id']]
             ],
             '@context': 'base.jsonld']
-        Set expected = [new Link(iri: '/external', relation: 'external')]
+        Set expected = [
+                new Link(iri: '/ext1', relation: 'bar'),
+                new Link(iri: '/external', relation: '2.external')
+        ]
 
         expect:
         assert JsonLd.getExternalReferences(graph) == expected
@@ -103,10 +107,11 @@ class JsonLdSpec extends Specification {
                                ['@id': '/baz/',
                                 'someOtherValue': 2]]]
        Set expected = [
-               new Link(iri: '/quux', relation: 'quux'),
-               new Link(iri: '/quux2', relation: 'quux'),
-               new Link(iri: '/baz', relation: 'baz'),
-               new Link(iri: '/bar', relation: 'bar')
+               new Link(iri: '/quux', relation: 'meta.aList.quux'),
+               new Link(iri: '/quux', relation: 'meta.quux'),
+               new Link(iri: '/quux2', relation: 'meta.quux'),
+               new Link(iri: '/baz', relation: 'meta.extra.baz'),
+               new Link(iri: '/bar', relation: 'meta.bar')
        ]
        expect:
        assert JsonLd.getAllReferences(input) == expected

--- a/whelktool/scripts/2021/01/lddb__dependencies-full-relation.groovy
+++ b/whelktool/scripts/2021/01/lddb__dependencies-full-relation.groovy
@@ -1,0 +1,16 @@
+def storage = getWhelk().storage
+
+selectBySqlWhere('deleted = false') { doc ->
+    storage.recalculateDependencies(doc.doc)
+}
+
+def getWhelk() {
+    def whelk = null
+    selectByIds(['https://id.kb.se/marc']) { docItem ->
+        whelk = docItem.whelk
+    }
+    if (!whelk) {
+        throw new RuntimeException("Could not get Whelk")
+    }
+    return whelk
+}

--- a/whelktool/scripts/analysis/relation-paths.groovy
+++ b/whelktool/scripts/analysis/relation-paths.groovy
@@ -4,7 +4,11 @@ selectBySqlWhere('deleted = false') { doc ->
     try {
         DocumentUtil.findKey(doc.graph, '@id') { String value, List path ->
             if (value.startsWith("https://libris") || value.startsWith("http://libris") || value.startsWith("https://id.kb.se")) {
-                incrementStats('p', path.findAll {!(it instanceof Integer) && it != '@id'}.join('.'))
+                def p = path.findAll {!(it instanceof Integer) && it != '@id'}
+                if (p) {
+                    incrementStats('0 p', p.join('.'))
+                    incrementStats(p.last(), p.join('.'))
+                }
             }
         }    
     } catch (Exception e) {

--- a/whelktool/scripts/analysis/relation-paths.groovy
+++ b/whelktool/scripts/analysis/relation-paths.groovy
@@ -1,9 +1,15 @@
 import whelk.util.DocumentUtil
+import whelk.Whelk
+
+uris = [
+        getWhelk().baseUri.toString(),
+        "https://id.kb.se",
+]
 
 selectBySqlWhere('deleted = false') { doc ->
     try {
         DocumentUtil.findKey(doc.graph, '@id') { String value, List path ->
-            if (value.startsWith("https://libris") || value.startsWith("http://libris") || value.startsWith("https://id.kb.se")) {
+            if (uris.any{value.startsWith(it)}) {
                 def p = path.findAll {!(it instanceof Integer) && it != '@id'}
                 if (p) {
                     incrementStats('0 p', p.join('.'))
@@ -14,4 +20,15 @@ selectBySqlWhere('deleted = false') { doc ->
     } catch (Exception e) {
         println(e)
     }
+}
+
+def getWhelk() {
+    def whelk = null
+    selectByIds(['https://id.kb.se/marc']) { docItem ->
+        whelk = docItem.whelk
+    }
+    if (!whelk) {
+        throw new RuntimeException("Could not get Whelk")
+    }
+    return whelk
 }

--- a/whelktool/scripts/analysis/relation-paths.groovy
+++ b/whelktool/scripts/analysis/relation-paths.groovy
@@ -1,0 +1,13 @@
+import whelk.util.DocumentUtil
+
+selectBySqlWhere('deleted = false') { doc ->
+    try {
+        DocumentUtil.findKey(doc.graph, '@id') { String value, List path ->
+            if (value.startsWith("https://libris") || value.startsWith("http://libris") || value.startsWith("https://id.kb.se")) {
+                incrementStats('p', path.findAll {!(it instanceof Integer) && it != '@id'}.join('.'))
+            }
+        }    
+    } catch (Exception e) {
+        println(e)
+    }
+}


### PR DESCRIPTION
Generate facet links (`sliceByDimension`) by relation ("link type") in o-search ("things that link here").

* Add `p` ("predicate") parameter that can be used together with `o`. This is what the facets are made of.
* Store full relation in `lddb__dependencies` (e.g. `instanceOf.hasPart.contribution.role` instead of `role`). 
    * Used to generate relation facets and counts
    * Doesn't (shouldn't) break anything
    * Need to run a whelktool script to rebuild `lddb__dependencies`
* Facets are generated on-the-fly from lddb if there are less than 500k incoming links since this is relatively fast. Otherwise no facets.
    * We could pre-compute these and store in `reverseLinks` in the ES indexed doc. Would make updating link counts a bit more complicated. What would be the form?
* Fix an old bug where definitions didn't get any entries in `lddb__dependencies`
* The new slice "dimension" is called `@reverse`. This is probably wrong. `Relation`?

Used in: https://github.com/libris/lxlviewer/pull/714

Example
`/find?o=<Astrid Lindgren>`
``` 
"stats": {
    "sliceByDimension": {
...   
      "@reverse": {
        "dimension": "@reverse",
        "observation": [
          {
            "totalItems": 7,
            "view": {
              "@id": "/find?_limit=200&o=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it&p=contribution.agent.@id&p=instanceOf.contribution.agent.@id"
            },
            "object": {
              "propertyChainAxiom": [
                {
                  "@id": "https://id.kb.se/vocab/contribution",
                  "@type": "ObjectProperty",
                  "isDefinedBy": {
                    "@id": "https://id.kb.se/vocab/"
                  },
                  "labelByLang": {
                    "en": "Contributor and role",
                    "sv": "Medverkan och funktion"
                  }
                },
                {
                  "@id": "https://id.kb.se/vocab/agent",
                  "@type": "ObjectProperty",
                  "isDefinedBy": {
                    "@id": "https://id.kb.se/vocab/"
                  },
                  "labelByLang": {
                    "en": "Associated agent",
                    "sv": "agent"
                  }
                }
              ],
              "label": "contribution agent",
              "_key": "contribution.agent"
            }
          },
          {
            "totalItems": 3,
            "view": {
              "@id": "/find?_limit=200&o=http://kblocalhost.kb.se:5000/fcrtpljz1qp2bdv%23it&p=subject.@id&p=instanceOf.subject.@id"
            },
            "object": {
              "@id": "https://id.kb.se/vocab/subject",
              "@type": "ObjectProperty",
              "isDefinedBy": {
                "@id": "https://id.kb.se/vocab/"
              },
              "labelByLang": {
                "en": [
                  "Subject",
                  "subject"
                ],
                "sv": "ämne"
              }
            }
          }
        ]
      }
    }
...
```