### PR TITLE
Export: Fix bad first subfield in generated bib 976

### DIFF
--- a/whelk-core/src/main/java/se/kb/libris/export/ExportProfile.java
+++ b/whelk-core/src/main/java/se/kb/libris/export/ExportProfile.java
@@ -420,7 +420,7 @@ public class ExportProfile {
             if (value != null) {
                 Datafield df976 = mr.createDatafield("976");
                 df976.setIndicator(0, ' ');
-                df976.setIndicator(0, '0');
+                df976.setIndicator(1, '0');
                 df976.addSubfield('a', sab);
                 df976.addSubfield('b', value);
                 // @todo: sort fields using comparator


### PR DESCRIPTION
Typo in index overwrites the first indicator ' ' with '0'.

https://jira.kb.se/browse/LXL-2939
https://katalogverk.kb.se/katalogisering/Formathandboken/Bibliografiska-formatet/9XX/index.html