### PR TITLE
Access control for ShelfMarkSequence

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/Digidaily.java
+++ b/apix_server/src/main/java/whelk/apixserver/Digidaily.java
@@ -72,7 +72,7 @@ public class Digidaily {
                     Document dup = Utils.getXlDocument(sf.getData(), "bib");
                     List<Document> attachedHoldings = Utils.s_whelk.getAttachedHoldings(dup.getThingIdentifiers());
                     for (Document attachedHolding : attachedHoldings) {
-                        if (attachedHolding.getSigel().equals(sigel)) {
+                        if (attachedHolding.getHeldBySigel().equals(sigel)) {
                             if (sf.getData() != null) {
                                 out.write("B" + bibid + "\tWARNING MULTIPLE DIGI RECORDS\n");
                                 continue;

--- a/apix_server/src/main/java/whelk/apixserver/Xml.java
+++ b/apix_server/src/main/java/whelk/apixserver/Xml.java
@@ -98,7 +98,7 @@ public class Xml
             {
                 Element holding = xmlDoc.createElement("holding");
                 holdings.appendChild(holding);
-                holding.setAttribute("code", holdingDocument.getSigel());
+                holding.setAttribute("code", holdingDocument.getHeldBySigel());
                 holding.setAttribute("x-mfhd_id", holdingDocument.getShortId());
 
                 String holdingMarcXmlString = Utils.convertToMarcXml(holdingDocument);
@@ -180,7 +180,7 @@ public class Xml
                 {
                     Element holding = xmlDoc.createElement("holding");
                     holdings.appendChild(holding);
-                    holding.setAttribute("code", holdingDocument.getSigel());
+                    holding.setAttribute("code", holdingDocument.getHeldBySigel());
                     holding.setAttribute("x-mfhd_id", holdingDocument.getShortId());
 
                     String holdingMarcXmlString = Utils.convertToMarcXml(holdingDocument);

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -267,7 +267,7 @@ public class ProfileExport
             if (collection.equals("hold"))
             {
                 Document updatedDocument = m_whelk.getStorage().load(id);
-                if (!profile.locations().contains(updatedDocument.getSigel())) {
+                if (!profile.locations().contains(updatedDocument.getHeldBySigel())) {
                     return false;
                 }
             }

--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -44,7 +44,7 @@ public class Helpers
 
             for (Document holding : holdings)
             {
-                String sigel = holding.getSigel();
+                String sigel = holding.getHeldBySigel();
                 if (bySigel.equals(sigel))
                 {
                     return true;
@@ -110,7 +110,7 @@ public class Helpers
                         }
                         else if (dependerCollection.equals("hold") && requestedCollection.equals("hold"))
                         {
-                            String sigel = dependerDocument.getSigel();
+                            String sigel = dependerDocument.getHeldBySigel();
                             if (mustBeHeldBy == null || mustBeHeldBy.equals(sigel))
                             {
                                 queueDocument(dependerDocument);
@@ -133,7 +133,7 @@ public class Helpers
             {
                 if (requestedCollection.equals("hold"))
                 {
-                    String sigel = updated.getSigel();
+                    String sigel = updated.getHeldBySigel();
                     if (mustBeHeldBy == null || mustBeHeldBy.equals(sigel))
                     {
                         queueDocument(updated);

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -175,7 +175,7 @@ public class ResponseCommon
             }
         }
 
-        String sigel = document.getSigel();
+        String sigel = document.getHeldBySigel();
         if (sigel != null)
         {
             writer.writeStartElement("setSpec");
@@ -237,7 +237,7 @@ public class ResponseCommon
         writer.writeStartElement("about");
         for (Document holding : holdings)
         {
-            String sigel = holding.getSigel();
+            String sigel = holding.getHeldBySigel();
             if (sigel == null)
             {
                 logger.warn("Holding post without valid sigel! hold id: {}", holding.getShortId());

--- a/rest/src/main/groovy/whelk/rest/security/AccessControl.groovy
+++ b/rest/src/main/groovy/whelk/rest/security/AccessControl.groovy
@@ -19,8 +19,8 @@ class AccessControl {
     boolean checkDocumentToPut(Document newDoc, Document oldDoc,
                                Map userPrivileges, JsonLd jsonld) {
         if (oldDoc.isHolding(jsonld)) {
-            def newDocSigel = newDoc.getSigel()
-            def oldDocSigel = oldDoc.getSigel()
+            def newDocSigel = newDoc.getHeldBySigel()
+            def oldDocSigel = oldDoc.getHeldBySigel()
 
             if (!newDoc.isHolding(jsonld)) {
                 // we don't allow changing from holding to non-holding
@@ -60,13 +60,14 @@ class AccessControl {
         }
 
         if (document.isHolding(jsonld)) {
-            String sigel = document.getSigel()
+            String sigel = document.getHeldBySigel()
             if (!sigel) {
                 throw new ModelValidationException('Missing sigel in document.')
             }
 
             return hasGlobalRegistrantPermission(userPrivileges) || hasPermissionForSigel(sigel, userPrivileges)
-        } else {
+        }
+        else {
             return hasCatalogingPermission(userPrivileges)
         }
     }

--- a/rest/src/main/groovy/whelk/rest/security/AccessControl.groovy
+++ b/rest/src/main/groovy/whelk/rest/security/AccessControl.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Log4j2 as Log
 import whelk.Document
 import whelk.JsonLd
 import whelk.exception.ModelValidationException
+import whelk.util.LegacyIntegrationTools
 
 @Log
 class AccessControl {
@@ -66,6 +67,10 @@ class AccessControl {
             }
 
             return hasGlobalRegistrantPermission(userPrivileges) || hasPermissionForSigel(sigel, userPrivileges)
+        }
+        else if (document.getThingType() == 'ShelfMarkSequence') {
+            String ownedBySigel = LegacyIntegrationTools.uriToLegacySigel(document.getDescriptionCreator())
+            return hasGlobalRegistrantPermission(userPrivileges) || hasPermissionForSigel(ownedBySigel, userPrivileges)
         }
         else {
             return hasCatalogingPermission(userPrivileges)

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -320,7 +320,7 @@ class Document {
         return ("hold" == LegacyIntegrationTools.determineLegacyCollection(this, jsonld))
     }
 
-    String getSigel() {
+    String getHeldBySigel() {
         String uri = get(sigelPath)
         if (uri != null)
             return LegacyIntegrationTools.uriToLegacySigel( uri )

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -615,7 +615,7 @@ class PostgreSQLComponent {
             connection.setAutoCommit(false)
             normalizeDocumentForStorage(doc, connection)
 
-            if (collection == "hold" && doc.getThingType() != "ShelfMarkSequence") {
+            if (collection == "hold") {
                 String holdingFor = doc.getHoldingFor()
                 if (holdingFor == null) {
                     log.warn("Was asked to save a holding record linked to a bib record that could not be located: " + doc.getHoldingFor() + " (so, did nothing).")

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -615,7 +615,7 @@ class PostgreSQLComponent {
             connection.setAutoCommit(false)
             normalizeDocumentForStorage(doc, connection)
 
-            if (collection == "hold") {
+            if (collection == "hold" && doc.getThingType() != "ShelfMarkSequence") {
                 String holdingFor = doc.getHoldingFor()
                 if (holdingFor == null) {
                     log.warn("Was asked to save a holding record linked to a bib record that could not be located: " + doc.getHoldingFor() + " (so, did nothing).")

--- a/whelk-core/src/main/groovy/whelk/util/MarcExport.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/MarcExport.groovy
@@ -59,7 +59,7 @@ class MarcExport {
 
         for (Document holding : holdingDocuments) {
             try {
-                holdings.put(holding.getSigel(), MarcXmlRecordReader.fromXml(toXmlString(holding, toMarcXmlConverter)))
+                holdings.put(holding.getHeldBySigel(), MarcXmlRecordReader.fromXml(toXmlString(holding, toMarcXmlConverter)))
             } catch (Exception e) {
                 log.warn("Failed adding holding record when compiling MARC for " + rootDocument.getShortId(), e)
             }

--- a/whelk-core/src/test/groovy/DocumentSpec.groovy
+++ b/whelk-core/src/test/groovy/DocumentSpec.groovy
@@ -300,7 +300,7 @@ class DocumentSpec extends Specification {
                                               ["notation": "S", "@id": "https://libris.kb.se/library/S"]]]]
         Document doc = new Document(content)
         expect:
-        assert doc.getSigel() == 'S'
+        assert doc.getHeldBySigel() == 'S'
     }
 
     def "should return null for holding without sigel, I"() {
@@ -319,7 +319,7 @@ class DocumentSpec extends Specification {
                                       "heldBy": []]]]
         Document doc = new Document(content)
         expect:
-        assert doc.getSigel() == null
+        assert doc.getHeldBySigel() == null
     }
 
     def "should return null for holding without sigel, II"() {
@@ -337,7 +337,7 @@ class DocumentSpec extends Specification {
                                       "contains": "some new other data"]]]
         Document doc = new Document(content)
         expect:
-        assert doc.getSigel() == null
+        assert doc.getHeldBySigel() == null
     }
 
     def "should return null sigel for non-holding"() {
@@ -357,7 +357,7 @@ class DocumentSpec extends Specification {
                                               ["notation": "S"]]]]
         Document doc = new Document(content)
         expect:
-        assert doc.getSigel() == null
+        assert doc.getHeldBySigel() == null
     }
 
     def "Cannot set created"() {

--- a/whelktool/scripts/cleanups/2020/01/lxl-2655/lxl-2655.groovy
+++ b/whelktool/scripts/cleanups/2020/01/lxl-2655/lxl-2655.groovy
@@ -1,3 +1,4 @@
+
 PrintWriter failedHoldIDs = getReportWriter("failed-holdIDs")
 PrintWriter scheduledForUpdating = getReportWriter("scheduled-updates")
 
@@ -66,7 +67,7 @@ for (String operation : ProgramLines) {
 
     boolean foundSomeThing = false
     selectBySqlWhere(where, silent: true) { hold ->
-        if (hold.doc.getSigel() == "Jon") {
+        if (hold.doc.getHeldBySigel() == "Jon") {
 
             foundSomeThing = true
 


### PR DESCRIPTION
* User can only write ShelfMarkSequence if
    * it is owned owned by sigel (meta.descriptionCreator).
    * user is "global registrant" (must be able to write any holding)
* Holding can only link to ShelfMarkSequence owned by the same sigel.