### PR TITLE
ES index: Also embellish "hold" when indexing

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -273,6 +273,16 @@
                 }
             },
             {
+                "shelfControlNumber_template": {
+                    "match": "shelfControlNumber",
+                    "mapping": {
+                        "index": true,
+                        "type": "text",
+                        "copy_to": "_all"
+                    }
+                }
+            },
+            {
                 "unknown_template": {
                     "path_match": "_marc*.*.subfields.*",
                     "mapping": {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -224,10 +224,8 @@ class ElasticSearch {
 
     String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
-
-        if ("hold" != LegacyIntegrationTools.determineLegacyCollection(document, whelk.jsonld)) {
-            whelk.embellish(copy, ['chips'])
-        }
+        
+        whelk.embellish(copy, ['chips'])
 
         if (log.isDebugEnabled()) {
             log.debug("Framing ${document.getShortId()}")


### PR DESCRIPTION
Needed to be able to display `Item` better in search hit lists.

We'll have to test how this affects index size and indexing time.