### PR TITLE
Get max control number for last year

### DIFF
--- a/librisxl-tools/scripts/get-active-shelf-mark-seqs.sh
+++ b/librisxl-tools/scripts/get-active-shelf-mark-seqs.sh
@@ -9,11 +9,16 @@ SELECT PrefixBeforeYear,
            END AS PrefixAfterYear,
        LastSerialNumber, Year
 FROM T_CodeType, (
-    SELECT CodeType_FKID, MAX(SerialNumber) as LastSerialNumber, MAX(Year) AS Year
-    FROM T_SerialNumber
-    WHERE ActiveStatus = 2
-    GROUP BY CodeType_FKID
-         ) as Serial
+    SELECT CodeType_FKID, MAX(SerialNumber) as LastSerialNumber, Year
+    FROM T_SerialNumber, (
+        SELECT CodeType_FKID as CodeId, MAX(Year) as maxYear
+        FROM T_SerialNumber
+        WHERE ActiveStatus = 2
+        GROUP BY CodeType_FKID
+    ) as Years
+    WHERE ActiveStatus = 2 AND Year = maxYear AND CodeType_FKID = CodeId
+    GROUP BY CodeType_FKID, Year
+) as Serial
 WHERE CodeType_ID = CodeType_FKID;"
 
 sqlcmd -S mssqlag3.kb.local -d signum -U Signum-read -Q "$QUERY" \


### PR DESCRIPTION
Discovered a silly mistake just in time before my vacation :) With this change we retrieve the highest control number for the _current_ year of a shelf mark sequence rather than for _any_ year.

This needs to be included in the release, otherwise the new signum generator will start with incorrect counters!  