### PR TITLE
Create new holding from existing holdings record

### DIFF
--- a/whelktool/scripts/syslib/Copy_hold_bibID.txt
+++ b/whelktool/scripts/syslib/Copy_hold_bibID.txt
@@ -1,0 +1,5 @@
+s2m2wdrlq1d60zxl
+s2m2wdsrqdb4qbs0
+s2mfqskqqj4xww9c
+7k696c5v5bw76jt0
+x8q2m62rv9kvq2cv

--- a/whelktool/scripts/syslib/Copy_holdings.groovy
+++ b/whelktool/scripts/syslib/Copy_holdings.groovy
@@ -1,0 +1,45 @@
+String CURRENT_SIGEL = 'https://libris.kb.se/library/Ssb'
+String NEW_SIGEL = 'https://libris.kb.se/library/Mlc'
+
+File bibIDs = new File(scriptDir, "Copy_hold_bibID.txt")
+
+def holdList = [] // Eller behövs Vector???
+
+String bibidstring = bibIDs.readLines().join("','")
+
+selectBySqlWhere("""id in
+
+(
+ select lh.id
+  from
+   lddb lb
+  left join
+   lddb lh
+  on lh.data#>>'{@graph,1,itemOf,@id}' = lb.data#>>'{@graph,1,@id}'
+ where lb.data#>>'{@graph,0,controlNumber}' in ( '$bibidstring' ) and lb.collection = 'bib'
+ and
+ lh.data#>>'{@graph,1,heldBy,@id}' = '{$CURRENT_SIGEL}'
+ 
+ )""", silent: false, { hold ->
+
+def holdData = hold.doc.data
+
+holdList.add( create(holdData) )
+
+    def heldBy = hold.graph[1].heldBy
+
+    heldBy["@id"] = NEW_SIGEL
+
+    if (hold.graph[1].hasComponent) {
+        hold.graph[1].hasComponent.each { component ->
+            if (component.heldBy) {
+                component.heldBy["@id"] = NEW_SIGEL
+            }
+        }
+    }
+})
+
+    selectFromIterable(holdList, { newlyCreatedItem ->
+    newlyCreatedItem.scheduleSave()
+ 
+  })

--- a/whelktool/scripts/syslib/Copy_holdings.groovy
+++ b/whelktool/scripts/syslib/Copy_holdings.groovy
@@ -3,7 +3,7 @@ String NEW_SIGEL = 'https://libris.kb.se/library/Mlc'
 
 File bibIDs = new File(scriptDir, "Copy_hold_bibID.txt")
 
-def holdList = [] // Eller behövs Vector???
+def holdList = []
 
 String bibidstring = bibIDs.readLines().join("','")
 


### PR DESCRIPTION
Libraries with multiple sigels may want to create new holdings based on another holdings record (from one of their other sigels). The use case is usually when the Libris holdings data is not up to date with their local data.