### PR TITLE
Add ES elision token filter; add separate pattern_replace for apostrophes

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -27,9 +27,7 @@
                 "apostrophe_and_okina_remover": {
                     "type": "mapping",
                     "mappings": [
-                        "\u0027=>",
                         "\u2018=>",
-                        "\u2019=>",
                         "\uFF07=>",
                         "\u02B9=>",
                         "\u02BB=>",
@@ -50,7 +48,13 @@
                     "type": "custom",
                     "char_filter": ["apostrophe_and_okina_remover"],
                     "tokenizer": "standard",
-                    "filter": ["lowercase", "ascii_folder", "swedish_snowball"]
+                    "filter": [
+                        "lowercase",
+                        "elision_case_insensitive",
+                        "apostrophe_remover",
+                        "ascii_folder",
+                        "swedish_snowball"
+                    ]
                 },
                 "isbn_analyzer": {
                     "tokenizer": "standard",
@@ -99,6 +103,19 @@
                 "ascii_folder": {
                     "type": "asciifolding",
                     "preserve_original": true
+                },
+                "elision_case_insensitive": {
+                    "type": "elision",
+                    "articles": [
+                        "l", "m", "t", "qu", "n", "s", "j", "d", "c",
+                        "jusqu", "quoiqu", "lorsqu", "puisqu"
+                    ],
+                    "articles_case": true
+                },
+                "apostrophe_remover": {
+                    "type": "pattern_replace",
+                    "pattern": "[\u0027|\u2019]",
+                    "replacement": ""
                 }
             }
         }

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -107,8 +107,10 @@
                 "elision_case_insensitive": {
                     "type": "elision",
                     "articles": [
-                        "l", "m", "t", "qu", "n", "s", "j", "d", "c",
-                        "jusqu", "quoiqu", "lorsqu", "puisqu"
+                        "b", "c", "d", "j", "l", "m", "n", "s", "t", "v",
+                        "qu", "jusqu", "quoiqu", "lorsqu", "puisqu",
+                        "all", "dall", "dell", "nell", "sull", "coll", "pell",
+                        "gl", "agl", "dagl", "degl", "negl", "sugl", "un"
                     ],
                     "articles_case": true
                 },


### PR DESCRIPTION
Previously, a search for e.g. `Opoponax` would not find `L'Opopnax`, because ES had turned it into `Lopopnax` due to the way the filters were set up in the `softmatcher` analyzer (`'` (\u0027) and `’` (\u2019) were removed by the `apostrophe_and_okina_remover` character filter before the tokenizer stage).

This excludes the aforementioned apostrophes from  `apostrophe_and_okina_remover`, adds an [elision token filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html) (which looks for \u0027 and \u2019 (thx Olov!)), and also adds a [pattern replace token filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pattern_replace-tokenfilter.html) to get rid of these two apostrophes after the elision filter (but before folding/snowball).

French, Catalan, Italian and Irish elisions are removed (these are the ones found in the [ES docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html)). This can be tested with e.g.
```
curl -X POST "localhost:9200/whelk_dev/_analyze?pretty" -H 'Content-Type: application/json' -d'
{
  "analyzer": "softmatcher",
  "text":     "L\'Opoponax"
}
'
```
Before/after comparison of tokens:
| Text | Before | After |
|---|---|---|
| L'Opopnax | "lopopnax" | "opopnax" |
| Quand on n'a que l'amour | "quand", "on", "na", "que", "lamour" | "quand", "on", "a", "que", "amour" |
| dell'Archiginnasio | "dellarchiginnasio" | "archiginnasio" |
| Deserter's Songs | "deserter", "song" | "deserter", "song" |
| rock'n'roll | "rocknroll" | "rocknroll" |
