### PR TITLE
Add common field for sorting, based on chips

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -254,6 +254,10 @@
                 "type": "keyword",
                 "copy_to": "_all"
             },
+            "_sortKeyByLang": {
+                "type": "icu_collation_keyword",
+                "language": "sv"
+            },
             "_all": {
                 "type": "text",
                 "store": false,

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -255,8 +255,16 @@
                 "copy_to": "_all"
             },
             "_sortKeyByLang": {
-                "type": "icu_collation_keyword",
-                "language": "sv"
+                "properties": {
+                    "sv": {
+                        "type": "icu_collation_keyword",
+                        "language": "sv"
+                    },
+                    "en": {
+                        "type": "icu_collation_keyword",
+                        "language": "en"
+                    }
+                }
             },
             "_all": {
                 "type": "text",

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -745,10 +745,7 @@ class JsonLd {
                         if (prop in languageContainers) {
                             value.retainAll { it.key in ['sv', 'en'] }
                         }
-
-                        parts << flattenMap(value)
-                                .findAll { !((String)it.key).startsWith("@") && !(it.key in ['subtitle']) }
-                                .values()
+                        parts << toChipAsString(value)
                     } else if (value instanceof String) {
                         parts << value
                     }
@@ -757,16 +754,6 @@ class JsonLd {
         }
 
         return parts.flatten().join(" ")
-    }
-
-    private Map flattenMap(Map map) {
-        map.collectEntries { k, v ->
-            if (v instanceof Map) {
-                flattenMap(v).collectEntries { k1, v1 -> [(k1): v1] }
-            } else {
-                [(k): v]
-            }
-        }
     }
 
     List makeSearchKeyParts(Map object) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -224,7 +224,7 @@ class ElasticSearch {
 
     String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
-        
+
         whelk.embellish(copy, ['chips'])
 
         if (log.isDebugEnabled()) {
@@ -309,6 +309,8 @@ class ElasticSearch {
         doc.data['@graph'][1]['reverseLinks'] = [
                 (JsonLd.TYPE_KEY) : 'PartialCollectionView',
                 'totalItems' : whelk.getStorage().getIncomingLinkCount(doc.getShortId())]
+
+        doc.data['@graph'][1]['_sortKeyByLang'] = whelk.jsonld.toChipAsString(doc.data['@graph'][1])
     }
 
     private static Collection<String> getOtherIsbns(List<String> isbns) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -310,7 +310,7 @@ class ElasticSearch {
                 (JsonLd.TYPE_KEY) : 'PartialCollectionView',
                 'totalItems' : whelk.getStorage().getIncomingLinkCount(doc.getShortId())]
 
-        doc.data['@graph'][1]['_sortKeyByLang'] = whelk.jsonld.toChipAsString(doc.data['@graph'][1])
+        doc.data['@graph'][1]['_sortKeyByLang'] = whelk.jsonld.toChipAsMapByLang(doc.data['@graph'][1])
     }
 
     private static Collection<String> getOtherIsbns(List<String> isbns) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -22,6 +22,9 @@ import java.util.concurrent.LinkedBlockingQueue
 @Log
 class ElasticSearch {
     static final String BULK_CONTENT_TYPE = "application/x-ndjson"
+
+    static final Set<String> LANGUAGES_TO_INDEX = ["sv", "en"] as Set
+
     private static final ObjectMapper mapper = new ObjectMapper()
 
     String defaultIndex = null
@@ -288,10 +291,9 @@ class ElasticSearch {
 
     private static void filterLanguages(Whelk whelk, Map thing) {
         Set languageContainers = whelk.jsonld.langContainerAlias.values() as Set
-        Set languagesToKeep = ['sv', 'en'] // TODO: where do we define these?
         DocumentUtil.traverse(thing, { value, path ->
             if (path && path.last() in languageContainers) {
-                return new DocumentUtil.Replace(value.findAll {lang, str -> lang in languagesToKeep})
+                return new DocumentUtil.Replace(value.findAll {lang, str -> lang in LANGUAGES_TO_INDEX})
             }
         })
     }
@@ -310,7 +312,7 @@ class ElasticSearch {
                 (JsonLd.TYPE_KEY) : 'PartialCollectionView',
                 'totalItems' : whelk.getStorage().getIncomingLinkCount(doc.getShortId())]
 
-        doc.data['@graph'][1]['_sortKeyByLang'] = whelk.jsonld.toChipAsMapByLang(doc.data['@graph'][1])
+        doc.data['@graph'][1]['_sortKeyByLang'] = whelk.jsonld.toChipAsMapByLang(doc.data['@graph'][1], LANGUAGES_TO_INDEX)
     }
 
     private static Collection<String> getOtherIsbns(List<String> isbns) {


### PR DESCRIPTION
Currently Instance/Work/Concept can be sorted alphabetically (using `hasTitle.mainTitle` / `prefLabel`), but we can't sort mixed results ("Alla", "Används i"), because we don't have a sort field common to all types. (Also, agents can't be sorted.)

This adds such a field to Elasticsearch, `_sortKeyByLang`. It contains two properties (sub-fields), `sv` and `en`. Each is a string containing the property values of the thing's chips in the order the properties are specified in the chip definition(s) `showProperties`. _byLang_ versions (e.g., `prefLabelByLang`, `titleByLang`) are used instead of the non-language-specific version when available (just like in the frontend).

The goal is to generate essentially the same as what the user sees in the frontend (in lxlviewer it's controlled by `header` in https://github.com/libris/lxlviewer/blob/develop/viewer/vue-client/src/resources/json/displayGroups.json).

Can be quickly tested with a whelktool script:
```groovy
import static groovy.json.JsonOutput.*
private pp(thing) {
    println(prettyPrint(toJson(thing)))
}
selectByIds(['bb59plxfd35ggq1t', 'v73tnvkjshb2hwp1', 'nm2hp58rq35gzd61', 'hvqllf5gf6dhdtkx']) { data ->
    pp(data.whelk.jsonld.toChipAsMapByLang(data.graph[1]))
}
```
=>
```
{
    "sv": "Datorbaserat multimedium",
    "en": "Interactive multimedia"
}
{
    "sv": "Statsvetenskap--teori, filosofi",
    "en": "Statsvetenskap--teori, filosofi"
}
{
    "sv": "Deskryptory Biblioteki Narodowej, dbn",
    "en": "National Library of Poland Descriptors, dbn"
}
{
    "sv": "Meghan, hertiginna av Sussex, 1981-",
    "en": "Meghan, hertiginna av Sussex, 1981-"
}
```

After recreating the index and reindexing, `&_sort=_sortKeyByLang.sv` and `&_sort=_sortKeyByLang.en` should work.