### PR TITLE
Trim U+FEFF (BOM) from document strings

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -94,12 +94,20 @@ class Document {
         }
     }
 
-    void trimStrings() {
+    boolean trimStrings() {
         DocumentUtil.traverse(data) { value, path ->
-            if (value instanceof String && value != value.trim()) {
-                return new DocumentUtil.Replace(value.trim())
+            if (value instanceof String && value != trimString(value)) {
+                return new DocumentUtil.Replace(trimString(value))
             }
         }
+    }
+    
+    private static String trimString(String s) {
+        // Trim string + drop all U+FEFF / BOM characters. 
+        // According to the Unicode FAQ, BOM should be treated as ZWNBSP in the middle of data for backwards 
+        // compatibility (deprecated use in Unicode 3.2). https://www.unicode.org/faq/utf_bom.html#BOM
+        // In Libris data analyzed it turns out to always be garbage.
+        return s.replace('\ufeff', '').trim()
     }
 
     URI getURI() {

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -96,20 +96,12 @@ class Document {
 
     boolean trimStrings() {
         DocumentUtil.traverse(data) { value, path ->
-            if (value instanceof String && value != trimString(value)) {
-                return new DocumentUtil.Replace(trimString(value))
+            if (value instanceof String && value != value.trim()) {
+                return new DocumentUtil.Replace(value.trim())
             }
         }
     }
     
-    private static String trimString(String s) {
-        // Trim string + drop all U+FEFF / BOM characters. 
-        // According to the Unicode FAQ, BOM should be treated as ZWNBSP in the middle of data for backwards 
-        // compatibility (deprecated use in Unicode 3.2). https://www.unicode.org/faq/utf_bom.html#BOM
-        // In Libris data analyzed it turns out to always be garbage.
-        return s.replace('\ufeff', '').trim()
-    }
-
     URI getURI() {
         return baseUri.resolve(getShortId())
     }

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -12,7 +12,7 @@ class Unicode {
      * https://www.unicode.org/charts/PDF/UFB00.pdf
      * https://en.wikipedia.org/wiki/Orthographic_ligature
      */
-    private static final List FORBIDDEN_UNICODE_CHARS = [
+    private static final List NORMALIZE_UNICODE_CHARS = [
             'ﬀ', // 'LATIN SMALL LIGATURE FF'
             'ﬃ', // 'LATIN SMALL LIGATURE FFI'
             'ﬄ', // 'LATIN SMALL LIGATURE FFL'
@@ -22,12 +22,23 @@ class Unicode {
             'ﬆ', // 'LATIN SMALL LIGATURE ST'
     ]
 
+    /** 
+     * Characters that should be stripped.
+     * 
+     * According to the Unicode FAQ, U+FEFF BOM should be treated as ZWNBSP in the middle of data for backwards 
+     * compatibility (that use is deprecated in Unicode 3.2). https://www.unicode.org/faq/utf_bom.html#BOM
+     * In Libris data analyzed it turned out to always be garbage.
+     */
+    private static final List STRIP_UNICODE_CHARS = [
+            '\ufeff',
+    ]
+    
     private static final Map EXTRA_NORMALIZATION_MAP
 
     static {
-        EXTRA_NORMALIZATION_MAP = FORBIDDEN_UNICODE_CHARS.collectEntries {
+        EXTRA_NORMALIZATION_MAP = NORMALIZE_UNICODE_CHARS.collectEntries {
             [(it): Normalizer.normalize(it, Normalizer.Form.NFKC)]
-        }
+        } + STRIP_UNICODE_CHARS.collectEntries { [(it): ''] }
     }
 
     static boolean isNormalized(String s) {

--- a/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
@@ -22,6 +22,15 @@ class UnicodeSpec extends Specification {
         Unicode.normalize(s) == norm
     }
 
+    def "strip BOM"() {
+        given:
+        String s = "9th Koli Calling International Conference on Computing Education Research\ufeff, October 29–November 1, 2009"
+        String norm = "9th Koli Calling International Conference on Computing Education Research, October 29–November 1, 2009"
+        expect:
+        Unicode.isNormalized(s) == false
+        Unicode.normalize(s) == norm
+    }
+
     def "trim noise()"() {
         expect:
         Unicode.trimNoise(dirty) == clean

--- a/whelktool/scripts/cleanups/2021/04/lxl-3550-trim-titles.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3550-trim-titles.groovy
@@ -1,0 +1,8 @@
+/**
+ * Trim leading and trailing whitespace + any BOM from doc strings
+ */
+selectByCollection('bib') { data ->
+    if (data.doc.trimStrings()) {
+        data.scheduleSave()
+    }
+}

--- a/whelktool/scripts/cleanups/2021/04/lxl-3550-trim-titles.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3550-trim-titles.groovy
@@ -1,5 +1,5 @@
 /**
- * Trim leading and trailing whitespace + any BOM from doc strings
+ * Trim leading and trailing whitespace from doc strings
  */
 selectByCollection('bib') { data ->
     if (data.doc.trimStrings()) {


### PR DESCRIPTION
* Trim any U+FEFF (BOM) from document strings 
  * Example: hasTitlemainTitle "**\ufeff**CAISE Review" https://libris-qa.kb.se/wf7c5gr72nkghl0/data.jsonld
  * Example: instanceOf.contribution.agent.name "9th Koli Calling International Conference on Computing Education Research **\ufeff**, October 29–November 1, 2009" https://libris.kb.se/z6stgk1gw623gv5s/data.jsonld
* Add script for trimming all string in all docs