### PR TITLE
Embellish auth records that are to be merged into a bib for export.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/MarcExport.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/MarcExport.groovy
@@ -88,7 +88,7 @@ class MarcExport {
         String recordId = whelk.storage.getRecordId(idOrSameAs)
         if (recordId == null)
             return null
-        return whelk.storage.loadDocumentByMainId(recordId)
+        return whelk.loadEmbellished(whelk.storage.getSystemIdByIri(recordId))
     }
 
     /**


### PR DESCRIPTION
Without this, the auth records lack important linked information, which
results in odd behaviour. See lxl-3524 for an example.