### PR TITLE
Fix a bug, which would allow definitions to bechanged via API.

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -732,6 +732,14 @@ class Crud extends HttpServlet {
                 String activeSigel = request.getHeader(XL_ACTIVE_SIGEL_HEADER)
 
                 if (isUpdate) {
+
+                    // You are not allowed to change definitions via API.
+                    String storedCollectionForId = whelk.storage.getCollectionBySystemID(doc.getShortId())
+                    if (!(storedCollectionForId in ["auth", "bib", "hold"])) {
+                        log.warn("Refused API update of document previously stored with collection $storedCollectionForId")
+                        return null
+                    }
+
                     String ifMatch = CrudUtils.cleanEtag(request.getHeader("If-Match"))
                     log.info("If-Match: ${ifMatch}")
                     whelk.storeAtomicUpdate(doc, false, "xl", activeSigel, ifMatch)

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -734,7 +734,7 @@ class Crud extends HttpServlet {
                 if (isUpdate) {
 
                     // You are not allowed to change collection when updating a record
-                    if (collection != whelk.storage.getCollectionBySystemID(doc.getShortId()))
+                    if (collection != whelk.storage.getCollectionBySystemID(doc.getShortId())) {
                         log.warn("Refused API update of document due to changed 'collection'")
                         return null
                     }

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -733,10 +733,9 @@ class Crud extends HttpServlet {
 
                 if (isUpdate) {
 
-                    // You are not allowed to change definitions via API.
-                    String storedCollectionForId = whelk.storage.getCollectionBySystemID(doc.getShortId())
-                    if (!(storedCollectionForId in ["auth", "bib", "hold"])) {
-                        log.warn("Refused API update of document previously stored with collection $storedCollectionForId")
+                    // You are not allowed to change collection when updating a record
+                    if (collection != whelk.storage.getCollectionBySystemID(doc.getShortId()))
+                        log.warn("Refused API update of document due to changed 'collection'")
                         return null
                     }
 


### PR DESCRIPTION
No record is ever allowed "change" it's collection, and API writes
only ever allow updates of auth, bib or hold. That _should_ have
been enough to prevent definitions updates, but there's a loop hole.

It turns out that the API makes it's judgement of collection based
on the contents of the update. So you can pass the API something
that looks like, say, a hold and pass the first check. But when
that presumed hold is then saved, there's no check that thing being
overwritten was indeed a hold. So in fact you can update a definition
as long the new data you're updating with doens't look like a
definition. This commit fixes the loophole by also checking that
the record about to be overwritten is in fact auth, bib or hold.