### PR TITLE
Add simple user data API

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000020-add-user-data-table.plsql
+++ b/librisxl-tools/postgresql/migrations/00000020-add-user-data-table.plsql
@@ -1,0 +1,35 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 19;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 20;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+SELECT version from lddb__schema INTO existing_version;
+IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+ROLLBACK;
+END IF;
+UPDATE lddb__schema SET version = new_version;
+
+-- ACTUAL SCHEMA CHANGES HERE:
+
+CREATE TABLE IF NOT EXISTS lddb__user_data (
+    id text PRIMARY KEY,
+    data jsonb NOT NULL,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    modified timestamp with time zone DEFAULT now() NOT NULL
+);
+
+END$$;
+
+COMMIT;

--- a/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
@@ -1,0 +1,113 @@
+package whelk.rest.api
+
+import groovy.json.JsonException
+import groovy.util.logging.Log4j2 as Log
+import groovy.json.JsonSlurper
+import whelk.Whelk
+import whelk.util.WhelkFactory
+
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import java.util.stream.Collectors
+
+@Log
+class UserDataAPI extends HttpServlet {
+    private Whelk whelk
+    private static final int POST_MAX_SIZE = 1000000
+    private static final String ID_HASH_FUNCTION = "SHA-256"
+
+    UserDataAPI() {
+    }
+
+    UserDataAPI(Whelk whelk) {
+        this.whelk = whelk
+    }
+
+    @Override
+    void init() {
+        log.info("Starting User Data API")
+        if (!whelk) {
+            whelk = WhelkFactory.getSingletonWhelk()
+        }
+    }
+
+    @Override
+    void doGet(HttpServletRequest request, HttpServletResponse response) {
+        log.debug("Handling GET request for ${request.pathInfo}")
+
+        Map userInfo = request.getAttribute("user")
+        if (!isValidUserWithPermission(request, response, userInfo))
+            return
+
+        String id = userInfo.email.digest(ID_HASH_FUNCTION)
+        String data = whelk.getUserData(id) ?: "{}"
+        HttpTools.sendResponse(response, data, "application/json")
+    }
+
+    @Override
+    void doPut(HttpServletRequest request, HttpServletResponse response) {
+        log.info("Handling PUT request for ${request.pathInfo}")
+
+        Map userInfo = request.getAttribute("user")
+        if (!isValidUserWithPermission(request, response, userInfo))
+            return
+
+        String id = userInfo.email.digest(ID_HASH_FUNCTION)
+        String data = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()))
+        String idAndEmail = "${id} (${userInfo.email})"
+
+        // Arbitrary upper limit to prevent Clearly Too Large things from being saved.
+        // Can't rely on request.getContentLength() because that's sent by the client.
+        if (data.length() > POST_MAX_SIZE) {
+            log.warn("${idAndEmail} sent too much data (length ${data.length()}, max ${POST_MAX_SIZE})")
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, "Too much data (length ${data.length()}, max ${POST_MAX_SIZE})")
+            return
+        }
+
+        // Make sure what we're saving is actually valid JSON
+        try {
+            new JsonSlurper().parseText(data)
+        } catch (IllegalArgumentException | JsonException e) {
+            log.warn("${idAndEmail} sent invalid JSON: ${e.message}")
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Invalid JSON: ${e.message}")
+            return
+        }
+
+        if (whelk.storeUserData(id, data)) {
+            log.info("${idAndEmail} saved")
+            response.setStatus(HttpServletResponse.SC_OK)
+        } else {
+            log.warn("${idAndEmail} could not be saved to database")
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Saving ${idAndEmail} to database failed")
+        }
+    }
+
+    private static boolean isValidUserWithPermission(HttpServletRequest request, HttpServletResponse response, Map userInfo) {
+        if (!userInfo) {
+            log.info("User authentication failed")
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "User authentication failed")
+            return false
+        }
+
+        if (!userInfo.containsKey("email")) {
+            log.info("User check failed: 'email' missing in user")
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Key 'email' missing in user info")
+            return false
+        }
+
+        String id = userInfo.email.digest(ID_HASH_FUNCTION)
+        if (getRequestId(request) != id) {
+            log.info("ID in request doesn't match ID from token")
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "ID in request doesn't match ID from token")
+            return false
+        }
+
+        return true
+    }
+
+    private static String getRequestId(HttpServletRequest request) {
+        return request.pathInfo == null ? "" : request.pathInfo.substring(request.pathInfo.indexOf('/') + 1)
+    }
+}

--- a/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
@@ -84,6 +84,18 @@ class UserDataAPI extends HttpServlet {
         }
     }
 
+    @Override
+    void doDelete(HttpServletRequest request, HttpServletResponse response) {
+        log.info("Handling DELETE request for ${request.pathInfo}")
+
+        Map userInfo = request.getAttribute("user")
+        if (!isValidUserWithPermission(request, response, userInfo))
+            return
+
+        whelk.removeUserData(userInfo.email.digest(ID_HASH_FUNCTION))
+        response.setStatus(HttpServletResponse.SC_NO_CONTENT)
+    }
+
     private static boolean isValidUserWithPermission(HttpServletRequest request, HttpServletResponse response, Map userInfo) {
         if (!userInfo) {
             log.info("User authentication failed")

--- a/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/UserDataAPI.groovy
@@ -70,8 +70,8 @@ class UserDataAPI extends HttpServlet {
         try {
             new JsonSlurper().parseText(data)
         } catch (IllegalArgumentException | JsonException e) {
-            log.warn("${idAndEmail} sent invalid JSON: ${e.message}")
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Invalid JSON: ${e.message}")
+            log.warn("${idAndEmail} sent invalid JSON")
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Invalid JSON")
             return
         }
 

--- a/rest/src/main/java/whelk/AuthenticationFilter.java
+++ b/rest/src/main/java/whelk/AuthenticationFilter.java
@@ -57,7 +57,7 @@ public class AuthenticationFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
-        if (httpRequest.getMethod().equals("POST") && whitelistedPostEndpoints.contains(httpRequest.getRequestURI())) {
+        if (httpRequest.getMethod().equals("POST") && whitelistedPostEndpoints != null && whitelistedPostEndpoints.contains(httpRequest.getRequestURI())) {
             chain.doFilter(request, response);
         } else if (!mockAuthMode && supportedMethods != null && supportedMethods.contains(httpRequest.getMethod())) {
             int response_code = 0;

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,6 @@
             <param-value>GET, POST, PUT, DELETE</param-value>
         </init-param>
     </filter>
-
     <filter>
         <filter-name>AuthenticationFilter</filter-name>
         <filter-class>whelk.AuthenticationFilter</filter-class>
@@ -36,6 +35,19 @@
             <param-value>false</param-value>
         </init-param>
     </filter>
+    <filter>
+        <filter-name>AuthenticationFilterGet</filter-name>
+        <filter-class>whelk.AuthenticationFilter</filter-class>
+        <init-param>
+            <param-name>supportedMethods</param-name>
+            <param-value>GET</param-value>
+        </init-param>
+        <init-param>
+            <param-name>mockAuthentication</param-name>
+            <param-value>false</param-value>
+        </init-param>
+    </filter>
+
     <servlet>
         <servlet-name>WhelkServlet</servlet-name>
         <servlet-class>whelk.rest.api.Crud</servlet-class>
@@ -69,12 +81,22 @@
         <servlet-name>DuplicatesAPI</servlet-name>
         <servlet-class>whelk.rest.api.DuplicatesAPI</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>UserDataAPI</servlet-name>
+        <servlet-class>whelk.rest.api.UserDataAPI</servlet-class>
+    </servlet>
+
 
     <servlet>
         <servlet-name>PrometheusSimpleClientServlet</servlet-name>
         <servlet-class>io.prometheus.client.exporter.MetricsServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+
+    <servlet-mapping>
+        <servlet-name>UserDataAPI</servlet-name>
+        <url-pattern>/_userdata/*</url-pattern>
+    </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>RemoteSearch</servlet-name>
@@ -124,6 +146,11 @@
     <filter-mapping>
         <filter-name>CORS</filter-name>
         <servlet-name>WhelkServlet</servlet-name>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>AuthenticationFilterGet</filter-name>
+        <url-pattern>/_userdata/*</url-pattern>
     </filter-mapping>
 
     <filter-mapping>

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -440,6 +440,10 @@ class Whelk {
         return storage.storeUserData(id, data)
     }
 
+    void removeUserData(String id) {
+        storage.removeUserData(id)
+    }
+
     private static boolean batchJobThread() {
         return Thread.currentThread().getThreadGroup().getName().contains("whelktool")
     }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -432,6 +432,14 @@ class Whelk {
         }
     }
 
+    String getUserData(String id) {
+        return storage.getUserData(id)
+    }
+
+    boolean storeUserData(String id, String data) {
+        return storage.storeUserData(id, data)
+    }
+
     private static boolean batchJobThread() {
         return Thread.currentThread().getThreadGroup().getName().contains("whelktool")
     }


### PR DESCRIPTION
This adds a simple REST API for storing user data (e.g., user settings). It makes sure a user can only GET/PUT stuff concerning itself, and only PUT valid JSON, and not PUT anything exceedingly large, but doesn't care about anything else. SHA-256 of user email is used as ID. ID is verified through the user map populated by `AuthenticationFilter` (in case of valid user). Data is stored in a `jsonb` field. 

To use:

```bash
# Devops: fab xl_local app.whelk.run_db_migrations
# Start local environment. Sign in.
# Copy token (Firefox: Inspector -> Storage -> Local Storage -> key `at`)
LIBRIS_TOKEN=<copied-from-browser>
EMAIL_HASH=$(echo -n 'foo@example.com'|sha256sum|head -c 64)

# Put stuff:
curl -i -XPUT "http://localhost:8180/_userdata/${EMAIL_HASH}" \
  -H "Authorization: Bearer ${LIBRIS_TOKEN}" \
  -d '{"foo":"bar", "hej":"hopp"}'
# => HTTP/1.1 200 OK

# Get stuff: 
curl -i -XGET "http://localhost:8180/_userdata/${EMAIL_HASH}" \
  -H "Authorization: Bearer ${LIBRIS_TOKEN}"
# => {"foo": "bar", "hej": "hopp"}

# Put something else:
curl -i -XPUT "http://localhost:8180/_userdata/${EMAIL_HASH}" \
  -H "Authorization: Bearer ${LIBRIS_TOKEN}" \
  -d '{"foo":"bar", "hej":"hoppppppppp"}'
# => HTTP/1.1 200 OK

# Get something with wrong user hash:
curl -i -XGET "http://localhost:8180/_userdata/dskfjsklfsdfs" \
  -H "Authorization: Bearer ${LIBRIS_TOKEN}"
# => HTTP/1.1 403 ID in request doesn't match ID from token

# Put something with invalid token:
curl -i -XPUT "http://localhost:8180/_userdata/${EMAIL_HASH}" \
  -H "Authorization: Bearer hunter2" \
  -d '{"foo":"bar", "hej":"hopp"}'
# => HTTP/1.1 401 Missing access token.

# Put too much stuff:
dd if=/dev/urandom bs=2M count=1 \
  | curl -i -XPUT "http://localhost:8180/_userdata/${EMAIL_HASH}" \
      -H "Authorization: Bearer ${LIBRIS_TOKEN}" \
      --data-binary @-
# => [...]
# => HTTP/1.1 413 Too much data (length 2097115, max 1000000)

# Put invalid stuff:
curl -i -XPUT "http://localhost:8180/_userdata/${EMAIL_HASH}" \
  -H "Authorization: Bearer ${LIBRIS_TOKEN}" \
  -d 'sdfskfjsdfsdf'
# => HTTP/1.1 400 Invalid JSON
```

We could use a more typical solution with multiple tables, but given our usage/access patterns and what we need to store, a simple JSON store like this might be sufficient and more flexible.

Sending the hash of the email with the request is not strictly necessary (because `AuthenticationFilter` fetches that through the token), but `PUT /_userdata/<user-hash>` is a bit more RESTful than `PUT /_userdata`.

PUT rather than POST because it should be create-OR-update and idempotent.

`web.xml` modified to add not just the servlet but also another filter, since we need to use `AuthenticationFilter` for GET requests to `_userdata` (but not any other GET requests). I've never worked with servlets before so there might be a nicer way of doing that.