### PR TITLE
Search: Faster assembly of result by reducing number of DB calls

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -1,5 +1,7 @@
 package whelk.rest.api
 
+import com.google.common.collect.ArrayListMultimap
+import com.google.common.collect.Multimap
 import com.google.common.escape.Escaper
 import com.google.common.net.UrlEscapers
 import groovy.util.logging.Log4j2 as Log
@@ -115,15 +117,16 @@ class SearchUtils {
         queryParameters['_limit'] = [limit.toString()]
 
         Map esResult = esQuery.doQuery(queryParameters)
-
+        Lookup lookup = new Lookup()
+        
         List<Map> mappings = []
         if (query) {
             mappings << ['variable' : 'q',
-                         'predicate': ld.toChip(getVocabEntry('textQuery')),
+                         'predicate': lookup.chip('textQuery'),
                          'value'    : query]
         }
 
-        Tuple2 mappingsAndPageParams = mapParams(queryParameters)
+        Tuple2 mappingsAndPageParams = mapParams(lookup, queryParameters)
         mappings.addAll(mappingsAndPageParams.first)
         pageParams << mappingsAndPageParams.second
 
@@ -151,7 +154,7 @@ class SearchUtils {
         // results will be (x=a OR x=b).
         def selectedFacets = ((Map) mappingsAndPageParams.second).findAll {it.key != JsonLd.TYPE_KEY }.keySet()
         def filteredAggregations = ((Map) esResult['aggregations']).findAll{ !selectedFacets.contains(it.key) }
-        Map stats = buildStats(filteredAggregations,
+        Map stats = buildStats(lookup, filteredAggregations,
                 makeFindUrl(SearchType.ELASTIC, stripNonStatsParams(pageParams)),
                 (total > 0 && !predicates) ? reverseObject : null)
         if (!stats) {
@@ -168,7 +171,7 @@ class SearchUtils {
             String upUrl = makeFindUrl(SearchType.ELASTIC, pageParams - ['o' :  pageParams['o']], offset)
             mappings << [
                     'variable' : 'o',
-                    'object'   : ld.toChip(lookup(reverseObject)),  // TODO: object/predicate/???
+                    'object'   : lookup.chip(reverseObject),  // TODO: object/predicate/???
                     'up'       : [(JsonLd.ID_KEY): upUrl],
             ]
         }
@@ -178,7 +181,7 @@ class SearchUtils {
             mappings << [
                     'variable' : 'p',
                     'object'   : reverseObject,
-                    'predicate': ld.toChip(lookup(predicates.first())),
+                    'predicate': lookup.chip(predicates.first()),
                     'up'       : [(JsonLd.ID_KEY): upUrl],
             ]
         }
@@ -195,6 +198,8 @@ class SearchUtils {
             result['_debug'] = esResult['_debug']
         }
 
+        lookup.run()
+        
         return result
     }
 
@@ -310,13 +315,13 @@ class SearchUtils {
      * Build aggregation statistics for ES result.
      *
      */
-    private Map buildStats(Map aggregations, String baseUrl, String reverseObject) {
+    private Map buildStats(Lookup lookup, Map aggregations, String baseUrl, String reverseObject) {
         Map result = [:]
-        result = addSlices([:], aggregations, baseUrl, reverseObject)
+        result = addSlices(lookup, [:], aggregations, baseUrl, reverseObject)
         return result
     }
 
-    private Map addSlices(Map stats, Map aggregations, String baseUrl, String reverseObject) {
+    private Map addSlices(Lookup lookup, Map stats, Map aggregations, String baseUrl, String reverseObject) {
         Map sliceMap = aggregations.inject([:]) { acc, key, aggregation ->
             String baseUrlForKey = removeWildcardForKey(baseUrl, key)
             List observations = []
@@ -327,7 +332,7 @@ class SearchUtils {
 
                 Map observation = ['totalItems': bucket.getAt('doc_count'),
                                    'view': [(JsonLd.ID_KEY): searchPageUrl],
-                                   'object': ld.toChip(lookup(itemId))]
+                                   'object': lookup.chip(itemId)]
                 
                 observations << observation
             }
@@ -350,7 +355,7 @@ class SearchUtils {
                         [
                                 'totalItems': count,
                                 'view'      : ['@id': viewUrl],
-                                'object'    : ld.toChip(lookup(relations.first()))
+                                'object'    : lookup.chip(relations.first())
                         ]
                     }
             ]
@@ -422,27 +427,47 @@ class SearchUtils {
         }
     }
 
-    /*
-     * Read vocab item from db.
-     *
-     * Default to dummy value if not found.
-     *
-     */
-    private Map lookup(String itemId) {
-        Map entry = getVocabEntry(itemId)
+    private class Lookup {
+        private Multimap<String, Map> iriPos = ArrayListMultimap.create()
+        
+        Map chip(String itemId) {
+            def termKey = ld.toTermKey(itemId)
+            if (termKey in ld.vocabIndex) {
+                return ld.vocabIndex[termKey]
+            }
 
-        if (entry) {
-            return entry
-        } else if (!itemId.startsWith('http') && itemId.contains('.')) {
-            def chain = itemId.split('\\.').findAll {it != JsonLd.ID_KEY}
-            return [
-                    'propertyChainAxiom': chain.collect(this.&lookup),
-                    'label': chain.join(' '),
-                    '_key': itemId,  // lxlviewer has some propertyChains of its own defined, this is used to match them 
-            ]
-        } else {
-            return [(JsonLd.ID_KEY): itemId, 'label': itemId]
+            if (!itemId.startsWith('http') && itemId.contains('.')) {
+                def chain = itemId.split('\\.').findAll {it != JsonLd.ID_KEY}
+                return [
+                        'propertyChainAxiom': chain.collect{ Lookup.this.chip(it) },
+                        'label': chain.join(' '),
+                        '_key': itemId,  // lxlviewer has some propertyChains of its own defined, this is used to match them 
+                ]
+            }
+
+            String iri = getFullUri(itemId)
+
+            if(!iri) {
+                return dummyChip(itemId)
+            }
+
+            Map m = [:]
+            iriPos.put(iri, m)
+            return m
         }
+        
+        void run() {
+            Map<String, Map> cards = whelk.getCards(iriPos.keySet())
+            iriPos.entries().each {
+                def thing = cards.get(it.key)?.with { card -> getEntry(card, it.key) } ?: dummyChip(it.key)
+                def chip = (Map) ld.toChip(thing)
+                it.value.putAll(chip)
+            }
+        }
+    }
+    
+    private Map dummyChip(String itemId) {
+        [(JsonLd.ID_KEY): itemId, 'label': itemId]
     }
 
     /*
@@ -451,15 +476,10 @@ class SearchUtils {
      * Returns null if not found.
      *
      */
-    private Map getVocabEntry(String id) {
-        def termKey = ld.toTermKey(id)
-        if (termKey in ld.vocabIndex) {
-            return ld.vocabIndex[termKey]
-        }
-        String fullId
+    private String getFullUri(String id) {
         try {
             if (vocabUri) {
-                fullId = vocabUri.resolve(id).toString()
+                return vocabUri.resolve(id).toString()
             }
         }
         catch (IllegalArgumentException e) {
@@ -467,15 +487,8 @@ class SearchUtils {
             // No need to check the db.
             return null
         }
-        Document doc = whelk.storage.getDocumentByIri(fullId)
-
-        if (doc) {
-            return getEntry(doc.data, fullId)
-        } else {
-            return null
-        }
     }
-
+    
     // FIXME move to Document or JsonLd
     private Map getEntry(Map jsonLd, String entryId) {
         // we rely on this convention for the time being.
@@ -636,7 +649,7 @@ class SearchUtils {
      * filtered out.
      *
      */
-    private Tuple2 mapParams(Map params) {
+    private Tuple2 mapParams(Lookup lookup, Map params) {
         List result = []
         Map pageParams = [:]
         List reservedParams = getReservedParameters()
@@ -652,24 +665,18 @@ class SearchUtils {
                 if (param == JsonLd.TYPE_KEY || param == JsonLd.ID_KEY) {
                     valueProp = 'object'
                     termKey = param
-                    value = ld.toChip(lookup(val)).with { it[JsonLd.ID_KEY] = val; return it }
+                    value = lookup.chip(val).with { it[JsonLd.ID_KEY] = val; return it }
                 } else if (param.endsWith(".${JsonLd.ID_KEY}")) {
                     valueProp = 'object'
                     termKey = param[0..-5]
-                    value = ld.toChip(lookup(val)).with { it[JsonLd.ID_KEY] = val; return it }
+                    value = lookup.chip(val).with { it[JsonLd.ID_KEY] = val; return it }
                 } else {
                     valueProp = 'value'
                     termKey = param
                     value = val
                 }
-
-                Map termChip
-                Map termDef = getVocabEntry(termKey)
-                if (termDef) {
-                    termChip = ld.toChip(termDef)
-                }
-
-                result << ['variable': param, 'predicate': termChip,
+                
+                result << ['variable': param, 'predicate': lookup.chip(termKey),
                            (valueProp): value]
 
                 if (!(param in pageParams)) {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -410,7 +410,12 @@ class Whelk {
 
         e.embellish(document)
     }
-    
+
+    /**
+     * Get cards
+     * @param iris
+     * @return map from all thing and record identifiers (including sameAs) to corresponding card of whole document 
+     */
     Map<String, Map> getCards(Iterable<String> iris) {
         Map<String, Map> result = [:]
         storage.getCards(iris).each { card ->

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -410,6 +410,23 @@ class Whelk {
 
         e.embellish(document)
     }
+    
+    Map<String, Map> getCards(Iterable<String> iris) {
+        Map<String, Map> result = [:]
+        storage.getCards(iris).each { card ->
+            List<Map> graph = (List<Map>) card['@graph']
+            graph?.each { Map e ->
+                e['@id']?.with { result[(String) it] = card }
+                if (e.sameAs) {
+                    ((List<Map>) (e.sameAs)).each { Map sameAs ->
+                        sameAs['@id']?.with { result[(String) it] = card }
+                    }
+                }
+            }
+        }
+        
+        return result
+    }
 
     Document loadEmbellished(String systemId) {
         return storage.loadEmbellished(systemId, this.&embellish)


### PR DESCRIPTION
When searching, for each request, hundreds of chips are loaded for e.g facets. This batches the DB requests and loads cards instead of full docs. ~40% faster when running locally on my machine.
