### PR TITLE
Document (types) no longer need to belong to a legacy MARC collection

### DIFF
--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -139,7 +139,7 @@ class WhelkCopier {
         newDoc.id = newId
 
         def collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, dest.jsonld)
-        if (collection && collection != "definitions") {
+        if (collection != "definitions") {
             try {
                 dest.quickCreateDocument(newDoc, "xl", "WhelkCopier", collection)
             } catch (Exception e) {

--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -78,11 +78,6 @@ public class Helpers
         {
             String updatedCollection = LegacyIntegrationTools.determineLegacyCollection(updated, OaiPmh.s_whelk.getJsonld());
 
-            if (updatedCollection == null)
-            {
-                return;
-            }
-
             if (requestedCollection == null)
             {
                 // If no collection is requested, all records matching the prepared statement are welcome.

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -163,18 +163,15 @@ public class ResponseCommon
         writer.writeEndElement(); // datestamp
 
         String dataset = LegacyIntegrationTools.determineLegacyCollection(document, OaiPmh.s_whelk.getJsonld());
-
-        if (dataset != null)
+        
+        String type = document.getThingType();
+        if ( !(dataset.equals("auth") && OaiPmh.workDerivativeTypes.contains(type)))
         {
-            String type = document.getThingType();
-            if ( !(dataset.equals("auth") && OaiPmh.workDerivativeTypes.contains(type)))
-            {
-                writer.writeStartElement("setSpec");
-                writer.writeCharacters(dataset);
-                writer.writeEndElement(); // setSpec
-            }
+            writer.writeStartElement("setSpec");
+            writer.writeCharacters(dataset);
+            writer.writeEndElement(); // setSpec
         }
-
+        
         String sigel = document.getHeldBySigel();
         if (sigel != null)
         {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -628,7 +628,7 @@ class PostgreSQLComponent {
         try {
             connection.setAutoCommit(false)
             normalizeDocumentForStorage(doc, connection)
-
+            
             if (collection == "hold") {
                 checkLinkedShelfMarkOwnership(doc, connection)
                 

--- a/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
@@ -27,6 +27,8 @@ class LegacyIntegrationTools {
         'https://id.kb.se/marc/bib': 'bib',
         'https://id.kb.se/marc/hold': 'hold'
     ]
+    
+    static final String NO_MARC_COLLECTION = 'none'
 
     static String generateId(String originalIdentifier) {
         String[] parts = originalIdentifier.split("/")
@@ -50,7 +52,7 @@ class LegacyIntegrationTools {
     }
 
     /**
-     * Will return "auth", "bib", "hold" or null
+     * Will return "auth", "bib", "hold", "definitions" or "none"
      */
     static String determineLegacyCollection(Document document, JsonLd jsonld) {
         String type = document.getThingType() // for example "Instance"
@@ -79,11 +81,11 @@ class LegacyIntegrationTools {
             }
             String superClassType = jsonld.toTermKey( (String) superClass["@id"] )
             String category = getMarcCollectionInHierarchy(superClassType, jsonld)
-            if ( category != null )
+            if ( category != NO_MARC_COLLECTION )
                 return category
         }
 
-        return null
+        return NO_MARC_COLLECTION
     }
 
     static String getMarcCollectionForTerm(Map termMap) {
@@ -98,7 +100,7 @@ class LegacyIntegrationTools {
                 return collection
             }
         }
-        return null
+        return NO_MARC_COLLECTION
     }
 
     /**


### PR DESCRIPTION
Set collection `none` for documents that don't belong to any of the legacy MARC collections (bib, auth, hold) or definitions.
So that we can store documents with other types e.g. `DataCatalog`

I've checked all the places where we look at collection and this shouldn't break anything.