### PR TITLE
Respect ES max_result_window in makePaginationLinks, and include it in response

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -198,6 +198,8 @@ class SearchUtils {
             result['_debug'] = esResult['_debug']
         }
 
+        result['maxItems'] = esQuery.getMaxItems().toString()
+
         lookup.run()
         
         return result
@@ -258,7 +260,7 @@ class SearchUtils {
         result['search'] = ['mapping': mappings]
 
         Map paginationLinks = makePaginationLinks(st, pageParams, limit,
-                                                  offset, total)
+                                                  offset, Math.min(total, esQuery.getMaxItems()))
         result << paginationLinks
 
         result['items'] = items

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -108,6 +108,28 @@ class ElasticSearch {
         }
     }
 
+    /**
+     * Get ES settings for associated index
+     */
+    Map getSettings() {
+        Map response
+        try {
+            response = mapper.readValue(client.performRequest('GET', "/${indexName}/_settings", ''), Map)
+        } catch (UnexpectedHttpStatusException e) {
+            log.warn("Got unexpected status code ${e.statusCode} when getting ES settings: ${e.message}", e)
+            return [:]
+        }
+
+        List<String> keys = response.keySet() as List
+
+        if (keys.size() == 1 && response[(keys[0])].containsKey('settings')) {
+            return response[(keys[0])]['settings']
+        } else {
+            log.warn("Couldn't get settings from ES index ${indexName}, response was ${response}.")
+            return [:]
+        }
+    }
+
     void bulkIndex(Collection<Document> docs, Whelk whelk) {
         if (docs) {
             String bulkString = docs.findResults{ doc ->


### PR DESCRIPTION
Fetches Elasticsearch `max_result_window` from index settings and uses it when generating pagination links. This fixes "next" and "last" links (can no longer go beyond what's possible), but some adjustments in the client are still necessary to make it not generate links beyond the limit, so a `maxItems` is now included in the response to make this possible.