### PR TITLE
Remove leading non-alphanumerics from sort field

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -798,6 +798,15 @@ class JsonLd {
             // Use last URI components as fallback
             if (!result && thing['@id']) {
                 result = removeDomain((String) thing['@id'], removableBaseUris)
+            } else {
+                result = result
+                    // Remove leading non-alphanumeric characters
+                    .replaceFirst(/^[^\p{L}\p{N}]+/, "")
+                    // A string without alphanumerics should not have "" as its sort value, because
+                    // then we get messed up records on top when sorting A-Z. Workaround: use a character from
+                    // Unicode's Private Use Area, forcing such records to appear at the very end when sorting.
+                    // TODO: default to some sensible/explanatory string instead?
+                    .replaceFirst(/^$/, "\uE83A")
             }
             [(k): result]
         }


### PR DESCRIPTION
Removes one or more leading non-alphanumeric characters from the special sort value. Related to LXL-2290.

Can't do this in Elasticsearch, because: 

`_sortKeyByLang` must be a keyword-type field. The `keyword` field type supports the `normalizer` option (similar to `analyzer` for `text` fields). A normalizer can have filters/char_filters configured. However, we need to use the `icu_collation_keyword` type to be able to sort things properly. `icu_collation_keyword` is very much like a normal `keyword` field, but not quite: it does _not_ support the `normalizer` option. :weary:. Hence having to do it in JsonLd instead (I guess?).

Some records (like [this](https://libris.kb.se/katalogisering/mxbgmvd0kstbcxv6) one) have completely messed up titles, making them appear near the top. This change makes it so that things that have nothing but non-alphanumeric characters have their `_sortKeyByLang` value set to "\uE83A", which is just an arbitrary code point from the Unicode Private Use Area, forcing them to come after everything else when sorting.

This doesn't affect A-Z sorting of instances and works, because they're still sorted by `hasTitle.mainTitle`, so they'll still be messed up (same issue there, it's an `icu_collation_keyword` field) . Maybe simply use `_sortKeyByLang` for those too, because for an instance/work `hasTitle` would be the first thing in the string anyway?