### PR TITLE
Allow GET /_remotesearch only when authenticated

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -159,17 +159,8 @@ class RemoteSearchAPI extends HttpServlet {
 
     @Override
     void doGet(HttpServletRequest request, HttpServletResponse response) {
-        // Check that we have kat-rights.
-        boolean hasPermission = false
         Map userInfo = request.getAttribute("user")
-        if (userInfo != null) {
-            if (userInfo.permissions.any { item ->
-                item.get(whelk.rest.security.AccessControl.KAT_KEY)
-            } || Crud.isSystemUser(userInfo))
-                hasPermission = true
-        }
-
-        if (hasPermission){
+        if (!userInfo) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN)
             return
         }

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -154,6 +154,11 @@
     </filter-mapping>
 
     <filter-mapping>
+        <filter-name>AuthenticationFilterGet</filter-name>
+        <url-pattern>/_remotesearch</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
         <filter-name>AuthenticationFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>


### PR DESCRIPTION
Previously, GET requests to /_remotesearch weren't actually authenticated. Now they are.