### PR TITLE
Add more validation for auth and bib

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -503,8 +503,9 @@ class Crud extends HttpServlet {
         newDoc.normalizeUnicode()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         newDoc.setControlNumber(newDoc.getShortId())
-        
-        List<JsonLdValidator.Error> errors = validator.validate(newDoc.data)
+
+        String collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, jsonld)
+        List<JsonLdValidator.Error> errors = validator.validate(newDoc.data, collection)
         if (errors) {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("POST", request.getRequestURI(),
@@ -640,7 +641,8 @@ class Crud extends HttpServlet {
         updatedDoc.normalizeUnicode()
         updatedDoc.setId(documentId)
 
-        List<JsonLdValidator.Error> errors = validator.validate(updatedDoc.data)
+        String collection = LegacyIntegrationTools.determineLegacyCollection(updatedDoc, jsonld)
+        List<JsonLdValidator.Error> errors = validator.validate(updatedDoc.data, collection)
         if (errors) {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("PUT", request.getRequestURI(),


### PR DESCRIPTION
- Makes it possible for JsonLdValidator to check a set of different scopes depending on legacy collection. Figured this would be the easiest way (it's just "temporary"). Makes POST/PUT in Crud send collection type along with the data to the validator.
- For auth: enables MISSING_DEFINITION, OBJECT_PROPERTIES, UNKOWN_VOCAB_VALUE
- For bib: enables MISSING_DEFINITION, OBJECT_PROPERTIES

OBJECT_PROPERTIES corresponds to the errors OBJECT_TYPE_EXPECTED and VOCAB_STRING_EXPECTED.