### PR TITLE
Add findKey for multiple keys to DocumentUtil

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -46,8 +46,21 @@ class DocumentUtil {
      * @return true if obj was changed
      */
     static boolean findKey(data, String key, Visitor visitor) {
+        return findKey(data, [key], visitor)
+    }
+
+    /**
+     * Search keys in JSON-LD structure
+     *
+     * @param data JSON-LD structure
+     * @param keys
+     * @param visitor function to call with value for found keys
+     * @return true if obj was changed
+     */
+    static boolean findKey(data, Collection<String> keys, Visitor visitor) {
+        Set<String> k = keys instanceof Set ? keys : new HashSet<>(keys) 
         return traverse(data, { value, path ->
-            if (path && path.last() == key) {
+            if (path && path.last() instanceof String && k.contains(path.last())) {
                 return visitor.visitElement(value, path)
             }
         })

--- a/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
@@ -98,6 +98,39 @@ class DocumentUtilSpec extends Specification {
         ]
     }
 
+    def findKeys() {
+        given:
+        def data = [
+                a: [b: [c: 'q']],
+                r: [s: [t: [a: [q: 2]]]],
+                l: [[], [a: 2]]
+        ]
+
+        def visited = []
+        def values = []
+        DocumentUtil.findKey(data, ['a', 's', 'q'], { value, path ->
+            values << value
+            visited << path
+            return NOP
+        })
+
+        expect:
+        values == [
+                [b: [c: 'q']],
+                [t: [a: [q: 2]]],
+                [q: 2],
+                2,
+                2
+        ]
+        visited == [
+                ['a'],
+                ['r', 's'],
+                ['r', 's', 't', 'a'],
+                ['r', 's', 't', 'a', 'q'],
+                ['l', 1, 'a']
+        ]
+    }
+
     def "link"() {
         given:
         def data = [


### PR DESCRIPTION
Old version only takes one key
`static boolean findKey(data, String key, Visitor visitor)`

Inspired by `clearGarbageProperties` in #918.