### PR TITLE
Handle reindex getAffectedIds > ES max_result_window

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -239,28 +239,12 @@ class Whelk {
                 }
             }
         }
-
-
+        
         if (storage.isCardChangedOrNonexistent(document.getShortId())) {
-            bulkIndex(getAffectedIds(document))
+            bulkIndex(elastic.getAffectedIds(document.getThingIdentifiers() + document.getRecordIdentifiers()))
         }
     }
-
-    /**
-     * Find all other documents that need to be re-indexed because of a change in document
-     * @param document the changed document
-     * @return an Iterable of system IDs.
-     */
-    private Iterable<String> getAffectedIds(Document document) {
-        List<Iterable<String>> queries = []
-        for (String iri : document.getThingIdentifiers()) {
-            for (String field : ["_links", "_outerEmbellishments"]) {
-                queries << elasticFind.findIds(['q': ["*"], (field): [iri]])
-            }
-        }
-        return Iterables.filter(Iterables.concat(queries), { it != null })
-    }
-
+    
     private void bulkIndex(Iterable<String> ids) {
         Iterables.partition(ids, 100).each {
             elastic.bulkIndexWithRetry(it, this)

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -15,6 +15,7 @@ import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
 import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.HttpDelete
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.client.methods.HttpPut
@@ -224,11 +225,18 @@ class ElasticClient {
                     return new HttpGet(host + path)
                 case 'PUT':
                     HttpPut request = new HttpPut(host + path)
-                    request.setEntity(httpEntity(body, contentType0))
+                    if (body)
+                        request.setEntity(httpEntity(body, contentType0))
                     return request
                 case 'POST':
                     HttpPost request = new HttpPost(host + path)
-                    request.setEntity(httpEntity(body, contentType0))
+                    if (body)
+                        request.setEntity(httpEntity(body, contentType0))
+                    return request
+                case 'DELETE':
+                    HttpDeleteWithBody request = new HttpDeleteWithBody(host + path)
+                    if (body)
+                        request.setEntity(httpEntity(body, contentType0))
                     return request
                 default:
                     throw new IllegalArgumentException("Bad request method:" + method)
@@ -238,6 +246,17 @@ class ElasticClient {
         private static HttpEntity httpEntity(String body, String contentType) {
             return new StringEntity(body,
                     contentType ? ContentType.create(contentType) : ContentType.APPLICATION_JSON)
+        }
+    }
+    
+    class HttpDeleteWithBody extends HttpPost { // LOL
+        HttpDeleteWithBody(String uri) {
+            super(uri)
+        }
+        
+        @Override
+        String getMethod() {
+            return 'DELETE'
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -15,7 +15,6 @@ import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
 import org.apache.http.client.config.RequestConfig
-import org.apache.http.client.methods.HttpDelete
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.client.methods.HttpPut

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -588,8 +588,8 @@ class ElasticSearch {
     }
 
     /**
-     * Use Point in time API to be able to retrieve more than {@link ElasticSearch#maxResultWindow} results
-     * Need to consume {@link ElasticSearch.Scroll#FETCH_SIZE} results in less time than 
+     * Use "search_after" + Point in time API to be able to retrieve more than {@link ElasticSearch#maxResultWindow} 
+     * results. Caller needs to consume {@link ElasticSearch.Scroll#FETCH_SIZE} results in less time than 
      * {@link PointInTimeScroll#keepAlive} otherwise the search context times out.
      */
     private class PointInTimeScroll<T> extends Scroll<T> {

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -19,8 +19,7 @@ class ESQuery {
     private JsonLd jsonld
     private Set keywordFields
     private Set dateFields
-    private int maxResultWindow = 10000 // Elasticsearch default (fallback value)
-
+    
     private static final ObjectMapper mapper = new ObjectMapper()
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
@@ -40,7 +39,6 @@ class ESQuery {
         this.whelk = whelk
         this.jsonld = whelk.jsonld
         initFieldMappings(this.whelk)
-        initIndexSettings(this.whelk)
 
         this.lensBoost = new ESQueryLensBoost(jsonld)
     }
@@ -55,18 +53,7 @@ class ESQuery {
             this.dateFields = Collections.emptySet()
         }
     }
-
-    void initIndexSettings(Whelk whelk) {
-        if (whelk.elastic) {
-            Map indexSettings = whelk.elastic.getSettings()
-            if (indexSettings.index &&
-                    indexSettings.index['max_result_window'] &&
-                    ((String) indexSettings.index['max_result_window']).isNumber()) {
-                maxResultWindow = ((String) indexSettings.index['max_result_window']).toInteger()
-            }
-        }
-    }
-
+    
     void setKeywords(Set keywordFields) {
         // NOTE: For unit tests only!
         this.keywordFields = keywordFields
@@ -825,6 +812,6 @@ class ESQuery {
     }
 
     int getMaxItems() {
-        return maxResultWindow
+        return whelk.elastic.maxResultWindow
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
@@ -1,6 +1,8 @@
 package whelk.search
 
 import groovy.transform.CompileStatic
+import io.github.resilience4j.retry.MaxRetriesExceeded
+import whelk.component.ElasticSearch
 
 @CompileStatic
 class ElasticFind {
@@ -67,6 +69,10 @@ class ElasticFind {
             private void fetchFirst() {
                 def firstResult = getter(0)
                 total = firstResult['totalHits']
+                if (total > esQuery.getMaxItems()) {
+                    throw new ElasticSearch.TooManyResultsException(total, esQuery.getMaxItems())
+                }
+                
                 items = (List<T>) firstResult['items']
 
                 beforeFirstFetch = false
@@ -96,3 +102,4 @@ class ElasticFind {
         return p
     }
 }
+ 

--- a/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
@@ -1,7 +1,6 @@
 package whelk.search
 
 import groovy.transform.CompileStatic
-import io.github.resilience4j.retry.MaxRetriesExceeded
 import whelk.component.ElasticSearch
 
 @CompileStatic


### PR DESCRIPTION
We find documents that need to be reindexed by querying _links and _outerEmbellishments.
This fails if the number of found documents exceed the max_result_window setting of the ES index (currently 100 000).

Fall back to using [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after) and [Point in time API](https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html) if number of results > max_result_window.

