### PR TITLE
Add "heuristic linker" document normalizer

### DIFF
--- a/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
@@ -14,26 +14,14 @@ import static whelk.JsonLd.ID_KEY
 
 /*
 TODO: add support for linking blank nodes based on owl:hasKey
-example (only hasKey defined in vocab at the moment): 
-{
-  "@id": "https://id.kb.se/vocab/Concept",
-  "@type": "Class",
-  ...
-  "owl:hasKey": {
-    "@list": [
-      {
-        "@id": "https://id.kb.se/vocab/code"
-      },
-      {
-        "@id": "https://id.kb.se/vocab/prefLabel"
-      },
-      {
-        "@id": "https://id.kb.se/vocab/inScheme"
-      }
-    ]
-  },
-  ...
-}
+example: 
+:Concept a owl:Class;
+    rdfs:label "Concept"@en, "Koncept"@sv;
+    rdfs:subClassOf :Identity;
+    owl:equivalentClass skos:Concept;
+    owl:hasKey (:code :prefLabel :inScheme) .
+
+(only hasKey defined in vocab at the moment)
  */
 
 @Log

--- a/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
@@ -6,7 +6,6 @@ import whelk.JsonLd
 import whelk.Whelk
 import whelk.component.DocumentNormalizer
 import whelk.exception.InvalidQueryException
-import whelk.exception.ModelValidationException
 import whelk.filter.BlankNodeLinker
 import whelk.filter.LanguageLinker
 
@@ -25,16 +24,16 @@ class Normalizers {
             linker.linkAll(doc.data, 'language')
         }
     }
+    
+    static Collection<DocumentNormalizer> heuristicLinkers(Whelk whelk) {
+        whelk.jsonld.getCategoryMembers('heuristicIdentity').collect{ type ->
+            BlankNodeLinker linker = new BlankNodeLinker(
+                    type, ['code', 'label', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabel'])
+            loadDefinitions(linker, whelk)
 
-    static DocumentNormalizer contributionRole(Whelk whelk) {
-        BlankNodeLinker linker = new BlankNodeLinker(
-                'Role', ['code', 'label', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabel'])
-        loadDefinitions(linker, whelk)
-
-        return { Document doc ->
-            Map work = getWork(whelk.jsonld, doc)
-            if (work && work['contribution']) {
-                linker.linkAll(work['contribution'], 'role')
+            Set<String> inRange = whelk.jsonld.getInRange(type)
+            return (DocumentNormalizer) { doc ->
+                linker.linkAll(doc.data, inRange)
             }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -144,7 +144,7 @@ class JsonLd {
         inRange = zipMaps(generateSubTermLists('rangeIncludes'), generateSubTermLists('range'))
         
         buildLangContainerAliasMap()
-2
+
         expandAliasesInLensProperties()
         expandInheritedLensProperties()
         expandInverseLensProperties()

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -86,6 +86,8 @@ class JsonLd {
     private Map<String, Set<String>> subClassesByType
     private Map<String, List<String>> superPropertyOf
     private Map<String, Set<String>> subPropertiesByType
+    private Map<String, Set<String>> categories
+    private Map<String, Set<String>> inRange
 
     Map langContainerAlias = [:]
 
@@ -136,8 +138,13 @@ class JsonLd {
         subPropertiesByType = new HashMap<String, Set>()
         superPropertyOf = generateSubTermLists("subPropertyOf")
 
+        categories = generateSubTermLists('category')
+        
+        def zipMaps = { a, b -> (a.keySet() + b.keySet()).collectEntries{k -> [k, a.get(k, []) + b.get(k, [])]}}
+        inRange = zipMaps(generateSubTermLists('rangeIncludes'), generateSubTermLists('range'))
+        
         buildLangContainerAliasMap()
-
+2
         expandAliasesInLensProperties()
         expandInheritedLensProperties()
         expandInverseLensProperties()
@@ -596,6 +603,14 @@ class JsonLd {
 
     Set<String> getSubProperties(String type) {
         return getSubTerms(type, superPropertyOf, subPropertiesByType)
+    }
+    
+    Set<String> getCategoryMembers(String category) {
+        return categories.get(category, Collections.EMPTY_SET)
+    }
+
+    Set<String> getInRange(String type) {
+        return inRange.get(type, Collections.EMPTY_SET)
     }
 
     private Set<String> getSubTerms(String type,

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -134,8 +134,7 @@ class Whelk {
                         Normalizers.workPosition(jsonld),
                         Normalizers.typeSingularity(jsonld),
                         Normalizers.language(this),
-                        Normalizers.contributionRole(this)
-                ]
+                ] + Normalizers.heuristicLinkers(this)
         )
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -89,7 +89,7 @@ class BlankNodeLinker implements DocumentUtil.Linker {
             }
         }
 
-        String id = definition[ID_KEY]
+        String id = definition.isReplacedBy? definition.isReplacedBy[ID_KEY] : definition[ID_KEY]
         identifiers.each { addMapping(it, id) }
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -25,13 +25,13 @@ class BlankNodeLinker implements DocumentUtil.Linker {
 
     List<String> fields = []
 
-    BlankNodeLinker(List<String> types, List<String> fields, Statistics stats = null) {
+    BlankNodeLinker(Collection<String> types, Collection<String> fields, Statistics stats = null) {
         this.types = types.collect()
-        this.fields = fields
+        this.fields = fields.collect()
         this.stats = stats
     }
 
-    BlankNodeLinker(String type, List<String> fields, Statistics stats = null) {
+    BlankNodeLinker(String type, Collection<String> fields, Statistics stats = null) {
         this([type], fields, stats)
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -35,6 +35,10 @@ class BlankNodeLinker implements DocumentUtil.Linker {
         this([type], fields, stats)
     }
 
+    boolean linkAll(data, Collection<String> keys) {
+        return findKey(data, keys, link(this)) && removeDeleted(data)
+    }
+    
     boolean linkAll(data, String key) {
         return findKey(data, key, link(this)) && removeDeleted(data)
     }


### PR DESCRIPTION
Implemented an old idea from https://github.com/libris/librisxl/pull/591. 
Configure types and properties for "BlankNodeLinker" normalizers with vocab instead of hardcoding them.

Link blank nodes based on "heuristic identifiers"
e.g. `{ "@type": "Role", "label": "Þýðandi" }` matches https://id.kb.se/relator/trl on `prefLabelByLang.is`

For all types that have :category :heuristicIdentity in vocab:
Link all blank nodes with that `@type` that match on a property that has `:category :heuristicIdentifier`.
Only check blank nodes in properties where `@type` is in range (`range` or `rangeIncludes`).

Depends on https://github.com/libris/definitions/pull/284

First use case is `country` in entities from bibdb.
Replace the hardcoded linker for `Role`