### PR TITLE
Search: Handle ORCID with spaces

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -141,8 +141,8 @@ class SearchUtils {
             items = esResult['items'].collect {
                 def item = applyLens(it, lens, reverseObject)
                 
-                // ISNIs are indexed with and without spaces, remove the one with spaces.
-                item.identifiedBy?.with { List ids -> ids.removeAll { Document.isIsni(it) && it.value?.size() == 16+3 } }
+                // ISNIs and ORCIDs are indexed with and without spaces, remove the one with spaces.
+                item.identifiedBy?.with { List ids -> ids.removeAll { (Document.isIsni(it) || Document.isOrcid(it) ) && it.value?.size() == 16+3 } }
                 
                 // This object must be re-added because it might get filtered out in applyLens().
                 item['reverseLinks'] = it['reverseLinks']

--- a/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
@@ -61,13 +61,13 @@ class Normalizers {
         }
     }
 
-    static DocumentNormalizer isni() {
+    static DocumentNormalizer identifiedBy() {
         // TODO: fix MARC conversion, then replace all typeNote: isni with @type: ISNI
         
         return { Document doc ->
             def (_record, thing) = doc.data[GRAPH_KEY]
             thing.identifiedBy?.with {
-                asList(it).findAll{ Document.&isIsni }.forEach { Map isni ->
+                asList(it).findAll{ Document.&isIsni || Document.&isOrcid }.forEach { Map isni ->
                     isni.value = ((String) isni.value)?.replace(' ', '')
                 }
             }

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -235,6 +235,14 @@ class Document {
     static boolean isIsni(Map identifier) { 
          identifier['@type'] == 'ISNI' || identifier.typeNote?.with{ String n -> n.toLowerCase() } == 'isni'
     }
+
+    List<String> getOrcidValues() {
+        return getTypedIDValues(this.&isOrcid, thingTypedIDsPath, "value")
+    }
+
+    static boolean isOrcid(Map identifier) {
+        identifier['@type'] == 'ORCID' || identifier.typeNote?.with{ String n -> n.toLowerCase() } == 'orcid'
+    }
     
     private List<String> getTypedIDValues(String typeKey, List<String> idListPath, String valueKey) {
         getTypedIDValues({ it['@type'] == typeKey }, idListPath, valueKey)

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -134,7 +134,7 @@ class Whelk {
                         Normalizers.workPosition(jsonld),
                         Normalizers.typeSingularity(jsonld),
                         Normalizers.language(this),
-                        Normalizers.isni(),
+                        Normalizers.identifiedBy(),
                 ] + Normalizers.heuristicLinkers(this)
         )
     }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -354,6 +354,9 @@ class ElasticSearch {
 
         getFormattedIsnis(doc.getIsniValues())
                 .each { doc.addTypedThingIdentifier('ISNI', it) }
+
+        getFormattedIsnis(doc.getOrcidValues()) // ORCID is a subset of ISNI, same format
+                .each { doc.addTypedThingIdentifier('ORCID', it) }
         
         doc.data['@graph'][1]['_links'] = links
         doc.data['@graph'][1]['_outerEmbellishments'] = doc.getEmbellishments() - links


### PR DESCRIPTION
This is a follow-up on 1de4449c3d4e4a5397291eaefe34cb6d128213af and f286c2c17a1f5cf20db8f9210bc4d6fe3e3d009c which I accidentally pushed to `develop`...

ISNIs are always 16 digits and can be displayed with out without grouping of digits. ORCID is a reserved subset of ISNI.

Handle ISNI and ORCID, formatted with or without spaces in search
- i.e. both 0000000084029206 and 0000 0000 8402 9206 works
- but 0000 8402 0000 9206 will also match because identifiedBy.value is a text fields in elastic so every group is treated as a word (token)...

Normalize ISNI and ORCID on save, always store without spaces