### PR TITLE
Fix MARC conversion of ISNI/ORCID/VIAF/WikidataID

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -21796,6 +21796,22 @@
     "022": {"inherit": "bib"},
     "024": {
       "include": ["identifier"],
+      "match": [
+        {
+          "when": "i1=7 & $2 =~ isni|ISNI|orcid|ORCID",
+          "i1": null,
+          "$2": {
+            "property": "@type",
+            "tokenMap": {
+              "NOTE": "NB! Order is significant. The last key for the same value will be used on revert",
+              "ISNI": "ISNI",
+              "isni": "ISNI",
+              "ORCID": "ORCID",
+              "orcid": "ORCID"
+            }
+          }
+        }
+      ],
       "i1": {
         "property": "@type",
         "tokenMap": {
@@ -21850,10 +21866,24 @@
           }
         },
         {
-          "name": "ISNI, indicator from $2 when i1 = 7, TODO: fix ind1=8",
+          "name": "ISNI, indicator from $2 when i1 = 7",
           "source": {
             "024": {"ind1": "7", "ind2": " ", "subfields": [{"a": "0000 0000 0000 0000"}, {"2": "isni"}]}
           },
+          "result": {
+            "mainEntity": {
+              "@type" : "Identity",
+              "identifiedBy": [
+                {
+                  "@type": "ISNI",
+                  "value":  "0000 0000 0000 0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "revert oldschool ISNI (Identifier with typeNote), TODO: fix ind1=8",
           "normalized": {
             "024": {"ind1": "8", "ind2": " ", "subfields": [{"a": "0000 0000 0000 0000"}, {"2": "isni"}]}
           },

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -21798,7 +21798,7 @@
       "include": ["identifier"],
       "match": [
         {
-          "when": "i1=7 & $2 =~ isni|ISNI|orcid|ORCID",
+          "when": "i1=7 & $2 =~ isni|ISNI|orcid|ORCID|viaf|VIAF|wikidata|WIKIDATA",
           "i1": null,
           "$2": {
             "property": "@type",
@@ -21807,7 +21807,11 @@
               "ISNI": "ISNI",
               "isni": "ISNI",
               "ORCID": "ORCID",
-              "orcid": "ORCID"
+              "orcid": "ORCID",
+              "VIAF": "VIAF",
+              "viaf": "VIAF",
+              "WIKIDATA": "WikidataID",
+              "wikidata": "WikidataID"
             }
           }
         }

--- a/whelktool/scripts/cleanups/2021/05/lxl-586-typeNote-vs-type.groovy
+++ b/whelktool/scripts/cleanups/2021/05/lxl-586-typeNote-vs-type.groovy
@@ -1,0 +1,31 @@
+import whelk.Document
+
+def OBSOLETE_TYPE_NOTES = ['isni', 'orcid', 'viaf', 'wikidata']
+
+selectByCollection('auth') { auth ->
+    def (_record, thing) = auth.graph
+    
+    boolean needsUpdate = false
+    thing.identifiedBy?.with {
+        asList(it).forEach { Map id ->
+            id.typeNote?.with { String tn ->
+                if (OBSOLETE_TYPE_NOTES.contains(tn)) {
+                    needsUpdate = true
+                }
+            }
+            asList(it).findAll { Document.&isIsni || Document.&isOrcid }.forEach { Map isni ->
+                if (((String) isni.value)?.contains(' ')) {
+                    needsUpdate = true
+                }
+            }
+        }
+    }
+
+    if (needsUpdate) {
+        auth.scheduleSave()
+    }
+}
+
+List asList(Object o) {
+    return o in List ? o : [o]
+}


### PR DESCRIPTION
* Fix MARC conversion of ISNI/ORCID/VIAF/WikidataID
* Map to `@type` instead of `@type`: Identifier with typeNote for these identifiers
* Add a document normalizer that replaces all obsolete typeNotes (e.g. cataloging according to old practise)
* Add a script for converting existing auth records