### PR TITLE
Avoid null values in lddbToTrig; clean up IRIs in JsonLdToTurtle

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -186,6 +186,7 @@ class ImporterMain {
                 filterProblematicData(data[property])
             }
         } else if (data instanceof List) {
+            data.removeAll([null])
             data.each {
                 filterProblematicData(it)
             }

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -159,7 +159,7 @@ class ImporterMain {
                     System.err.println("$i records dumped.")
                 }
                 ++i
-                filterProblematicData(doc.data)
+                filterProblematicData(id, doc.data)
                 try {
                     serializer.objectToTrig(id, doc.data)
                 } catch (Throwable e) {
@@ -177,18 +177,20 @@ class ImporterMain {
         whelk.storage.queueSparqlUpdatesFrom(fromUnixTime)
     }
 
-    private static void filterProblematicData(data) {
+    private static void filterProblematicData(id, data) {
         if (data instanceof Map) {
             data.removeAll { entry ->
                 return entry.key.startsWith("generic") || entry.key.equals("marc:hasGovernmentDocumentClassificationNumber")
             }
             data.keySet().each { property ->
-                filterProblematicData(data[property])
+                filterProblematicData(id, data[property])
             }
         } else if (data instanceof List) {
-            data.removeAll([null])
+            if (data.removeAll([null])) {
+                log.warn("Removing null value from ${id}")
+            }
             data.each {
-                filterProblematicData(it)
+                filterProblematicData(id, it)
             }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
@@ -4,6 +4,9 @@ import static org.apache.commons.lang3.StringEscapeUtils.escapeJava
 
 import org.codehaus.jackson.map.ObjectMapper
 
+import groovy.util.logging.Log4j2 as Log
+
+@Log
 class JsonLdToTurtle {
 
     def INDENT = "  "
@@ -105,9 +108,7 @@ class JsonLdToTurtle {
         } else if (useVocab && ref.indexOf("/") == -1) {
             return ":" + ref
         }
-        ref = cleanValue(ref).
-            replaceAll(/ /, '+').
-            replaceAll("\\\\", "\\\\\\\\")
+        ref = cleanIri(cleanValue(ref).replaceAll(/ /, '+'))
         return "<${ref}>"
     }
 
@@ -120,6 +121,16 @@ class JsonLdToTurtle {
         return term.
             replaceAll(/%/, /0/).
             replaceAll(/\./, '')
+    }
+
+    // [8] IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+    // https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
+    String cleanIri(String iri) {
+        String cleanedIri = iri.replaceAll(/[\x00-\x20<>"{}|^`\\]/, '')
+        if (cleanedIri != iri) {
+            log.warn("Broken IRI ${iri}, changing to ${cleanedIri}")
+        }
+        return cleanedIri
     }
 
     String cleanValue(String v) {


### PR DESCRIPTION
vcopyImporter's `lddbToTrig` can produce invalid triples due to bad data. We should obviously fix these broken records (some are even hardcoded in `trigExcludeList` at the moment); however, we might also want to use the output of `lddbToTrig` as input to [Apache Jena](https://jena.apache.org/). Apache Jena's behavior is to completely stop processing when an invalid triple is encountered -- skipping is not an option (some discussion [here](https://users.jena.apache.narkive.com/srym8jU4/getting-rid-of-triples-with-bad-uris)).

Loading/updating SPARQL data is something that should be done routinely and that preferably shouldn't involve manual "fix data - restart import" interventions every now and then, à la sisyphean whack-a-mole, so I think we should make some effort to avoid outputting completely invalid things.

I've been trying to import the entire lddb-as-trig dataset into Jena, but encountered some errors. Some records have `null` values that make it through the converter and end up in the TriG version (e.g. [4nggh9tg3l3kgbp](https://libris.kb.se/4nggh9tg3l3kgbp#it), [q26xxwhfn63n4jkd](https://libris.kb.se/q26xxwhfn63n4jkd#it)), some have IRIs with [illegal](https://www.w3.org/TR/turtle/#grammar-production-IRIREF) characters (e.g. [x67fk77lvckfnf4z](https://libris.kb.se/x67fk77lvckfnf4z#it), [r128d23zpmxvb662](https://libris.kb.se/r128d23zpmxvb662#it) -- `https://id.kb.se/marc/GovernmentPublicationType-\\`).

This small change just removes the problem-causing nulls when using `lddbToTrig` and removes illegal characters from IRI references (while logging a warning) in `JsonLdToTurtle`. There might be more things to fix, we'll see.