### PR TITLE
Add --skip-index flag to datasetimporter

### DIFF
--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -3,7 +3,6 @@ package whelk.importer
 import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
-import whelk.IdGenerator
 import whelk.Whelk
 import whelk.exception.CancelUpdateException
 

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -38,16 +38,15 @@ class ImporterMain {
 
     @Command(args='FNAME DATASET [--skipIndex]')
     void dataset(String fname, String dataset, String skipIndexParam=null) {
-        Whelk whelk = Whelk.createLoadedSearchWhelk(props)
-        if (skipIndexParam) {
-            if (skipIndexParam == '--skipIndex') {
-                whelk.setSkipIndex(true)
-            }
-            else {
-                throw new IllegalArgumentException("Third argument must be --skipIndex or nothing")
-            }
+        if (fname == '--skipIndex' || dataset == '--skipIndex' || (skipIndexParam && skipIndexParam != '--skipIndex')) {
+            throw new IllegalArgumentException("--skipIndex must be last argument")
         }
         
+        Whelk whelk = Whelk.createLoadedSearchWhelk(props)
+        if (skipIndexParam == '--skipIndex') {
+            whelk.setSkipIndex(true)
+        }
+                
         DatasetImporter.importDataset(whelk, fname, dataset)
     }
 

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -36,14 +36,14 @@ class ImporterMain {
         defsImporter.run("definitions")
     }
 
-    @Command(args='FNAME DATASET [--skipIndex]')
+    @Command(args='FNAME DATASET [--skip-index]')
     void dataset(String fname, String dataset, String skipIndexParam=null) {
-        if (fname == '--skipIndex' || dataset == '--skipIndex' || (skipIndexParam && skipIndexParam != '--skipIndex')) {
-            throw new IllegalArgumentException("--skipIndex must be third argument")
+        if (fname == '--skip-index' || dataset == '--skip-index' || (skipIndexParam && skipIndexParam != '--skip-index')) {
+            throw new IllegalArgumentException("--skip-index must be third argument")
         }
         
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)
-        if (skipIndexParam == '--skipIndex') {
+        if (skipIndexParam == '--skip-index') {
             whelk.setSkipIndex(true)
         }
                 

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -39,7 +39,7 @@ class ImporterMain {
     @Command(args='FNAME DATASET [--skipIndex]')
     void dataset(String fname, String dataset, String skipIndexParam=null) {
         if (fname == '--skipIndex' || dataset == '--skipIndex' || (skipIndexParam && skipIndexParam != '--skipIndex')) {
-            throw new IllegalArgumentException("--skipIndex must be last argument")
+            throw new IllegalArgumentException("--skipIndex must be third argument")
         }
         
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -36,9 +36,18 @@ class ImporterMain {
         defsImporter.run("definitions")
     }
 
-    @Command(args='FNAME DATASET')
-    void dataset(String fname, String dataset) {
+    @Command(args='FNAME DATASET [--skipIndex]')
+    void dataset(String fname, String dataset, String skipIndexParam=null) {
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)
+        if (skipIndexParam) {
+            if (skipIndexParam == '--skipIndex') {
+                whelk.setSkipIndex(true)
+            }
+            else {
+                throw new IllegalArgumentException("Third argument must be --skipIndex or nothing")
+            }
+        }
+        
         DatasetImporter.importDataset(whelk, fname, dataset)
     }
 

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -85,6 +85,7 @@ class WhelkTool {
         } catch (NullPointerException e) {
             whelk = Whelk.createLoadedCoreWhelk()
         }
+        whelk.setSkipIndex(skipIndex)
         initScript(scriptPath)
         this.reportsDir = reportsDir
         reportsDir.mkdirs()
@@ -499,7 +500,7 @@ class WhelkTool {
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
-            whelk.storeAtomicUpdate(doc, !item.loud, changedIn, scriptJobUri, item.preUpdateChecksum, !skipIndex)
+            whelk.storeAtomicUpdate(doc, !item.loud, changedIn, scriptJobUri, item.preUpdateChecksum)
         }
         modifiedLog.println(doc.shortId)
     }
@@ -511,7 +512,7 @@ class WhelkTool {
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
             if (!whelk.createDocument(doc, changedIn, scriptJobUri,
-                    LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld()), false, !skipIndex))
+                    LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld()), false))
                 throw new WhelkException("Failed to save a new document. See general whelk log for details.")
         }
         createdLog.println(doc.shortId)


### PR DESCRIPTION
- Add --skip-index flag to datasetimporter
- Make skipIndex a property in Whelk instead since we never use it on a per-request basis
- Also check skipIndex in `removeDocument`