### PR TITLE
Check for resulting duplicate holds when modifying holds, not only wh…

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -854,6 +854,8 @@ class PostgreSQLComponent {
             String oldChangedBy = resultSet.getString("changedBy")
             if (changedBy == null)
                 changedBy = oldChangedBy
+
+            normalizeDocumentForStorage(doc, connection)
             
             if (collection == "hold") {
                 checkLinkedShelfMarkOwnership(doc, connection)
@@ -877,12 +879,6 @@ class PostgreSQLComponent {
 
                 if (getHoldingForBibAndSigel(holdingFor, doc.getHeldBy(), connection) != null)
                     throw new ConflictingHoldException("Already exists a holding record for ${doc.getHeldBy()} and bib: $holdingFor")
-            }
-
-            normalizeDocumentForStorage(doc, connection)
-
-            if (collection == "hold") {
-                checkLinkedShelfMarkOwnership(doc, connection)
             }
 
             if (doVerifyDocumentIdRetention) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -854,6 +854,30 @@ class PostgreSQLComponent {
             String oldChangedBy = resultSet.getString("changedBy")
             if (changedBy == null)
                 changedBy = oldChangedBy
+            
+            if (collection == "hold") {
+                checkLinkedShelfMarkOwnership(doc, connection)
+                String holdingFor = doc.getHoldingFor()
+                if (holdingFor == null) {
+                    log.warn("Was asked to save a holding record linked to a bib record that could not be located: " + doc.getHoldingFor() + " (so, did nothing).")
+                    return null
+                }
+                String holdingForRecordId = getRecordId(holdingFor, connection)
+                if (holdingForRecordId == null) {
+                    log.warn("Was asked to save a holding record linked to a bib record that could not be located: " + doc.getHoldingFor() + " (so, did nothing).")
+                    return null
+                }
+                String holdingForSystemId = holdingForRecordId.substring(Document.BASE_URI.toString().length())
+                if (holdingForSystemId == null) {
+                    log.warn("Was asked to save a holding record linked to a bib record that could not be located: " + doc.getHoldingFor() + " (so, did nothing).")
+                    return null
+                }
+
+                acquireRowLock(holdingForSystemId, connection)
+
+                if (getHoldingForBibAndSigel(holdingFor, doc.getHeldBy(), connection) != null)
+                    throw new ConflictingHoldException("Already exists a holding record for ${doc.getHeldBy()} and bib: $holdingFor")
+            }
 
             normalizeDocumentForStorage(doc, connection)
 


### PR DESCRIPTION
…en creating them.