### PR TITLE
Don't update changedBy on minor (silent) updates

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -852,7 +852,7 @@ class PostgreSQLComponent {
 
             String collection = resultSet.getString("collection")
             String oldChangedBy = resultSet.getString("changedBy")
-            if (changedBy == null)
+            if (changedBy == null || minorUpdate)
                 changedBy = oldChangedBy
 
             normalizeDocumentForStorage(doc, connection)


### PR DESCRIPTION
Assumes `changedBy` should _never_ be updated if it's a minor update (so affects more than just whelktool).