### PR TITLE
Search: make it possible to have separate card definition for indexing

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -95,7 +95,7 @@ class SearchUtils {
             case 'full':
                 return removeSystemInternalProperties(framedThing)
             default:
-                return ld.toCard(framedThing, false, false, false , preservedPaths)
+                return ld.toCard(framedThing, false, false, false , preservedPaths, true)
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -907,8 +907,7 @@ class JsonLd {
     private Map getLens(Map thing, List<String> lensTypes) {
         Map lensGroups = displayData.get('lensGroups')
         lensTypes.findResult { lensType ->
-            Map lensGroup = lensGroups.get(lensType)
-            getLensFor(thing, lensGroup)
+            lensGroups.get(lensType)?.with { getLensFor(thing, (Map) it) }
         }
     }
     

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -672,7 +672,7 @@ class JsonLd {
     }
 
     Map toCard(Map thing, boolean chipsify = true, boolean addSearchKey = false,
-            boolean reduceKey = false, List<List> preservePaths = [], boolean searchCard = true) {
+            boolean reduceKey = false, List<List> preservePaths = [], boolean searchCard = false) {
         Map result = [:]
 
         Map card = removeProperties(thing, getLens(thing, searchCard ? ['search-cards', 'cards'] : ['cards']))

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -672,14 +672,14 @@ class JsonLd {
     }
 
     Map toCard(Map thing, boolean chipsify = true, boolean addSearchKey = false,
-            boolean reduceKey = false, List<List> preservePaths = []) {
+            boolean reduceKey = false, List<List> preservePaths = [], boolean searchCard = true) {
         Map result = [:]
 
-        Map card = removeProperties(thing, 'cards')
+        Map card = removeProperties(thing, getLens(thing, searchCard ? ['search-cards', 'cards'] : ['cards']))
         // If result is too small, use chip instead.
         // TODO: Support and use extends + super in card defs instead.)
         if (card.size() < 2) {
-            card = removeProperties(thing, 'chips')
+            card = removeProperties(thing, getLens(thing, ['chips']))
         }
 
         restorePreserved(card, thing, preservePaths)
@@ -694,11 +694,11 @@ class JsonLd {
                 if (value instanceof List) {
                     lensValue = ((List) value).withIndex().collect { it, index ->
                         it instanceof Map
-                        ? toCard((Map) it, chipsify, addSearchKey, reduceKey, pathRemainders([key, index], preservePaths))
+                        ? toCard((Map) it, chipsify, addSearchKey, reduceKey, pathRemainders([key, index], preservePaths), searchCard)
                         : it
                     }
                 } else if (value instanceof Map) {
-                    lensValue = toCard((Map) value, chipsify, addSearchKey, reduceKey, pathRemainders([key], preservePaths))
+                    lensValue = toCard((Map) value, chipsify, addSearchKey, reduceKey, pathRemainders([key], preservePaths), searchCard)
                 }
             }
             result[key] = lensValue
@@ -733,7 +733,7 @@ class JsonLd {
             }
         } else if ((object instanceof Map)) {
             Map result = [:]
-            Map reduced = removeProperties(object, 'chips')
+            Map reduced = removeProperties(object, getLens(object, ['chips']))
             restorePreserved(reduced, (Map) object, preservePaths)
             reduced.each { key, value ->
                 result[key] = toChip(value, pathRemainders([key], preservePaths))
@@ -904,11 +904,15 @@ class JsonLd {
                 .collect{ it.drop(prefix.size()) }
     }
 
-    private Map removeProperties(Map thing, String lensType) {
+    private Map getLens(Map thing, List<String> lensTypes) {
         Map lensGroups = displayData.get('lensGroups')
-        Map lensGroup = lensGroups.get(lensType)
-        Map lens = getLensFor(thing, lensGroup)
-
+        lensTypes.findResult { lensType ->
+            Map lensGroup = lensGroups.get(lensType)
+            getLensFor(thing, lensGroup)
+        }
+    }
+    
+    private Map removeProperties(Map thing, Map lens) {
         Map result = [:]
         if (lens) {
             List propertiesToKeep = (List) lens.get("showProperties")

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -325,8 +325,9 @@ class ElasticSearch {
         boolean addSearchKey = true
         boolean reduceKey = false
         def preservedPaths = preserveLinks ? JsonLd.findPaths(thing, '@id', preserveLinks) : []
-
-        whelk.jsonld.toCard(thing, chipsify, addSearchKey, reduceKey, preservedPaths)
+        boolean searchCard = true
+        
+        whelk.jsonld.toCard(thing, chipsify, addSearchKey, reduceKey, preservedPaths, searchCard)
     }
 
     private static Map getShapeForEmbellishment(Whelk whelk, Map thing) {


### PR DESCRIPTION
Currently the same card definitions is used for display and for shaping documents for indexing.
Sometimes we want to index properties but not display them.

Make it possible to override card definitions for indexing with the new lens group `search-cards`.

See https://github.com/libris/definitions/pull/295