### PR TITLE
Add IF NOT EXISTS to CREATE INDEX idx_lddb_generation_date

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000018-index-generationDate.plsql
+++ b/librisxl-tools/postgresql/migrations/00000018-index-generationDate.plsql
@@ -28,7 +28,7 @@ BEGIN
    'SELECT $1::timestamptz'
    LANGUAGE sql IMMUTABLE;
 
-   CREATE INDEX idx_lddb_generation_date ON lddb (totstz(data#>>'{@graph,0,generationDate}'));
+   CREATE INDEX IF NOT EXISTS idx_lddb_generation_date ON lddb (totstz(data#>>'{@graph,0,generationDate}'));
    
 END$$;
 


### PR DESCRIPTION
So that we can create it manually before the release to save some time.

Need to hotfix some documentation anyway.