### PR TITLE
Add documentation for or- in search-API

### DIFF
--- a/rest/API.md
+++ b/rest/API.md
@@ -184,17 +184,28 @@ means `OR`, `*` is used for prefix queries, `""` matches the whole phrase, and
 * `_offset` - Number of hits to skip in the result, used for pagination.
   Default is 0.
 
-Records can be filtered on field values. Multiple fields means `AND`. Multiple values
-for the same field means `OR`. Specifying multiple values for the same field can be done
-by repeating the parameter or by giving a comma-separated list as value.
+Records can be filtered on field values. Specifying multiple values for the same field can be done
+by repeating the parameter or by giving a comma-separated list as value. Specifying multiple fields 
+means `AND`. Multiple values for the same field means `OR`. It is possible to combine multiple fields 
+with `OR` by using the prefix `or-`.
 
-* `<field>` - The record has exactly this value for `field`.  
+* `<field>` - The record has this value for `field`.
+* `or-<field>` - Combine filters for multiple fields with `OR` instead of `AND`.
 * `exists-<field>` - The field exists in the record. Value should be `true` or `false`.
 * `min-<field>` - Greater or equal to.
 * `minEx-<field>` - Greater than (exclusive minimum).
 * `max-<field>` - Less or equal to.
 * `maxEx-<field>` - Less than.
 * `matches-<field>` - Value is matching (see date-search below).
+
+Filter-expression                                     | Filter-parameters
+------------------------------------------------------|----------------------------------------------
+a is x `OR` a is y...                                 | `a=x&a=y...`
+a is x `AND` a is y                                   | Not possible.
+a is x `AND` b is y `AND` c is z...                   | `a=x&b=y&c=z...`
+a is x `OR` b is y...                                 | `or-a=x&or-b=y...`
+(a is x `OR` b is y) `AND` c is z...                  | `or-a=x&or-b=y&c=z...`
+(a is x `OR` b is y) `AND` (c is z `OR` d is q)       | Not possible. Can only specify one group with `or-`.
 
 For fields of type date (`meta.created`, `meta.modified` and `meta.generationDate`)
 the following formats can be used for value:

--- a/rest/API_sv.md
+++ b/rest/API_sv.md
@@ -189,16 +189,28 @@ innebär `ELLER`, `*` används för prefixsökningar, `""` matchar hela frasen o
 * `_offset` - Antal träffar att hoppa över i resultatet, används för
   paginering. Standardvärdet är 0.
   
-Sökningen kan filtreras på värdet på egenskaper i posten. Om flera egenskaper anges innebär det `OCH`.
-Om samma egenskap anges flera gånger innebär det `ELLER`. Samma egenskap kan anges flera gånger genom 
-att uppprepa parametern eller genom att komma-separera värdena.
-* `<egenskap>` - Egenskapen har exakt värdet.
+Sökningen kan filtreras på värdet på egenskaper i posten. Samma egenskap kan anges flera gånger genom
+att upprepa parametern eller genom att komma-separera värdena. Om olika egenskaper anges innebär det 
+`OCH`. Om samma egenskap anges flera gånger innebär det `ELLER`. Det går att kombinera olika egenskaper 
+med `ELLER` genom att använda prefixet `or-`.
+
+* `<egenskap>` - Egenskapen har värdet.
+* `or-<egenskap>` - Kombinera filter för olika egenskaper med `ELLER` istället för `OCH`.
 * `exists-<egenskap>` - Egenskapen existerar. Ange ett booleskt värde, d.v.s. `true` eller `false`.
 * `min-<egenskap>` - Värdet är större eller lika med.
 * `minEx-<egenskap>` - Värdet är större än (Ex står för "Exclusive").
 * `max-<egenskap>` - Värdet är mindre eller lika med.
 * `maxEx-<egenskap>` - Värdet är mindre än.
 * `matches-<egenskap>` - Värdet matchar (se datum-sökning nedan).
+
+ Filter-uttryck                                        | Filter-parametrar    
+-------------------------------------------------------|-----------------------                 
+ a är x `ELLER` a är y...                              | `a=x&a=y...`
+ a är x `OCH` a är y                                   | Inte möjligt.
+ a är x `OCH` b är y `OCH` c är z...                   | `a=x&b=y&c=z...`
+ a är x `ELLER` b är y...                              | `or-a=x&or-b=y...`          
+ (a är x `ELLER` b är y) `OCH` c är z...               | `or-a=x&or-b=y&c=z...`  
+ (a är x `ELLER` b är y) `OCH` (c är z `ELLER` d är q) | Inte möjligt. Kan bara ange en grupp med `or-`.                    
 
 För egenskaper som är av typen datum (`meta.created`, `meta.modified` och `meta.generationDate`)
 kan värdet anges på följande format:


### PR DESCRIPTION
Add documentation for `or-` in search-API. Started with Swedish version for review. Will translate if OK.
Not super happy about this. Can it be made more clear?