### PR TITLE
Remove extra whitespace from 001/003 when creating 035$a

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/LegacyIntegrationTools.groovy
@@ -129,7 +129,7 @@ class LegacyIntegrationTools {
                 != null && field003.getData() != null && field003.getData()
                 != "SE-LIBR" && field003.getData() != "LIBRIS") {
 
-            String idInOtherSystem = "(" + field003.getData() + ")" + field001.getData()
+            String idInOtherSystem = "(" + field003.getData().trim() + ")" + field001.getData().trim()
 
             boolean hasRelevant035aAlready = false
             record.getDatafields("035").each { f ->


### PR DESCRIPTION
OCLC sometimes deliver records where 001 carries an extra
space character at the end. XLs code did not expect this and
as a result created extra (double) 035$a-fields.

This commit trims values from 001/003 before using them to
construct (and double check) 035$a.