### PR TITLE
Add a safety margin to export time intervals.

### DIFF
--- a/marc_export/marc-export-documentation.md
+++ b/marc_export/marc-export-documentation.md
@@ -16,12 +16,15 @@ Dessa parametrar är:
    1. `append` som innebär att borttagna posters ID:n exporteras som en CSV-fil _efter_ den vanliga exportdatan (separerat av en null-byte).
 1. `virtualDelete` som kan ha värde `true` eller `false`. Är `virtualDelete` satt till `true` så kommer poster anses vara borttagna i den genererade exporten, i de fall där de sigel som anges i `locations` i profilen inte längre har bestånd på posterna. Flaggan används förslagsvis tillsammans med `deleted=export`.
 
-Exempel på anrop:
+## Exempel på anrop
 ```
 $ curl -Ss -XPOST "https://libris.kb.se/api/marc_export/?from=2019-10-05T22:00:00Z&until=2019-10-06T22:00:00Z&deleted=ignore&virtualDelete=false" --data-binary @./etc/export.properties > export.marc
 ```
 
+## Var noga med tiden!
+
 SE UPP med era tidsangivelser/tidszoner! Exemplet ovan skickar in tider i UTC (därav 'Z' på slutet). Det är ett bra sätt att göra det på. Vill man skicka in lokala tider istället för UTC så går det också, men då måste tidszonen ingå i angivelsen. Vänligen läs på om ISO-8601!
+Se till att maskinen som anropar detta API använder sig av NTP, så att maskinens klocka går rätt. Om detta inte görs finns risken att man missar uppdateringar av poster. För att gardera sig emot eventuella avrundningsfel/trunkeringsfel vid tidsangivelser så drar servern också alltid bort en sekund ifrån värdet på `from`. Detta kan vara förvirrande om man försöker använda APIet för statistik-syften eller liknande.
 
 Vill man anropa detta API med ett schemalagt skript så finns exempel/förslag på sådana skript här för:
 [Windows](https://github.com/libris/librisxl/blob/master/marc_export/examplescripts/export_windows.bat)
@@ -29,7 +32,8 @@ och
 [*nix-derivat (bash)](https://github.com/libris/librisxl/blob/master/marc_export/examplescripts/export_nix.sh)
 
 
-Exempel på exportprofil:
+## Exempel på exportprofil
+
 ```
 move240to244=off
 f003=SE-LIBR

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -85,6 +86,11 @@ public class ProfileExport
 
         ZonedDateTime zonedFrom = ZonedDateTime.parse(from);
         ZonedDateTime zonedUntil = ZonedDateTime.parse(until);
+
+        // To account for small diffs in between client and server clocks, always add an extra second
+        // at the low end of time intervals!
+        zonedFrom = zonedFrom.minus(1, ChronoUnit.SECONDS);
+
         Timestamp fromTimeStamp = new Timestamp(zonedFrom.toInstant().getEpochSecond() * 1000L);
         Timestamp untilTimeStamp = new Timestamp(zonedUntil.toInstant().getEpochSecond() * 1000L);
 


### PR DESCRIPTION
Without this, the only safety margin is the network transport
time, which can be very small. The consequence is that a client
could miss being told of records that have changed.

Clients should always use NTP, but even then one second diffs
could easily occur, due to rounding.