### PR TITLE
marc2bfConversionUpdate3xx-v1.6

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -11285,9 +11285,9 @@
       },
       "$a": {"about": "_:frequency", "property": "label"},
       "$b": {"about": "_:frequency", "property": "date"},
-      "$0": {"property": "marc:recordControlNumber"},
+      "$0": {"about": "_:frequency", "property": "marc:recordControlNumber"},
       "$1": null,
-      "$2": {"link": "source", "resourceType": "Source", "property": "code", "supplementary": true},
+      "$2": {"about": "_:frequency", "link": "source", "resourceType": "Source", "property": "code", "supplementary": true},
       "$6": {"ignored": true, "NOTE:LC": "ignore (v1.6)"},
       "_spec": [
         {

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -11179,7 +11179,7 @@
         }
       },
       "$a": {"aboutNew": "_:durationPart", "property": "value"},
-      "$6": {"about": "_:durationPart", "property": "marc:fieldref"},
+      "$6": {"ignored": true, "NOTE:LC": "ignore (v.1.6)"},
       "_spec": [
         {
           "Name": "Simple duration value",

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -11113,7 +11113,7 @@
         "about": "_:extent",
         "property": "marc:sizeOfUnit"
       },
-      "$6": {"about": "_:extent", "property": "marc:fieldref"},
+      "$6": {"ignored": true, "NOTE:LC": "ignore (v1.6)"},
       "$8": {"about": "_:extent", "property": "marc:groupid"},
       "_spec": [
         {
@@ -11179,7 +11179,7 @@
         }
       },
       "$a": {"aboutNew": "_:durationPart", "property": "value"},
-      "$6": {"ignored": true, "NOTE:LC": "ignore (v.1.6)"},
+      "$6": {"ignored": true, "NOTE:LC": "ignore (v1.6)"},
       "_spec": [
         {
           "Name": "Simple duration value",
@@ -11248,7 +11248,10 @@
       "NOTE:marc-repeatable": false,
       "$a": {"property": "label"},
       "$b": {"property": "date"},
-      "$6": {"property": "marc:fieldref", "supplementary": true},
+      "$0": {"property": "marc:recordControlNumber"},
+      "$1": null,
+      "$2": {"link": "source", "resourceType": "Source", "property": "code", "supplementary": true},
+      "$6": {"ignored": true, "NOTE:LC": "ignore (v1.6)"},
       "_spec": [
         {
           "source": [
@@ -11282,7 +11285,10 @@
       },
       "$a": {"about": "_:frequency", "property": "label"},
       "$b": {"about": "_:frequency", "property": "date"},
-      "$6": {"about": "_:frequency", "property": "marc:fieldref", "supplementary": true},
+      "$0": {"property": "marc:recordControlNumber"},
+      "$1": null,
+      "$2": {"link": "source", "resourceType": "Source", "property": "code", "supplementary": true},
+      "$6": {"ignored": true, "NOTE:LC": "ignore (v1.6)"},
       "_spec": [
         {
           "source": [


### PR DESCRIPTION
**Description**

Align with LC marc2Bibframe2 conversion v1.6

- 300: Ignore $6 (Small occurence in "extent", but this needs further analyzing because they could be wrong. All $6 was added to extent in conversion even though other properties are possible, like hasDimensions, hasNote etc.).
- 306: Ignore $6 (No occurence in "duration").
- 310: Add $0 (controlNumber), $2 (source), Ignore $6  (No occurence in "frequency").
- 321: Add $0 (controlNumber), $2 (source), Ignore $6 (No occurence in "replaces").