### PR TITLE
Add support for ES autocompletion/suggestions and source filtering

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -238,6 +238,10 @@
                     "keyword": {
                         "type": "icu_collation_keyword",
                         "language": "sv"
+                    },
+                    "suggest": {
+                        "type": "search_as_you_type",
+                        "analyzer": "softmatcher"
                     }
                 },
                 "copy_to": "_all"

--- a/rest/API.md
+++ b/rest/API.md
@@ -183,6 +183,8 @@ means `OR`, `*` is used for prefix queries, `""` matches the whole phrase, and
   Default is 200.
 * `_offset` - Number of hits to skip in the result, used for pagination.
   Default is 0.
+* `_fieldsToInclude` - Only include the specified fields (comma-delimited) in the results.
+  If not set, all fields are returned.
 
 Records can be filtered on field values. Specifying multiple values for the same field can be done
 by repeating the parameter or by giving a comma-separated list as value. Specifying multiple fields 
@@ -285,6 +287,16 @@ Containing 'Aniara' and held by sigel APP1.
 ```
 $ curl -XGET -H "Accept: application/ld+json" \
     'https://libris-qa.kb.se/find.jsonld?q=Aniara&@reverse.itemOf.heldBy.@id=https://libris.kb.se/library/APP1'
+...
+```
+
+#### Example
+
+Instances containing 'Jansson'. Only the fields `hasTitle` and `identifiedBy`
+are included in each returned item.
+```
+$ curl -XGET -H "Accept: application/ld+json" \
+    'https://libris-qa.kb.se/find.jsonld?q=Jansson&@type=Instance&_fieldsToInclude=hasTitle,identifiedBy'
 ...
 ```
 

--- a/rest/API_sv.md
+++ b/rest/API_sv.md
@@ -188,6 +188,8 @@ innebär `ELLER`, `*` används för prefixsökningar, `""` matchar hela frasen o
   paginering. Standardvärdet är 200.
 * `_offset` - Antal träffar att hoppa över i resultatet, används för
   paginering. Standardvärdet är 0.
+* `_fieldsToInclude` - Inkludera enbart angivna fält (kommaseparerade) i  resultatet.
+  Om ej angivet returneras alla fält.
   
 Sökningen kan filtreras på värdet på egenskaper i posten. Samma egenskap kan anges flera gånger genom
 att upprepa parametern eller genom att komma-separera värdena. Om olika egenskaper anges innebär det 
@@ -289,6 +291,16 @@ Innehåller 'Aniara' och har ett bestånd med sigel APP1.
 ```
 $ curl -XGET -H "Accept: application/ld+json" \
     'https://libris-qa.kb.se/find.jsonld?q=Aniara&@reverse.itemOf.heldBy.@id=https://libris.kb.se/library/APP1'
+...
+```
+
+#### Exempel
+
+Instanser som innehåller 'Jansson'. Endast fälten  `hasTitle` och `identifiedBy`
+inkluderas i resultatet för varje post.
+```
+$ curl -XGET -H "Accept: application/ld+json" \
+    'https://libris-qa.kb.se/find.jsonld?q=Jansson&@type=Instance&_fieldsToInclude=hasTitle,identifiedBy'
 ...
 ```
 

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -201,6 +201,29 @@ class ESQuerySpec extends Specification {
         es.getKeywordFields(nestedMappings) == nestedResult
     }
 
+    def "should get suggest field"() {
+        expect:
+        es.getSuggestField(params) == result
+        where:
+        params                  | result
+        [:]                     | null
+        ['_suggest': []]        | null
+        ['_suggest': ['']]      | null
+        ['_suggest': ['foo']]   | 'foo'
+    }
+
+    def "should get fields to include fields"(Map<String, String[]> params, List result) {
+        expect:
+        es.getFieldsToInclude(params) == result
+        where:
+        params                               | result
+        [:]                                  | null
+        ['_fieldsToInclude': []]             | null
+        ['_fieldsToInclude': ['']]           | null
+        ['_fieldsToInclude': ['foo']]        | ['foo']
+        ['_fieldsToInclude': ['foo,bar']]    | ['foo', 'bar']
+    }
+
     def "should expand @type param"() {
         when:
         Map context = [:]


### PR DESCRIPTION
We want to provide search suggestions a.k.a. autocompletion a.k.a. search-as-you-type when people search on id.kb.se. This needs to be reasonably fast with low overhead since each keystroke triggers a new search. It needs to feel instant(-ish) to the user.

There are a few ways to do this with Elasticsearch, the most obvious ones being the [suggest](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html) feature's [completion suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#completion-suggester) and the [`search_as_you_type`](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-as-you-type.html) field type. The completion suggester should be the fastest, but it's limited - we can't use filters, for example. And in this case we just want autocompletion on a small subset of the index. The [context suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#context-suggester) can help with this, but would be pretty messy for our purposes.

So, after experimenting, I found that the `search_as_you_type` field used with a [`match_phrase_prefix`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html) query seemed to give the most decent results in the least hackish way. I added a field called `suggest` to `prefLabel` in `libris_config.json`, so the index needs to be recreated.

A new query parameter, `_suggest`, is added. The value should be the field on which suggestion/autocompletion should be performed. If specified, a `match_phrase_prefix` query is performed on the specified field, and no boosting is done. Example:

```
curl -XGET -H "Accept: application/ld+json" \
      'http://kblocalhost.kb.se:5000/find.jsonld?q=musik&_limit=10&inScheme.@id=https://id.kb.se/term/sao&_suggest=prefLabel.suggest'
```

Additionally, to reduce network overhead, a `_fieldsToInclude` parameter is added. It takes a comma-separated list of fields. By default ES returns the entire JSON document that was indexed, but if `_fieldsToInclude` is specified then [source filtering](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering) is used to only retrieve the selected fields.

The query above resulted in 67662 bytes of JSON when I tested locally. But for autocompletion we're only interested in a few fields - perhaps just `@id`, `prefLabel` and `inScheme.titleByLang`. So let's get only those fields:

```
curl -XGET -H "Accept: application/ld+json" \
      'http://kblocalhost.kb.se:5000/find.jsonld?q=musik&_limit=10&inScheme.@id=https://id.kb.se/term/sao&_suggest=prefLabel.suggest&_fieldsToInclude=@id,prefLabel,inScheme.titleByLang'
```

Now it's just 8955 bytes of JSON, or about 87% smaller. Still, 2/3 of that is taken up by the `stats` and `search` objects that we don't need for autocompletion, so we can do better (but that requires adding a few special cases which might or might not be worth it).

(`_fieldsToInclude` might also be useful in other situations where we are only interested in a few specific fields.)