### PR TITLE
Support chunked/split file output in lddbToTrig

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
@@ -35,6 +35,10 @@ class JsonLdToTurtle {
         this.useGraphKeyword = opts?.useGraphKeyword == true
         this.markEmptyBnode = opts?.markEmptyBnode == true
         if ('owl' in prefixes) emptyMarker = 'owl:Nothing'
+        this.setOutputStream(outStream)
+    }
+
+    void setOutputStream(OutputStream outStream) {
         writer = new OutputStreamWriter(outStream, "UTF-8")
     }
 


### PR DESCRIPTION
We've had problems bulk loading RDF data into Virtuoso. The uncompressed output of vcopyImporter's `lddbToTrig` is 90+ GB. Looking through the OpenLink docs/forums I read "On a multi-core machine, it is recommended that data sets be split into multiple files" [[source](http://vos.openlinksw.com/owiki/wiki/VOS/VirtBulkRDFLoader)] and "Generally it is recommended that large files be split into multiple smaller files of about 1 to 2 GB in size" [[source](https://community.openlinksw.com/t/memory-consumption-when-loading-large-triple-files/351/2)].

Splitting a 90+ GB TriG file is _very_ time-consuming and doing so cleanly (not in the middle of a triple/quad) even more so. So, this simply adds support for optional chunked/split output. For example, the following creates `.trig` files of about 200 MB each:

```
$ cd importers
$ ../gradlew jar
$ java -Xmx2g -Dxl.secret.properties=../secret.properties -jar build/libs/vcopyImporter.jar lddbToTrig foobar.trig 200
$ ls -l *.trig
-rw-r--r-- 1 andersju andersju 200000693 Jul 29 13:22 0001-foobar.trig
-rw-r--r-- 1 andersju andersju 200000049 Jul 29 13:23 0002-foobar.trig
-rw-r--r-- 1 andersju andersju 200000167 Jul 29 13:25 0003-foobar.trig
-rw-r--r-- 1 andersju andersju  31999649 Jul 29 13:25 0004-foobar.trig
```