### PR TITLE
Use dedicated _suggest param for autocomplete/suggestion search

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -99,7 +99,7 @@ class ESQuery {
         List filters
 
         if (suggest && !SUGGEST_LANGS.contains(suggest)) {
-            throw new InvalidQueryException("_suggest value ${suggest} invalid, must be one of ${SUGGEST_LANGS}")
+            throw new InvalidQueryException("Parameter '_suggest' value '${suggest}' invalid, must be one of ${SUGGEST_LANGS}")
         }
 
         String[] originalTypeParam = queryParameters.get('@type')

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -8,6 +8,7 @@ import groovy.util.logging.Log4j2 as Log
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.JsonLd
 import whelk.Whelk
+import whelk.component.ElasticSearch
 import whelk.exception.InvalidQueryException
 import whelk.util.DocumentUtil
 import whelk.util.Unicode
@@ -27,7 +28,6 @@ class ESQuery {
     ]
     private static final String OR_PREFIX = 'or-'
     private static final String EXISTS_PREFIX = 'exists-'
-    private static final List SUGGEST_LANGS = ['sv', 'en']
 
     private Map<String, List<String>> boostFieldsByType = [:]
     private ESQueryLensBoost lensBoost
@@ -98,8 +98,8 @@ class ESQuery {
         //   any k=v param - FILTER query (same key => OR, different key => AND)
         List filters
 
-        if (suggest && !SUGGEST_LANGS.contains(suggest)) {
-            throw new InvalidQueryException("Parameter '_suggest' value '${suggest}' invalid, must be one of ${SUGGEST_LANGS}")
+        if (suggest && !ElasticSearch.LANGUAGES_TO_INDEX.contains(suggest)) {
+            throw new InvalidQueryException("Parameter '_suggest' value '${suggest}' invalid, must be one of ${ElasticSearch.LANGUAGES_TO_INDEX}")
         }
 
         String[] originalTypeParam = queryParameters.get('@type')


### PR DESCRIPTION
Follow-up to #964

Autocomplete search is now performed if `_suggest={sv,en}` and `_lens=chips`.

With autocomplete:
```bash
~ curl -s -XGET -H "Accept: application/ld+json" \
      'http://localhost:8180/find?q=musik&_limit=10&_lens=chips&_suggest=sv&_debug=esQuery' \
      | jq '._debug.esQuery | {query}'
{
  "query": {
    "bool": {
      "must": [
        {
          "match_phrase_prefix": {
            "_sortKeyByLang.sv.suggest": "musik"
          }
        }
      ]
    }
  }
}
```

Without:

```bash
~ curl -s -XGET -H "Accept: application/ld+json" \
        'http://localhost:8180/find?q=musik&_limit=10&_lens=chips&_debug=esQuery' \
        | jq '._debug.esQuery | {query}'
[...lots...]
              {
                "simple_query_string": {
                  "query": "musik",
                  "default_operator": "AND",
                  "analyze_wildcard": true
                }
              }
```

`_suggest` set but `_lens` not `chips` (or missing):

```bash
~ curl -i -XGET -H "Accept: application/ld+json" \
      'http://localhost:8180/find?q=musik&_limit=10&_lens=card&_suggest=sv'
HTTP/1.1 400 Invalid query, please check the documentation. Parameter '_suggest' can only be used when '_lens' is set to 'chips'
```

`_suggest` set to invalid language:

```bash
~ curl -i -XGET -H "Accept: application/ld+json" \
      'http://localhost:8180/find?q=musik&_limit=10&_lens=chips&_suggest=fr'
HTTP/1.1 400 Invalid query, please check the documentation. Parameter '_suggest' value 'fr' invalid, must be one of [sv, en]
```