### PR TITLE
CRUD: Send error response bodies as json

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -563,7 +563,7 @@ class Crud extends HttpServlet {
         try {
             doPut2(request, response)
         } catch (Exception e) {
-            failedRequests.labels("POST", request.getRequestURI(),
+            failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
             sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -111,7 +111,6 @@ class Crud extends HttpServlet {
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
             HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to reach elastic for query.")
-            return
         }
         catch (WhelkRuntimeException e) {
             log.error("Attempted elastic query, but whelk has no " +
@@ -121,14 +120,12 @@ class Crud extends HttpServlet {
             HttpTools.sendError(response, HttpServletResponse.SC_NOT_IMPLEMENTED,
                     "Attempted to use elastic for query, but " +
                             "no elastic component is configured.")
-            return
         } catch (InvalidQueryException e) {
             log.warn("Invalid query: ${queryParameters}")
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid query, please check the documentation. ${e.getMessage()}")
-            return
         }
     }
 

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -1,12 +1,14 @@
 package whelk.rest.api
 
-
+import groovy.transform.Memoized
 import groovy.transform.PackageScope
 import groovy.util.logging.Log4j2 as Log
 import io.prometheus.client.Counter
 import io.prometheus.client.Gauge
 import io.prometheus.client.Summary
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.http.entity.ContentType
+import org.codehaus.groovy.runtime.StackTraceUtils
 import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.IdGenerator
@@ -16,14 +18,15 @@ import whelk.JsonLdValidator
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.exception.ElasticIOException
-import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.InvalidQueryException
+import whelk.exception.LinkValidationException
 import whelk.exception.ModelValidationException
 import whelk.exception.StaleUpdateException
 import whelk.exception.StorageCreateFailedException
-import whelk.exception.LinkValidationException
+import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.WhelkAddException
 import whelk.exception.WhelkRuntimeException
+import whelk.rest.api.CrudGetRequest.Lens
 import whelk.rest.security.AccessControl
 import whelk.util.LegacyIntegrationTools
 import whelk.util.WhelkFactory
@@ -32,8 +35,7 @@ import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
-
-import whelk.rest.api.CrudGetRequest.Lens
+import java.lang.reflect.Field
 
 import static whelk.rest.api.HttpTools.sendResponse
 
@@ -111,8 +113,7 @@ class Crud extends HttpServlet {
             log.error("Attempted elastic query, but failed: $e", e)
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    "Failed to reach elastic for query.")
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to reach elastic for query.")
             return
         }
         catch (WhelkRuntimeException e) {
@@ -120,7 +121,7 @@ class Crud extends HttpServlet {
                     "elastic component configured.", e)
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_NOT_IMPLEMENTED.toString()).inc()
-            response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED,
+            sendError(response, HttpServletResponse.SC_NOT_IMPLEMENTED,
                     "Attempted to use elastic for query, but " +
                             "no elastic component is configured.")
             return
@@ -128,7 +129,7 @@ class Crud extends HttpServlet {
             log.warn("Invalid query: ${queryParameters}")
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid query, please check the documentation. ${e.getMessage()}")
             return
         }
@@ -149,6 +150,10 @@ class Crud extends HttpServlet {
         log.debug("Handling GET request for ${request.pathInfo}")
         try {
             doGet2(request, response)
+        } catch (Exception e) {
+            failedRequests.labels("GET", request.getRequestURI(),
+                    HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("GET").dec()
             requestTimer.observeDuration()
@@ -180,23 +185,23 @@ class Crud extends HttpServlet {
         } catch (UnsupportedContentTypeException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_NOT_ACCEPTABLE.toString()).inc()
-            response.sendError(response.SC_NOT_ACCEPTABLE, e.message)
+            sendError(response, HttpServletResponse.SC_NOT_ACCEPTABLE, e.message)
         } catch (NotFoundException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_NOT_FOUND.toString()).inc()
-            response.sendError(response.SC_NOT_FOUND, e.message)
+            sendError(response, HttpServletResponse.SC_NOT_FOUND, e.message)
         } catch (BadRequestException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(response.SC_BAD_REQUEST, e.message)
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.message)
         }
         catch (WhelkRuntimeException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            response.sendError(response.SC_INTERNAL_SERVER_ERROR, e.message)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         }
     }
-
+    
     void handleGetRequest(CrudGetRequest request,
                           HttpServletResponse response) {
         // TODO: return already loaded displayData and vocabData (cached on modified)? (LXL-260)
@@ -214,8 +219,7 @@ class Crud extends HttpServlet {
         } else if (doc.deleted) {
             failedRequests.labels("GET", request.getPath(),
                     HttpServletResponse.SC_GONE.toString()).inc()
-            response.sendError(HttpServletResponse.SC_GONE,
-                    "Document has been deleted.")
+            sendError(response, HttpServletResponse.SC_GONE, "Document has been deleted.")
         } else {
             sendGetResponse(
                     maybeAddProposal25Headers(response, loc),
@@ -234,15 +238,13 @@ class Crud extends HttpServlet {
         setVary(response)
         response.setHeader("ETag", "\"${doc.getChecksum(jsonld)}\"")
         response.setHeader("Server-Start-Time", "" + ManagementFactory.getRuntimeMXBean().getStartTime())
-        response.sendError(HttpServletResponse.SC_NOT_MODIFIED,
-                "Document has not been modified.")
+        sendError(response, HttpServletResponse.SC_NOT_MODIFIED, "Document has not been modified.")
     }
 
     private void sendNotFound(HttpServletResponse response, String path) {
         failedRequests.labels("GET", path,
                 HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-        response.sendError(HttpServletResponse.SC_NOT_FOUND,
-                "Document not found.")
+        sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
     }
 
     private Object getFormattedResponseBody(CrudGetRequest request, Document doc) {
@@ -450,6 +452,10 @@ class Crud extends HttpServlet {
 
         try {
             doPost2(request, response)
+        } catch (Exception e) {
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("POST").dec()
             requestTimer.observeDuration()
@@ -463,8 +469,7 @@ class Crud extends HttpServlet {
             log.debug("Invalid POST request URL.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-                    "Method not allowed.")
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
             return
         }
 
@@ -472,8 +477,7 @@ class Crud extends HttpServlet {
             log.debug("Unsupported Content-Type for POST.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Content-Type not supported.")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Content-Type not supported.")
             return
         }
 
@@ -483,8 +487,7 @@ class Crud extends HttpServlet {
             log.debug("Empty POST request.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "No data received")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "No data received")
             return
         }
 
@@ -492,8 +495,7 @@ class Crud extends HttpServlet {
             log.debug("POST body is not flat JSON-LD")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Body is not flat JSON-LD.")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Body is not flat JSON-LD.")
             return
         }
 
@@ -511,7 +513,7 @@ class Crud extends HttpServlet {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid JsonLd, got errors: " + message)
             return
         }
@@ -523,7 +525,7 @@ class Crud extends HttpServlet {
             if (!allowed) {
                 failedRequests.labels("POST", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                sendError(response, HttpServletResponse.SC_FORBIDDEN,
                         "You are not authorized to perform this " +
                                 "operation")
                 log.debug("Permission check failed. Denying request.")
@@ -533,8 +535,7 @@ class Crud extends HttpServlet {
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    mve.getMessage())
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, mve.getMessage())
             log.debug("Model validation check failed. Denying request: " + mve.getMessage())
             return
         }
@@ -561,6 +562,10 @@ class Crud extends HttpServlet {
 
         try {
             doPut2(request, response)
+        } catch (Exception e) {
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("PUT").dec()
             requestTimer.observeDuration()
@@ -575,7 +580,7 @@ class Crud extends HttpServlet {
             log.debug("Invalid PUT request URL.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                     "Method not allowed.")
             return
         }
@@ -584,7 +589,7 @@ class Crud extends HttpServlet {
             log.debug("Unsupported Content-Type for PUT.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Content-Type not supported.")
             return
         }
@@ -595,7 +600,7 @@ class Crud extends HttpServlet {
             log.debug("Empty PUT request.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "No data received")
             return
         }
@@ -607,7 +612,7 @@ class Crud extends HttpServlet {
             log.debug("Missing document ID in PUT request.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Missing @id in request.")
             return
         }
@@ -619,7 +624,7 @@ class Crud extends HttpServlet {
         if (!existingDoc && !location) {
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-            response.sendError(HttpServletResponse.SC_NOT_FOUND,
+            sendError(response, HttpServletResponse.SC_NOT_FOUND,
                     "Document not found.")
             return
         } else if (!existingDoc && location) {
@@ -632,7 +637,7 @@ class Crud extends HttpServlet {
                           "${fullPutId} in PUT body")
                 failedRequests.labels("PUT", request.getRequestURI(),
                         HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                         "Record ID was modified")
                 return
             }
@@ -641,14 +646,14 @@ class Crud extends HttpServlet {
         Document updatedDoc = new Document(requestBody)
         updatedDoc.normalizeUnicode()
         updatedDoc.setId(documentId)
-
+                
         String collection = LegacyIntegrationTools.determineLegacyCollection(updatedDoc, jsonld)
         List<JsonLdValidator.Error> errors = validator.validate(updatedDoc.data, collection)
         if (errors) {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid JsonLd, got errors: " + message)
             return
         }
@@ -662,7 +667,7 @@ class Crud extends HttpServlet {
             if (!allowed) {
                 failedRequests.labels("PUT", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                sendError(response, HttpServletResponse.SC_FORBIDDEN,
                         "You are not authorized to perform this " +
                                 "operation")
                 return
@@ -671,7 +676,7 @@ class Crud extends HttpServlet {
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     mve.getMessage())
             return
         }
@@ -742,7 +747,7 @@ class Crud extends HttpServlet {
             log.warn("Refused document with id ${scfe.duplicateId}")
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_CONFLICT.toString()).inc()
-            response.sendError(HttpServletResponse.SC_CONFLICT,
+            sendError(response, HttpServletResponse.SC_CONFLICT,
                     scfe.message)
             return null
         } catch (WhelkAddException wae) {
@@ -750,35 +755,33 @@ class Crud extends HttpServlet {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE.toString()).inc()
             // FIXME data leak
-            response.sendError(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
+            sendError(response, HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
                     wae.message)
             return null
         } catch (StaleUpdateException eme) {
             log.warn("Did not store document, because the ETAGs did not match.")
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_PRECONDITION_FAILED.toString()).inc()
-            response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED,
+            sendError(response, HttpServletResponse.SC_PRECONDITION_FAILED,
                                         "The resource has been updated by someone " +
                                                 "else. Please refetch.")
             return null
         } catch (PostgreSQLComponent.AcquireLockException e) {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Failed to acquire a necessary lock. Did you submit a holding record without a valid bib link? " + e.message)
             return null
         } catch (LinkValidationException | PostgreSQLComponent.ConflictingHoldException e) {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage())
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage())
             return null
         } catch (Exception e) {
-            log.error("Operation failed", e)
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
             // FIXME data leak
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    e.message)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
             return null
         }
         return null
@@ -891,6 +894,10 @@ class Crud extends HttpServlet {
 
         try {
             doDelete2(request, response)
+        } catch (Exception e) {
+            failedRequests.labels("DELETE", request.getRequestURI(),
+                    HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("DELETE").dec()
             requestTimer.observeDuration()
@@ -903,7 +910,7 @@ class Crud extends HttpServlet {
         if (request.pathInfo == "/") {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
             return
         }
         try {
@@ -919,20 +926,20 @@ class Crud extends HttpServlet {
             } else if (!doc) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-                response.sendError(HttpServletResponse.SC_NOT_FOUND, "Document not found.")
+                sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
             } else if (doc && !hasDeletePermission(doc, request.getAttribute("user"))) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                response.sendError(HttpServletResponse.SC_FORBIDDEN, "You do not have sufficient privileges to perform this operation.")
+                sendError(response, HttpServletResponse.SC_FORBIDDEN, "You do not have sufficient privileges to perform this operation.")
             } else if (doc && doc.deleted) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_GONE.toString()).inc()
-                response.sendError(HttpServletResponse.SC_GONE,
+                sendError(response, HttpServletResponse.SC_GONE,
                         "Document has been deleted.")
             } else if(!whelk.storage.followDependers(doc.getShortId()).isEmpty()) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                response.sendError(HttpServletResponse.SC_FORBIDDEN, "This record may not be deleted, because it is referenced by other records.")
+                sendError(response, HttpServletResponse.SC_FORBIDDEN, "This record may not be deleted, because it is referenced by other records.")
             } else {
                 log.debug("Removing resource at ${doc.getShortId()}")
                 String activeSigel = request.getHeader(XL_ACTIVE_SIGEL_HEADER)
@@ -943,15 +950,43 @@ class Crud extends HttpServlet {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     mve.getMessage())
-        } catch (Exception wre) {
-            log.error("Something went wrong", wre)
+        } catch (Exception e) {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, wre.message)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         }
 
+    }
+
+    static void sendError(HttpServletResponse response, int statusCode, String msg, Exception e = null) {
+        Map json = [
+                "status_code": statusCode,
+                "status": httpStatus(statusCode),
+                "message": msg,
+        ]
+
+        if (statusCode >= 500 && e) {
+            e = StackTraceUtils.sanitize(e)
+            log.error("Internal server error: ${e.getMessage()}", e)
+
+            json.stackTrace = ExceptionUtils.getStackFrames(e).with{
+                it.take(2 + it.findLastIndexOf { at -> at.contains(Crud.class.getName())})
+            }.collect { it.replace('\t', '    ')}
+        }
+
+        sendResponse(response, json, "application/json", statusCode)
+    }
+
+    @Memoized
+    static String httpStatus(int statusCode) {
+        for (Field f : HttpServletResponse.class.declaredFields) {
+            if (f.getName().startsWith("SC_") && f.getType() == int.class && f.getInt(null) == statusCode) {
+                return f.getName().substring("SC_".length()).replace("_", " ")
+            }
+        }
+        return ""
     }
 
     static class NotFoundException extends RuntimeException {

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -873,15 +873,6 @@ class Crud extends HttpServlet {
         return alts
     }
 
-    String mintIdentifier(Map data) {
-        String id = null
-        if (data) {
-            id = JsonLd.findIdentifier(data)
-        }
-        return id ?: IdGenerator.generate()
-    }
-
-
     @Override
     void doDelete(HttpServletRequest request, HttpServletResponse response) {
         requests.labels("DELETE").inc()

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -132,7 +132,7 @@ class Crud extends HttpServlet {
         }
     }
 
-    void displayInfo(HttpServletResponse response) {
+    static void displayInfo(HttpServletResponse response) {
         def info = [:]
         info["system"] = "LIBRISXL"
         info["format"] = "linked-data-api"
@@ -238,7 +238,7 @@ class Crud extends HttpServlet {
         HttpTools.sendError(response, HttpServletResponse.SC_NOT_MODIFIED, "Document has not been modified.")
     }
 
-    private void sendNotFound(HttpServletResponse response, String path) {
+    private static void sendNotFound(HttpServletResponse response, String path) {
         failedRequests.labels("GET", path,
                 HttpServletResponse.SC_NOT_FOUND.toString()).inc()
         HttpTools.sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
@@ -268,11 +268,11 @@ class Crud extends HttpServlet {
         }
     }
 
-    private Map frameRecord(Document document) {
+    private static Map frameRecord(Document document) {
         return JsonLd.frame(document.getCompleteId(), document.data)
     }
 
-    private Map frameThing(Document document) {
+    private static Map frameThing(Document document) {
         document.setThingMeta(document.getCompleteId())
         List<String> thingIds = document.getThingIdentifiers()
         if (thingIds.isEmpty()) {
@@ -295,7 +295,7 @@ class Crud extends HttpServlet {
         }
     }
 
-    private void setVary(HttpServletResponse response) {
+    private static void setVary(HttpServletResponse response) {
         response.setHeader("Vary", "Accept")
     }
 
@@ -365,8 +365,8 @@ class Crud extends HttpServlet {
         return result
     }
 
-    private HttpServletResponse maybeAddProposal25Headers(HttpServletResponse response,
-                                                          String location) {
+    private static HttpServletResponse maybeAddProposal25Headers(HttpServletResponse response,
+                                                                 String location) {
         if (location) {
             response.addHeader('Content-Location',
                                getDataURI(location))
@@ -376,7 +376,7 @@ class Crud extends HttpServlet {
         return response
     }
 
-    private String getDataURI(String location) {
+    private static String getDataURI(String location) {
         if (location.endsWith('/')) {
             return location + 'data.jsonld'
         } else {
@@ -426,8 +426,8 @@ class Crud extends HttpServlet {
      * Send 302 Found response
      *
      */
-    void sendRedirect(HttpServletRequest request,
-                      HttpServletResponse response, String location) {
+    static void sendRedirect(HttpServletRequest request,
+                             HttpServletResponse response, String location) {
         if (new URI(location).getScheme() == null) {
             def locationRef = request.getScheme() + "://" +
                     request.getServerName() +
@@ -540,7 +540,7 @@ class Crud extends HttpServlet {
         // try store document
         // return 201 or error
         boolean isUpdate = false
-        Document savedDoc;
+        Document savedDoc
         savedDoc = saveDocument(newDoc, request, response, isUpdate, "POST")
         if (savedDoc != null) {
             sendCreateResponse(response, savedDoc.getURI().toString(),
@@ -687,18 +687,18 @@ class Crud extends HttpServlet {
 
     }
 
-    boolean isEmptyInput(Map inputData) {
+    static boolean isEmptyInput(Map inputData) {
         return !inputData || inputData.size() == 0
     }
 
-    boolean isSupportedContentType(HttpServletRequest request) {
+    static boolean isSupportedContentType(HttpServletRequest request) {
         ContentType contentType = ContentType.parse(request.getContentType())
         String mimeType = contentType.getMimeType()
         // FIXME add additional content types?
         return mimeType == "application/ld+json"
     }
 
-    Map getRequestBody(HttpServletRequest request) {
+    static Map getRequestBody(HttpServletRequest request) {
         byte[] body = request.getInputStream().getBytes()
 
         try {
@@ -784,19 +784,19 @@ class Crud extends HttpServlet {
         return null
     }
 
-    void sendCreateResponse(HttpServletResponse response, String locationRef,
-                            String etag) {
+    static void sendCreateResponse(HttpServletResponse response, String locationRef,
+                                   String etag) {
         sendDocumentSavedResponse(response, locationRef, etag, true)
     }
 
-    void sendUpdateResponse(HttpServletResponse response, String locationRef,
-                            String etag) {
+    static void sendUpdateResponse(HttpServletResponse response, String locationRef,
+                                   String etag) {
         sendDocumentSavedResponse(response, locationRef, etag, false)
     }
 
-    void sendDocumentSavedResponse(HttpServletResponse response,
-                                   String locationRef, String etag,
-                                   boolean newDocument) {
+    static void sendDocumentSavedResponse(HttpServletResponse response,
+                                          String locationRef, String etag,
+                                          boolean newDocument) {
         log.debug("Setting header Location: $locationRef")
 
         response.setHeader("Location", locationRef)
@@ -859,7 +859,7 @@ class Crud extends HttpServlet {
     }
 
     @Deprecated
-    List<String> getAlternateIdentifiersFromLinkHeaders(HttpServletRequest request) {
+    static List<String> getAlternateIdentifiersFromLinkHeaders(HttpServletRequest request) {
         def alts = []
         for (link in request.getHeaders("Link")) {
             def (id, rel) = link.split(";")*.trim()

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -971,8 +971,9 @@ class Crud extends HttpServlet {
             e = StackTraceUtils.sanitize(e)
             log.error("Internal server error: ${e.getMessage()}", e)
 
-            json.stackTrace = ExceptionUtils.getStackFrames(e).with{
-                it.take(2 + it.findLastIndexOf { at -> at.contains(Crud.class.getName())})
+            // Don't include servlet container stack frames
+            json.stackTrace = ExceptionUtils.getStackFrames(e).with {
+                it.take(2 + it.findLastIndexOf { at -> at.contains(Crud.class.getName()) })
             }.collect { it.replace('\t', '    ')}
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
+import static whelk.rest.api.HttpTools.sendError
 import static whelk.rest.api.HttpTools.sendResponse
 
 /**
@@ -110,21 +111,21 @@ class Crud extends HttpServlet {
             log.error("Attempted elastic query, but failed: $e", e)
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to reach elastic for query.")
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to reach elastic for query.")
         }
         catch (WhelkRuntimeException e) {
             log.error("Attempted elastic query, but whelk has no " +
                     "elastic component configured.", e)
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_NOT_IMPLEMENTED.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_NOT_IMPLEMENTED,
+            sendError(response, HttpServletResponse.SC_NOT_IMPLEMENTED,
                     "Attempted to use elastic for query, but " +
                             "no elastic component is configured.")
         } catch (InvalidQueryException e) {
             log.warn("Invalid query: ${queryParameters}")
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid query, please check the documentation. ${e.getMessage()}")
         }
     }
@@ -147,7 +148,7 @@ class Crud extends HttpServlet {
         } catch (Exception e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("GET").dec()
             requestTimer.observeDuration()
@@ -179,20 +180,20 @@ class Crud extends HttpServlet {
         } catch (UnsupportedContentTypeException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_NOT_ACCEPTABLE.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_NOT_ACCEPTABLE, e.message)
+            sendError(response, HttpServletResponse.SC_NOT_ACCEPTABLE, e.message)
         } catch (NotFoundException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_NOT_FOUND.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_NOT_FOUND, e.message)
+            sendError(response, HttpServletResponse.SC_NOT_FOUND, e.message)
         } catch (BadRequestException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.message)
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.message)
         }
         catch (WhelkRuntimeException e) {
             failedRequests.labels("GET", request.getRequestURI(),
                     response.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         }
     }
     
@@ -213,7 +214,7 @@ class Crud extends HttpServlet {
         } else if (doc.deleted) {
             failedRequests.labels("GET", request.getPath(),
                     HttpServletResponse.SC_GONE.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_GONE, "Document has been deleted.")
+            sendError(response, HttpServletResponse.SC_GONE, "Document has been deleted.")
         } else {
             sendGetResponse(
                     maybeAddProposal25Headers(response, loc),
@@ -232,13 +233,13 @@ class Crud extends HttpServlet {
         setVary(response)
         response.setHeader("ETag", "\"${doc.getChecksum(jsonld)}\"")
         response.setHeader("Server-Start-Time", "" + ManagementFactory.getRuntimeMXBean().getStartTime())
-        HttpTools.sendError(response, HttpServletResponse.SC_NOT_MODIFIED, "Document has not been modified.")
+        sendError(response, HttpServletResponse.SC_NOT_MODIFIED, "Document has not been modified.")
     }
 
     private static void sendNotFound(HttpServletResponse response, String path) {
         failedRequests.labels("GET", path,
                 HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-        HttpTools.sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
+        sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
     }
 
     private Object getFormattedResponseBody(CrudGetRequest request, Document doc) {
@@ -449,7 +450,7 @@ class Crud extends HttpServlet {
         } catch (Exception e) {
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("POST").dec()
             requestTimer.observeDuration()
@@ -463,7 +464,7 @@ class Crud extends HttpServlet {
             log.debug("Invalid POST request URL.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
             return
         }
 
@@ -471,7 +472,7 @@ class Crud extends HttpServlet {
             log.debug("Unsupported Content-Type for POST.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Content-Type not supported.")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Content-Type not supported.")
             return
         }
 
@@ -481,7 +482,7 @@ class Crud extends HttpServlet {
             log.debug("Empty POST request.")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, "No data received")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "No data received")
             return
         }
 
@@ -489,7 +490,7 @@ class Crud extends HttpServlet {
             log.debug("POST body is not flat JSON-LD")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Body is not flat JSON-LD.")
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Body is not flat JSON-LD.")
             return
         }
 
@@ -507,7 +508,7 @@ class Crud extends HttpServlet {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid JsonLd, got errors: " + message)
             return
         }
@@ -519,7 +520,7 @@ class Crud extends HttpServlet {
             if (!allowed) {
                 failedRequests.labels("POST", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_FORBIDDEN,
+                sendError(response, HttpServletResponse.SC_FORBIDDEN,
                         "You are not authorized to perform this " +
                                 "operation")
                 log.debug("Permission check failed. Denying request.")
@@ -529,7 +530,7 @@ class Crud extends HttpServlet {
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, mve.getMessage())
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, mve.getMessage())
             log.debug("Model validation check failed. Denying request: " + mve.getMessage())
             return
         }
@@ -559,7 +560,7 @@ class Crud extends HttpServlet {
         } catch (Exception e) {
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("PUT").dec()
             requestTimer.observeDuration()
@@ -574,7 +575,7 @@ class Crud extends HttpServlet {
             log.debug("Invalid PUT request URL.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                     "Method not allowed.")
             return
         }
@@ -583,7 +584,7 @@ class Crud extends HttpServlet {
             log.debug("Unsupported Content-Type for PUT.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Content-Type not supported.")
             return
         }
@@ -594,7 +595,7 @@ class Crud extends HttpServlet {
             log.debug("Empty PUT request.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "No data received")
             return
         }
@@ -606,7 +607,7 @@ class Crud extends HttpServlet {
             log.debug("Missing document ID in PUT request.")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Missing @id in request.")
             return
         }
@@ -618,7 +619,7 @@ class Crud extends HttpServlet {
         if (!existingDoc && !location) {
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_NOT_FOUND,
+            sendError(response, HttpServletResponse.SC_NOT_FOUND,
                     "Document not found.")
             return
         } else if (!existingDoc && location) {
@@ -631,7 +632,7 @@ class Crud extends HttpServlet {
                           "${fullPutId} in PUT body")
                 failedRequests.labels("PUT", request.getRequestURI(),
                         HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+                sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                         "Record ID was modified")
                 return
             }
@@ -647,7 +648,7 @@ class Crud extends HttpServlet {
             String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Invalid JsonLd, got errors: " + message)
             return
         }
@@ -661,7 +662,7 @@ class Crud extends HttpServlet {
             if (!allowed) {
                 failedRequests.labels("PUT", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_FORBIDDEN,
+                sendError(response, HttpServletResponse.SC_FORBIDDEN,
                         "You are not authorized to perform this " +
                                 "operation")
                 return
@@ -670,7 +671,7 @@ class Crud extends HttpServlet {
             failedRequests.labels("PUT", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     mve.getMessage())
             return
         }
@@ -741,7 +742,7 @@ class Crud extends HttpServlet {
             log.warn("Refused document with id ${scfe.duplicateId}")
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_CONFLICT.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_CONFLICT,
+            sendError(response, HttpServletResponse.SC_CONFLICT,
                     scfe.message)
             return null
         } catch (WhelkAddException wae) {
@@ -749,33 +750,33 @@ class Crud extends HttpServlet {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE.toString()).inc()
             // FIXME data leak
-            HttpTools.sendError(response, HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
+            sendError(response, HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
                     wae.message)
             return null
         } catch (StaleUpdateException eme) {
             log.warn("Did not store document, because the ETAGs did not match.")
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_PRECONDITION_FAILED.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_PRECONDITION_FAILED,
+            sendError(response, HttpServletResponse.SC_PRECONDITION_FAILED,
                                         "The resource has been updated by someone " +
                                                 "else. Please refetch.")
             return null
         } catch (PostgreSQLComponent.AcquireLockException e) {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     "Failed to acquire a necessary lock. Did you submit a holding record without a valid bib link? " + e.message)
             return null
         } catch (LinkValidationException | PostgreSQLComponent.ConflictingHoldException e) {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage())
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage())
             return null
         } catch (Exception e) {
             failedRequests.labels(httpMethod, request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
             // FIXME data leak
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
             return null
         }
         return null
@@ -882,7 +883,7 @@ class Crud extends HttpServlet {
         } catch (Exception e) {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         } finally {
             ongoingRequests.labels("DELETE").dec()
             requestTimer.observeDuration()
@@ -895,7 +896,7 @@ class Crud extends HttpServlet {
         if (request.pathInfo == "/") {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_METHOD_NOT_ALLOWED.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
+            sendError(response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Method not allowed.")
             return
         }
         try {
@@ -911,20 +912,20 @@ class Crud extends HttpServlet {
             } else if (!doc) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_NOT_FOUND.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
+                sendError(response, HttpServletResponse.SC_NOT_FOUND, "Document not found.")
             } else if (doc && !hasDeletePermission(doc, request.getAttribute("user"))) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_FORBIDDEN, "You do not have sufficient privileges to perform this operation.")
+                sendError(response, HttpServletResponse.SC_FORBIDDEN, "You do not have sufficient privileges to perform this operation.")
             } else if (doc && doc.deleted) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_GONE.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_GONE,
+                sendError(response, HttpServletResponse.SC_GONE,
                         "Document has been deleted.")
             } else if(!whelk.storage.followDependers(doc.getShortId()).isEmpty()) {
                 failedRequests.labels("DELETE", request.getRequestURI(),
                         HttpServletResponse.SC_FORBIDDEN.toString()).inc()
-                HttpTools.sendError(response, HttpServletResponse.SC_FORBIDDEN, "This record may not be deleted, because it is referenced by other records.")
+                sendError(response, HttpServletResponse.SC_FORBIDDEN, "This record may not be deleted, because it is referenced by other records.")
             } else {
                 log.debug("Removing resource at ${doc.getShortId()}")
                 String activeSigel = request.getHeader(XL_ACTIVE_SIGEL_HEADER)
@@ -935,12 +936,12 @@ class Crud extends HttpServlet {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             // FIXME data leak
-            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST,
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                     mve.getMessage())
         } catch (Exception e) {
             failedRequests.labels("DELETE", request.getRequestURI(),
                     HttpServletResponse.SC_INTERNAL_SERVER_ERROR.toString()).inc()
-            HttpTools.sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
+            sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage(), e)
         }
 
     }

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -67,15 +67,7 @@ class HttpTools {
 
         sendResponse(response, json, "application/json", statusCode)
     }
-
-    static String getMajorContentType(String contentType) {
-        if (contentType == "application/x-marc-json") {
-            return "application/json"
-        }
-        return contentType?.replaceAll("/[\\w]+\\+", "/")
-    }
-
-
+    
     enum DisplayMode {
         DOCUMENT, META, RAW
     }

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -61,7 +61,7 @@ class HttpTools {
 
             // Don't include servlet container stack frames
             json.stackTrace = ExceptionUtils.getStackFrames(e).with {
-                it.take(2 + it.findLastIndexOf { at -> at.contains(Crud.class.getName()) })
+                it.take(2 + it.findLastIndexOf { at -> at.contains(HttpTools.class.getPackage().getName()) })
             }.collect { it.replace('\t', '    ')}
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -1,12 +1,19 @@
 package whelk.rest.api
 
+
+import groovy.util.logging.Log4j2 as Log
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.codehaus.groovy.runtime.StackTraceUtils
 import org.codehaus.jackson.map.ObjectMapper
 
 import javax.servlet.http.HttpServletResponse
 
+import static org.eclipse.jetty.http.HttpStatus.getMessage
+
 /**
  * Created by markus on 2015-10-09.
  */
+@Log
 class HttpTools {
 
     static final ObjectMapper mapper = new ObjectMapper()
@@ -39,6 +46,26 @@ class HttpTools {
             out.flush()
             out.close()
         }
+    }
+
+    static void sendError(HttpServletResponse response, int statusCode, String msg, Exception e = null) {
+        Map json = [
+                "status_code": statusCode,
+                "status": getMessage(statusCode),
+                "message": msg,
+        ]
+
+        if (statusCode >= 500 && e) {
+            e = StackTraceUtils.sanitize(e)
+            log.error("Internal server error: ${e.getMessage()}", e)
+
+            // Don't include servlet container stack frames
+            json.stackTrace = ExceptionUtils.getStackFrames(e).with {
+                it.take(2 + it.findLastIndexOf { at -> at.contains(Crud.class.getName()) })
+            }.collect { it.replace('\t', '    ')}
+        }
+
+        sendResponse(response, json, "application/json", statusCode)
     }
 
     static String getMajorContentType(String contentType) {


### PR DESCRIPTION
Send error response bodies as json instead of letting servlet container generate a plaintext/html response.

Include stack trace on HTTP 500. Tradeoff between leaking internals and easing trouble-shooting.
