### PR TITLE
Send structured response on 400 invalid jsonld

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -509,7 +509,7 @@ class Crud extends HttpServlet {
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             
             sendError(response, HttpServletResponse.SC_BAD_REQUEST,
-                    "Invalid JsonLd", ['errors': errors.collect{ it.toMap() }])
+                    "Invalid JSON-LD", ['errors': errors.collect{ it.toMap() }])
             return
         }
         

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -505,11 +505,11 @@ class Crud extends HttpServlet {
         String collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, jsonld)
         List<JsonLdValidator.Error> errors = validator.validate(newDoc.data, collection)
         if (errors) {
-            String message = errors.collect { it.toStringWithPath() }.join("\n")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            
             sendError(response, HttpServletResponse.SC_BAD_REQUEST,
-                    "Invalid JsonLd, got errors: " + message)
+                    "Invalid JsonLd", ['errors': errors.collect{ it.toMap() }])
             return
         }
         

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -48,12 +48,15 @@ class HttpTools {
         }
     }
 
-    static void sendError(HttpServletResponse response, int statusCode, String msg, Exception e = null) {
+    static void sendError(HttpServletResponse response, int statusCode, String msg, Object extraInfo = null) {
+        Exception e = extraInfo instanceof Exception ? extraInfo : null
+        Map extra = extraInfo instanceof Map ? extraInfo : [:]
+        
         Map json = [
+                "message"    : msg,
                 "status_code": statusCode,
-                "status": getMessage(statusCode),
-                "message": msg,
-        ]
+                "status"     : getMessage(statusCode)
+        ] + extra
 
         if (statusCode >= 500 && e) {
             e = StackTraceUtils.sanitize(e)

--- a/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
@@ -278,5 +278,14 @@ class JsonLdValidator {
         String toString() {
             return type.description +" for KEY: $key VALUE: $value"
         }
+
+        Map toMap() {
+            [
+                    'type'       : type,
+                    'description': type.description,
+                    'path'       : path,
+                    'value'      : value
+            ]
+        }
     }
 }


### PR DESCRIPTION
e.g. 
```
{
  "message": "Invalid JsonLd",
  "status_code": 400,
  "status": "Bad Request",
  "errors": [
    {
      "type": "MISSING_DEFINITION",
      "description": "Unknown term. Missing definition",
      "path": ["@graph", 1, "marc:otherPhysicalDetails"],
      "value": ""
    },
    {
      "type": "MISSING_DEFINITION",
      "description": "Unknown term. Missing definition",
      "path": ["@graph", 2, "classification", 0, "ienScheme"],
      "value": ""
    }
  ]
}
```