### PR TITLE
400 instead of 500 when POSTing new doc with temporary @id missing

### DIFF
--- a/rest/API.md
+++ b/rest/API.md
@@ -87,6 +87,9 @@ There are some checks in place, e.g. in order to prevent creation of duplicate
 holding records, and to these requests the API responds with a `400 Bad Request`
 with an error message explaining the issue.
 
+Note that a temporary record `@id` **must** be set in the document you send
+(e.g., `{"@graph":[{"@id":"https://id.kb.se/TEMPID", ...`).
+
 A successful creation will get a `201 Created` response with a `Location`
 header containing the URI of the new record.
 

--- a/rest/API.md
+++ b/rest/API.md
@@ -87,8 +87,17 @@ There are some checks in place, e.g. in order to prevent creation of duplicate
 holding records, and to these requests the API responds with a `400 Bad Request`
 with an error message explaining the issue.
 
-Note that a temporary record `@id` **must** be set in the document you send
-(e.g., `{"@graph":[{"@id":"https://id.kb.se/TEMPID", ...`).
+Note that a temporary `@id` **must** be set in a few places in the document you send:
+
+* Temporary `@id` in Record
+* Temporary `mainEntity.@id` in Record
+* Temporary `@id` in Thing
+
+For example:
+
+```
+{"@graph":[{"@id":"https://id.kb.se/TEMPID","@type":"Record","mainEntity":{"@id":"https://id.kb.se/TEMPID#it"}},{"@id":"https://id.kb.se/TEMPID#it","@type":"Person","familyName":"Testing"}]}
+```
 
 A successful creation will get a `201 Created` response with a `Location`
 header containing the URI of the new record.

--- a/rest/API_sv.md
+++ b/rest/API_sv.md
@@ -88,8 +88,18 @@ API:et implementerar ett antal valideringssteg, till exempel för att förhindra
 att duplicerade beståndsposter skapas. Om någon validering misslyckas svarar
 API:et `400 Bad Request` med ett felmeddelande som förklarar problemet.
 
-Observera att ett tillfälligt `@id` **måste** specificeras i dokumentet du skickar
-(t.ex. `{"@graph":[{"@id":"https://id.kb.se/TEMPID", ...`).
+Observera att ett tillfälligt `@id` **måste** specificeras på flera ställen i
+dokumentet du skickar:
+
+* Tillfälligt `@id` i Record
+* Tillfälligt `mainEntity.@id` i Record
+* Tillfälligt `@id` i Thing ("saken")
+
+Till exempel:
+
+```
+{"@graph":[{"@id":"https://id.kb.se/TEMPID","@type":"Record","mainEntity":{"@id":"https://id.kb.se/TEMPID#it"}},{"@id":"https://id.kb.se/TEMPID#it","@type":"Person","familyName":"Testing"}]}
+```
 
 Ett lyckat anrop kommer resultera i ett `201 Created`-svar med den nya postens
 URI satt i `Location`-headern.

--- a/rest/API_sv.md
+++ b/rest/API_sv.md
@@ -88,6 +88,9 @@ API:et implementerar ett antal valideringssteg, till exempel för att förhindra
 att duplicerade beståndsposter skapas. Om någon validering misslyckas svarar
 API:et `400 Bad Request` med ett felmeddelande som förklarar problemet.
 
+Observera att ett tillfälligt `@id` **måste** specificeras i dokumentet du skickar
+(t.ex. `{"@graph":[{"@id":"https://id.kb.se/TEMPID", ...`).
+
 Ett lyckat anrop kommer resultera i ett `201 Created`-svar med den nya postens
 URI satt i `Location`-headern.
 

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -500,10 +500,26 @@ class Crud extends HttpServlet {
         Document newDoc = new Document(requestBody)
 
         if (!newDoc.getId()) {
-            log.debug("Temporary @id missing")
+            log.debug("Temporary @id missing in Record")
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
             sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Document is missing temporary @id in Record")
+            return
+        }
+
+        if (newDoc.getThingIdentifiers().isEmpty()) {
+            log.debug("Temporary mainEntity @id missing in Record")
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Document is missing temporary mainEntity.@id in Record")
+            return
+        }
+
+        if (!newDoc.data['@graph'][1] || !newDoc.data['@graph'][1]['@id']) {
+            log.debug("Temporary @id missing in Thing")
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Document is missing temporary @id in Thing")
             return
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -498,6 +498,15 @@ class Crud extends HttpServlet {
         // should we deny the others?
 
         Document newDoc = new Document(requestBody)
+
+        if (!newDoc.getId()) {
+            log.debug("Temporary @id missing")
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Document is missing temporary @id in Record")
+            return
+        }
+
         newDoc.normalizeUnicode()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         newDoc.setControlNumber(newDoc.getShortId())

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -523,6 +523,22 @@ class Crud extends HttpServlet {
             return
         }
 
+        if (newDoc.getThingIdentifiers().first() != newDoc.data['@graph'][1]['@id']) {
+            log.debug("mainEntity.@id not same as Thing @id")
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "The Record's temporary mainEntity.@id is not same as the Thing's temporary @id")
+            return
+        }
+
+        if (newDoc.getId() == newDoc.getThingIdentifiers().first()) {
+            log.debug("Record @id same as Thing @id")
+            failedRequests.labels("POST", request.getRequestURI(),
+                    HttpServletResponse.SC_BAD_REQUEST.toString()).inc()
+            sendError(response, HttpServletResponse.SC_BAD_REQUEST, "The Record's temporary @id can't be the same as the Thing's temporary mainEntity.@id")
+            return
+        }
+
         newDoc.normalizeUnicode()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         newDoc.setControlNumber(newDoc.getShortId())

--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -862,7 +862,7 @@ class CrudSpec extends Specification {
     }
 
     @Unroll
-    def "POST to / should return 400 Bad Request if @id is missing"() {
+    def "POST to / should return 400 Bad Request if @id is missing, record/thing @id are equivalent, or mainEntity.@id not same as thing @id"() {
         given:
         def is = GroovyMock(ServletInputStream.class)
         is.getBytes() >> {
@@ -929,6 +929,22 @@ class CrudSpec extends Specification {
                          "mainEntity" : ["@id": "some_temporary_thing_id"],
                          "contains"   : "some new data"],
                         ["@type"      : "Instance"]
+                ]],
+                // mainEntity.@id not equivalent to thing @id
+                ["@graph": [
+                        ["@type"   : "Record",
+                         "@id": "some_temporary_id",
+                         "mainEntity" : ["@id": "some_temporary_thing_id"],
+                         "contains": "some new data"],
+                        ["@id"     : "some_other_temporary_thing_id"]
+                ]],
+                // Record @id equivalent to thing @id
+                ["@graph": [
+                        ["@type"   : "Record",
+                         "@id": "some_temporary_id",
+                         "mainEntity" : ["@id": "some_temporary_id"],
+                         "contains": "some new data"],
+                        ["@id"     : "some_temporary_id"]
                 ]],
         ]
     }


### PR DESCRIPTION
Before:

```
curl --request POST \
   --url http://localhost:8180/ \
   --header 'Authorization: Bearer <TOKEN>' \
   --header 'Content-Type: application/ld+json' \
   --header 'XL-Active-Sigel: Utb1' \
   --data '{"@graph":[{"@iddddd":"https://id.kb.se/TEMPID","@type":"Record","mainEntity":{"@id":"https://id.kb.se/TEMPID#it"},"descriptionConventions":[{"@type":"DescriptionConventions","code":"rda"}],"descriptionLanguage":{"@id":"https://id.kb.se/language/swe"}},{"@id":"https://id.kb.se/TEMPID#it","@type":"Person","familyName":"Testing","givenName":"Just"}]}'

{"status_code":500,"status":"Server Error","message":null,"stackTrace":["java.lang.NullPointerException" ... etc...
```

After:
```
{"status_code":400,"status":"Bad Request","message":"Document is missing temporary @id in Record"}
```