### PR TITLE
Update expressionOf script

### DIFF
--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf-generic-titles.txt
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf-generic-titles.txt
@@ -1,0 +1,45 @@
+Lagar
+Annual report
+Psalmer
+Rapport
+Court and city register.
+Nyhetsbrev
+Sundsvallstidningen Norrland
+Newsletter
+Katalog
+Medlemsblad
+Occasional paper
+Report
+Information bulletin
+Quarterly economic review
+Information
+Psalter
+Publication
+QER
+Annonsbladet
+Old tenures.
+Annonsaktuellt
+Town and country directory.
+Anuario de migraciones
+Modern English short stories, second series
+Ordspråksboken
+Snorre Sturlasson
+Årsbok
+Aktuellt för alla
+Discussion paper
+English pilot
+Framåt
+Fäderneslandet
+Granta (Stockholm).
+Medlemsmatrikel
+Veckobladet
+Årsberättelse
+Approved estimates
+Assertiones
+Die Internationale
+Morgonbladet
+Profeterna
+Publications
+Skrifter
+Tiden
+Verksamhetsberättelse

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf-generic-titles.txt
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf-generic-titles.txt
@@ -1,45 +1,45 @@
-Lagar
-Annual report
-Psalmer
-Rapport
-Court and city register.
-Nyhetsbrev
-Sundsvallstidningen Norrland
-Newsletter
-Katalog
-Medlemsblad
-Occasional paper
-Report
-Information bulletin
-Quarterly economic review
-Information
-Psalter
-Publication
-QER
-Annonsbladet
-Old tenures.
-Annonsaktuellt
-Town and country directory.
-Anuario de migraciones
-Modern English short stories, second series
-Ordspråksboken
-Snorre Sturlasson
-Årsbok
 Aktuellt för alla
+Annonsaktuellt
+Annonsbladet
+Annual report
+Anuario de migraciones
+Approved estimates
+Assertiones
+Court and city register.
+Die Internationale
 Discussion paper
 English pilot
 Framåt
 Fäderneslandet
 Granta (Stockholm).
+Information
+Information bulletin
+Katalog
+Lagar
+Medlemsblad
 Medlemsmatrikel
-Veckobladet
-Årsberättelse
-Approved estimates
-Assertiones
-Die Internationale
+Modern English short stories, second series
 Morgonbladet
+Newsletter
+Nyhetsbrev
+Occasional paper
+Old tenures.
+Ordspråksboken
 Profeterna
+Psalmer
+Psalter
+Publication
 Publications
+QER
+Quarterly economic review
+Rapport
+Report
 Skrifter
+Snorre Sturlasson
+Sundsvallstidningen Norrland
 Tiden
+Town and country directory.
+Veckobladet
 Verksamhetsberättelse
+Årsberättelse
+Årsbok

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -499,7 +499,7 @@ Map substitutions() {
             'tyska (lågtyska)'                : 'lågtyska',
             'tyska (medelhögtyska)'           : 'medelhögtyska',
             'tyska (medellågtyska)'           : 'medellågtyska',
-            
+
             // Added in lxl-3547
             'polyglott'                       : 'flera språk',
             'pehlevi'                         : 'pahlavi',
@@ -508,9 +508,9 @@ Map substitutions() {
             'english (anglo-saxon)'           : 'fornengelska',
             'judetyska'                       : 'jiddisch',
             'italiensk'                       : 'italienska',
-            'german (middle high german)'     : 'medelhögtyska'
-            'skotsk-gaeliska' : 'skotsk gäliska'
-            
+            'german (middle high german)'     : 'medelhögtyska',
+            'skotsk-gaeliska'                 : 'skotsk gäliska'
+
             // Also seen
             // Fornnorska
             // Fornryska

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -324,6 +324,7 @@ class Norm {
         def t = normalize(title.findAll {it.key in TITLE_KEYS})
         
         // Some records have the language in the title e.g. "Tusen och en natt. Svenska" drop the language part
+        // These should normally already have been moved by moveLanguagesFromTitle()
         t.mainTitle?.with { String m ->
             def s = m.split(' ')
             if (s.last() in languageNames) {
@@ -421,6 +422,9 @@ boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
                 langs << group(i + 1)
             }
             langs = langs.grep().findAll{ it != title }.collect{ Unicode.trimNoise(it.toLowerCase()) }
+            if (!langs) {
+                return false
+            }
             def l = langs.collect{ ['@type': 'Language', 'label': it] }
             if (langs.any{ it in ambiguousLangNames }) {
                 l += whichLanguageVersion
@@ -432,12 +436,14 @@ boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
                 languageFromTitle.println("${work.hasTitle.mainTitle} --> $title $l")
                 work.hasTitle.mainTitle = title
                 work.languages = l
+                return true
             }
             else {
                 languageFromTitle.println("COULD NOT HANDLE: $work")
             }
         }
     }
+    return false
 }
 
 class AndLanguageLinker extends LanguageLinker {

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -362,7 +362,7 @@ private String titleStr(Map thing) {
 // Handle e.g. { "@type": "Language", "label": ["English & Tamil."] }
 private List mapBlankLanguages(List languages, List whichGreek = []) {
     if (languages.size() == 1 && languages[0].label) {
-        String label = languages[0].label.toLowerCase()
+        String label = asList(languages[0].label).first().toLowerCase()
         // to be able to map "Greek" to modern or classical Greek (LanguageLinker will use an existing linked sibling to decide when ambiguous) 
         boolean anyGreek = label.contains("grekiska") || label.contains("greek")
         List copy = new ArrayList(anyGreek ? languages + whichGreek : languages)

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -119,7 +119,7 @@ selectByIds(uniqueUnmatchedIds) { bib ->
     Map work = instance.instanceOf
     List<Map> expressionOf = asList(work.expressionOf)
 
-    if (!work || !expressionOf) {3
+    if (!work || !expressionOf) {
         return
     }
     

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -434,7 +434,7 @@ boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
             l = m.l
             if (l.size() == langs.size() && l.every {it['@id'] }) {
                 languageFromTitle.println("${work.hasTitle.mainTitle} --> $title $l")
-                work.hasTitle.mainTitle = title
+                work.hasTitle['mainTitle'] = title
                 work.languages = l
                 return true
             }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -271,11 +271,6 @@ private List asList(Object o) {
 }
 
 private Set lang(Map work) {
-    String mainTitle = asList(work['hasTitle'])?.first().mainTitle
-    if (mainTitle ==~ /^.*\.\s*\w+(&\s*\w+)?/) {
-        
-    }
-    
     (mapBlankLanguages(asList(work.language)) + mapBlankLanguages(asList(work.associatedLanguage))) as Set
 }
 

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -55,9 +55,6 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
         }
 
         if (e.language && (languageLabelToLanguages(asList(e.language)).toSorted() != asList(work.language).toSorted())) {
-            println(languageLabelToLanguages(asList(e.language)).toSorted())
-            println(asList(work.language).toSorted())
-            println()
             otherExpressionLanguage.println("${bib.doc.shortId} E: ${toString(e)} W: ${toString(work)}" )
             return
         }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -218,7 +218,7 @@ private Set<String> loadLanguageNames() {
 private String toString(Map work) {
     def keys = (Norm.TITLE_KEYS.collect {['hasTitle', 0] + it } + Norm.CMP_KEYS) 
     def props = keys.collect {getPathSafe(work, asList(it)) }
-    def langcode = lang(work).collect{ (it['@id'] ?: '').split('/').last() }
+    def langcode = lang(work).collect{ (it['@id'] ?: (it['label'] ?: '')).split('/').last() }
     def contribution = asList(work['primaryContribution']) + asList(getPrimaryContributionString(work))
     return (props + langcode + contribution).grep().join(' · ')
 }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -73,7 +73,7 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
 
         List whichOne = asList(work.language).findAll { it['@id'] in ambiguousLangIds }
         
-        if (moveLanguagesFromTitle(e, whichOne)) {
+        if (moveLanguagesFromTitle(bib.doc.shortId, e, whichOne)) {
             bib.scheduleSave()
         }
 
@@ -408,7 +408,7 @@ private List mapBlankLanguages(List languages, List whichLanguageVersion = []) {
     return languages
 }
 
-boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
+boolean moveLanguagesFromTitle(String id, Map work, List whichLanguageVersion = []) {
     (asList(work['hasTitle'])?.first().mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?: & | och | and )([^&]+)$/).with {
         if (matches()) {
             String title = group('title')
@@ -428,13 +428,13 @@ boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
             languageLinker.linkLanguages(m, 'l')
             l = m.l
             if (l.size() == langs.size() && l.every {it['@id'] }) {
-                languageFromTitle.println("${work.hasTitle.mainTitle} --> $title $l")
+                languageFromTitle.println("$id ${work.hasTitle.mainTitle} --> $title $l")
                 asList(work['hasTitle'])?.first().mainTitle = title
                 work.languages = l
                 return true
             }
             else {
-                languageFromTitle.println("COULD NOT HANDLE: $work")
+                languageFromTitle.println("COULD NOT HANDLE: $id $work")
             }
         }
     }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -218,7 +218,7 @@ private Set<String> loadLanguageNames() {
 private String toString(Map work) {
     def keys = (Norm.TITLE_KEYS.collect {['hasTitle', 0] + it } + Norm.CMP_KEYS) 
     def props = keys.collect {getPathSafe(work, asList(it)) }
-    def langcode = lang(work).collect{ (it['@id'] ?: (it['label'] ?: '')).split('/').last() }
+    def langcode = lang(work).collect{ (it['@id'] ?: asList((it['label'] ?: '')).first()).split('/').last() }
     def contribution = asList(work['primaryContribution']) + asList(getPrimaryContributionString(work))
     return (props + langcode + contribution).grep().join(' · ')
 }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -54,7 +54,7 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
             return
         }
 
-        if (e.language && (languageLabelToLanguages(asList(e.language)).toSorted() != asList(work.language).toSorted())) {
+        if (e.language && !asList(work.language).containsAll(mapBlankLanguages(asList(e.language)))) {
             otherExpressionLanguage.println("${bib.doc.shortId} E: ${toString(e)} W: ${toString(work)}" )
             return
         }
@@ -243,7 +243,7 @@ private List asList(Object o) {
 }
 
 private Set lang(Map work) {
-    (languageLabelToLanguages(asList(work.language)) + languageLabelToLanguages(asList(work.associatedLanguage))) as Set
+    (mapBlankLanguages(asList(work.language)) + mapBlankLanguages(asList(work.associatedLanguage))) as Set
 }
 
 private String getPrimaryContributionString(Map work) {
@@ -359,7 +359,7 @@ private String titleStr(Map thing) {
 }
 
 // Handle e.g. { "@type": "Language", "label": ["English & Tamil."] }
-private List languageLabelToLanguages(List languages) {
+private List mapBlankLanguages(List languages) {
     if (languages.size() == 1 && languages[0].label) {
         List copy = new ArrayList(languages)
         Map m = ['l': copy]

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -54,7 +54,8 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
             return
         }
 
-        if (e.language && !asList(work.language).containsAll(mapBlankLanguages(asList(e.language)))) {
+        List greek = asList(work.language).findAll { it['@id'] == 'https://id.kb.se/language/gre' || it['@id'] == 'https://id.kb.se/language/grc' }
+        if (e.language && !asList(work.language).containsAll(mapBlankLanguages(asList(e.language), greek))) {
             otherExpressionLanguage.println("${bib.doc.shortId} E: ${toString(e)} W: ${toString(work)}" )
             return
         }
@@ -359,9 +360,12 @@ private String titleStr(Map thing) {
 }
 
 // Handle e.g. { "@type": "Language", "label": ["English & Tamil."] }
-private List mapBlankLanguages(List languages) {
+private List mapBlankLanguages(List languages, List whichGreek = []) {
     if (languages.size() == 1 && languages[0].label) {
-        List copy = new ArrayList(languages)
+        String label = languages[0].label.toLowerCase()
+        // to be able to map "Greek" to modern or classical Greek (LanguageLinker will use an existing linked sibling to decide when ambiguous) 
+        boolean anyGreek = label.contains("grekiska") || label.contains("greek")
+        List copy = new ArrayList(anyGreek ? languages + whichGreek : languages)
         Map m = ['l': copy]
         languageLinker.linkLanguages(m, 'l')
         return m['l']

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -9,6 +9,7 @@
  * 
  * TODO: decide which non-linkable expressionOf should be extracted to new works and linked, i.e. how many identical expressionOf have to exist 
  */
+
 import org.apache.commons.lang3.StringUtils
 import whelk.util.Unicode
 import whelk.Document
@@ -58,6 +59,12 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
             return
         }
 
+        // languages1 must contain all languages in languages2
+        // Work
+        //  languages1
+        //  expressionOf
+        //    Work
+        //      languages2
         List whichOne = asList(work.language).findAll { it['@id'] in ambiguousLangIds }
         if (e.language && !asList(work.language).containsAll(mapBlankLanguages(asList(e.language), whichOne))) {
             otherExpressionLanguage.println("${bib.doc.shortId} E: ${toString(e)} W: ${toString(work)}" )
@@ -248,6 +255,11 @@ private List asList(Object o) {
 }
 
 private Set lang(Map work) {
+    String mainTitle = asList(work['hasTitle'])?.first().mainTitle
+    if (mainTitle ==~ /^.*\.\s*\w+(&\s*\w+)?/) {
+        
+    }
+    
     (mapBlankLanguages(asList(work.language)) + mapBlankLanguages(asList(work.associatedLanguage))) as Set
 }
 
@@ -300,6 +312,9 @@ class Norm {
             def s = m.split(' ')
             if (s.last() in languageNames) {
                 t.mainTitle = normalize(s.dropRight(1).join(' '))
+            }
+            if (s.size() > 3 && s[-1] in languageNames && s[-2] == "&" && s[-3] in languageNames) {
+                t.mainTitle = normalize(s.dropRight(3).join(' '))
             }
         }
         

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -414,7 +414,7 @@ private List mapBlankLanguages(List languages, List whichLanguageVersion = []) {
 }
 
 boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
-    (work.hasTitle?.mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?:&|och|and)([^&]+)$/).with {
+    (asList(work['hasTitle'])?.first().mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?:&|och|and)([^&]+)$/).with {
         if (matches()) {
             String title = group('title')
             List<String> langs = []
@@ -434,7 +434,7 @@ boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
             l = m.l
             if (l.size() == langs.size() && l.every {it['@id'] }) {
                 languageFromTitle.println("${work.hasTitle.mainTitle} --> $title $l")
-                work.hasTitle['mainTitle'] = title
+                asList(work['hasTitle'])?.first().mainTitle = title
                 work.languages = l
                 return true
             }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -409,7 +409,7 @@ private List mapBlankLanguages(List languages, List whichLanguageVersion = []) {
 }
 
 boolean moveLanguagesFromTitle(Map work, List whichLanguageVersion = []) {
-    (asList(work['hasTitle'])?.first().mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?:&|och|and)([^&]+)$/).with {
+    (asList(work['hasTitle'])?.first().mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?: & | och | and )([^&]+)$/).with {
         if (matches()) {
             String title = group('title')
             List<String> langs = []
@@ -452,8 +452,8 @@ class AndLanguageLinker extends LanguageLinker {
             return labelOrCode
         }
 
-        if (labelOrCode ==~ /^(.*,)*.*(&|och|and).*/) {
-            return labelOrCode.split(",|&|och|and") as List
+        if (labelOrCode ==~ /^(.*,)*.*( & | och | and ).*/) {
+            return labelOrCode.split(",| & | och | and ") as List
         }
     }
 }
@@ -500,7 +500,29 @@ Map substitutions() {
             'tyska (medelhögtyska)'           : 'medelhögtyska',
             'tyska (medellågtyska)'           : 'medellågtyska',
             
-            'polyglott'                       : 'flera språk'
+            // Added in lxl-3547
+            'polyglott'                       : 'flera språk',
+            'pehlevi'                         : 'pahlavi',
+            'kanbodjanska (khmer)'            : 'kambodjanska',
+            'english (middle english)'        : 'medelengelska',
+            'english (anglo-saxon)'           : 'fornengelska',
+            'judetyska'                       : 'jiddisch',
+            'italiensk'                       : 'italienska',
+            'german (middle high german)'     : 'medelhögtyska'
+            'skotsk-gaeliska' : 'skotsk gäliska'
+            
+            // Also seen
+            // Fornnorska
+            // Fornryska
+            // Irish (Old Irish)
+            // Fornspanska
+            // Medellågtyska
+            // Luchazi
+            // Egyptian
+            // anglo-norman
+            // spanska (medelspanska)
+            // vepsiska
+            // gäliska
     ]
 }
 

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -168,7 +168,7 @@ notLinkedExpr.each {key, ids ->
         sameExpr.println(ids.size() + " " + toString(key))
     }
     else {
-        if (Norm.normalize(asList(work['hasTitle'])?.first().mainTitle) in genericTitles) {
+        if (Norm.normalize(asList(key['hasTitle'])?.first().mainTitle) in genericTitles) {
             sameExpr.println(ids.size() + " " + toString(key) + " [GENERIC TITLE]")
             unmatchedIds.add(ids.poll())
         }

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -432,6 +432,8 @@ Map substitutions() {
             'tyska (lågtyska)'                : 'lågtyska',
             'tyska (medelhögtyska)'           : 'medelhögtyska',
             'tyska (medellågtyska)'           : 'medellågtyska',
+            
+            'polyglott'                       : 'flera språk'
     ]
 }
 

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -509,7 +509,8 @@ Map substitutions() {
             'judetyska'                       : 'jiddisch',
             'italiensk'                       : 'italienska',
             'german (middle high german)'     : 'medelhögtyska',
-            'skotsk-gaeliska'                 : 'skotsk gäliska'
+            'skotsk-gaeliska'                 : 'skotsk gäliska',
+            'nubiska'                         : 'nubiska språk'
 
             // Also seen
             // Fornnorska

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -77,11 +77,11 @@ selectBySqlWhere("data#>>'{@graph,1,instanceOf,expressionOf}' is not null") { bi
             bib.scheduleSave()
         }
 
-        // languages must contain all languages in expressionOf.languages, otherwise abort
+        // language must contain all languages in expressionOf.language, otherwise abort
         // Work
-        //  languages
+        //  language
         //  expressionOf
-        //    languages
+        //    language
         if (e.language && !asList(work.language).containsAll(mapBlankLanguages(asList(e.language), whichOne))) {
             otherExpressionLanguage.println("${bib.doc.shortId} E: ${toString(e)} W: ${toString(work)}" )
             return
@@ -408,7 +408,10 @@ private List mapBlankLanguages(List languages, List whichLanguageVersion = []) {
     return languages
 }
 
+// A bit messy
+// mainTitle: "Haggada. Jiddisch & Hebreiska" --> mainTitle: Haggada, language: [[@id:https://id.kb.se/language/yid], [@id:https://id.kb.se/language/heb]]
 boolean moveLanguagesFromTitle(String id, Map work, List whichLanguageVersion = []) {
+    boolean changed = false
     (asList(work['hasTitle'])?.first().mainTitle =~ /^(?<title>.*)\.\s*(?:(.+),|&)?([^&]+)(?: & | och | and )([^&]+)$/).with {
         if (matches()) {
             String title = group('title')
@@ -430,15 +433,15 @@ boolean moveLanguagesFromTitle(String id, Map work, List whichLanguageVersion = 
             if (l.size() == langs.size() && l.every {it['@id'] }) {
                 languageFromTitle.println("$id ${work.hasTitle.mainTitle} --> $title $l")
                 asList(work['hasTitle'])?.first().mainTitle = title
-                work.languages = l
-                return true
+                work.language = l
+                changed = true
             }
             else {
                 languageFromTitle.println("COULD NOT HANDLE: $id $work")
             }
         }
     }
-    return false
+    return changed
 }
 
 class AndLanguageLinker extends LanguageLinker {

--- a/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
+++ b/whelktool/scripts/cleanups/2021/04/lxl-3547-link-expressionOf.groovy
@@ -137,9 +137,12 @@ notLinkedExpr.each {key, ids ->
     ids.each {
         incrementStats('same expr', toString(key), it)
     }
-    sameExpr.println(ids.size() + " " + toString(key))
+    
     if (ids.size() == 1) {
         uniqueUnmatchedIds.add(ids.poll())
+    }
+    else {
+        sameExpr.println(ids.size() + " " + toString(key))
     }
 }
 


### PR DESCRIPTION
Updates:
* Identical expressionOf that occur in multiple records are extracted into new "uniformWorkTitle" works. 
* Languages in expressionOf.hasTitle.mainTitle strings are moved to expressionOf.language
* Handle blank languages e.g. `{ "@type": "Language", "label": ["English & Tamil."] }`
* It's ok if instanceOf.expressionOf.language is a subset of instanceOf.language 