### PR TITLE
Optionally exclude hold records when using copywhelk

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -104,8 +104,8 @@ class ImporterMain {
      * The additional_types argument should be a comma separated list of types to include. Like so:
      * Person,GenreForm
      */
-    @Command(args='SOURCE_PROPERTIES RECORD_ID_FILE [ADDITIONAL_TYPES]')
-    void copywhelk(String sourcePropsFile, String recordsFile, additionalTypes=null) {
+    @Command(args='SOURCE_PROPERTIES RECORD_ID_FILE [ADDITIONAL_TYPES [--exclude-items]]')
+    void copywhelk(String sourcePropsFile, String recordsFile, additionalTypes=null, String excludeItems=null) {
         def sourceProps = new Properties()
         new File(sourcePropsFile).withInputStream { it
             sourceProps.load(it)
@@ -115,7 +115,8 @@ class ImporterMain {
         def recordIds = new File(recordsFile).collect {
             it.split(/\t/)[0]
         }
-        def copier = new WhelkCopier(source, dest, recordIds, additionalTypes)
+        boolean shouldExcludeItems = excludeItems && excludeItems == '--exclude-items'
+        def copier = new WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems)
         copier.run()
     }
 

--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -14,16 +14,18 @@ class WhelkCopier {
     Whelk dest
     List recordIds
     String additionalTypes
+    boolean shouldExcludeItems
     ThreadPool threadPool = new ThreadPool(Runtime.getRuntime().availableProcessors())
     List<Document> saveQueue = []
 
     private int copied = 0
 
-    WhelkCopier(source, dest, recordIds, additionalTypes) {
+    WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems) {
         this.source = source
         this.dest = dest
         this.recordIds = recordIds
         this.additionalTypes = additionalTypes
+        this.shouldExcludeItems = shouldExcludeItems
 
         dest.storage.doVerifyDocumentIdRetention = false
     }
@@ -31,7 +33,7 @@ class WhelkCopier {
     void run() {
         TreeSet<String> alreadyImportedIDs = new TreeSet<>()
 
-        if (additionalTypes != null) {
+        if (additionalTypes) {
             String[] types = additionalTypes.split(",")
             for (doc in selectBySqlWhere("data#>>'{@graph,1,@type}' in (\n" +
                     "'" + types.join("','") + "'" +
@@ -72,7 +74,13 @@ class WhelkCopier {
                 queueSave(doc)
             }
             // links to this:
-            for (revDoc in selectBySqlWhere("""id in (select id from lddb__dependencies where dependsonid = '${id}')""")) {
+            def linksToThisWhere
+            if (shouldExcludeItems) {
+                linksToThisWhere = "id in (select id from lddb__dependencies where dependsonid = '${id}' and relation != 'itemOf')"
+            } else {
+                linksToThisWhere = "id in (select id from lddb__dependencies where dependsonid = '${id}')"
+            }
+            for (revDoc in selectBySqlWhere(linksToThisWhere)) {
                 if (revDoc.deleted) continue
                 revDoc.baseUri = source.baseUri
                 if (!alreadyImportedIDs.contains(revDoc.shortId)) {


### PR DESCRIPTION
For e.g. working with works it'd be nice to be able to copy all instance records without dragging 50M+ hold (item) records along. This simply adds `--exclude-items` (default false) to `copywhelk` to make that possible. Related to LXL-3613.