### PR TITLE
Feature/db connection cleanup

### DIFF
--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -14,6 +14,7 @@ import se.kb.libris.utils.isbn.IsbnParser;
 import whelk.Document;
 import whelk.IdGenerator;
 import whelk.Whelk;
+import whelk.component.PostgreSQLComponent;
 import whelk.converter.MarcJSONConverter;
 import whelk.converter.marc.MarcFrameConverter;
 import whelk.exception.TooHighEncodingLevelException;
@@ -474,8 +475,9 @@ class XL
             librisId = Document.getBASE_URI().toString() + librisId;
         }
 
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getOnId_ps(connection, librisId);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getOnId_ps(m_whelk.getStorage().getMyConnection(), librisId);
             ResultSet resultSet = statement.executeQuery())
         {
             return collectIDs(resultSet);
@@ -490,8 +492,9 @@ class XL
         {
             String systemNumber = DigId.grep035a( (Datafield) field );
 
-            try(Connection connection = m_whelk.getStorage().getConnection();
-                PreparedStatement statement = getOnSystemNumber_ps(connection, systemNumber);
+            try(PostgreSQLComponent.ConnectionContext ignored =
+                        new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+                PreparedStatement statement = getOnSystemNumber_ps(m_whelk.getStorage().getMyConnection(), systemNumber);
                 ResultSet resultSet = statement.executeQuery())
             {
                 results.addAll( collectIDs(resultSet) );
@@ -513,8 +516,9 @@ class XL
                 {
                     String incomingEan = subfield.getData();
 
-                    try (Connection connection = m_whelk.getStorage().getConnection();
-                         PreparedStatement statement = getOnEAN_ps(connection, incomingEan);
+                    try (PostgreSQLComponent.ConnectionContext ignored =
+                                 new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+                         PreparedStatement statement = getOnEAN_ps(m_whelk.getStorage().getMyConnection(), incomingEan);
                          ResultSet resultSet = statement.executeQuery())
                     {
                         results.addAll(collectIDs(resultSet));
@@ -541,8 +545,9 @@ class XL
                 {
                     String incomingUri = subfield.getData();
 
-                    try (Connection connection = m_whelk.getStorage().getConnection();
-                         PreparedStatement statement = getOnURI_ps(connection, incomingUri);
+                    try (PostgreSQLComponent.ConnectionContext ignored =
+                                 new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+                         PreparedStatement statement = getOnURI_ps(m_whelk.getStorage().getMyConnection(), incomingUri);
                          ResultSet resultSet = statement.executeQuery())
                     {
                         results.addAll(collectIDs(resultSet));
@@ -569,8 +574,9 @@ class XL
                 {
                     String incomingUrn = subfield.getData();
 
-                    try (Connection connection = m_whelk.getStorage().getConnection();
-                         PreparedStatement statement = getOnURN_ps(connection, incomingUrn);
+                    try (PostgreSQLComponent.ConnectionContext ignored =
+                                 new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+                         PreparedStatement statement = getOnURN_ps(m_whelk.getStorage().getMyConnection(), incomingUrn);
                          ResultSet resultSet = statement.executeQuery())
                     {
                         results.addAll(collectIDs(resultSet));
@@ -590,8 +596,9 @@ class XL
 
         List<String> duplicateIDs = new ArrayList<>();
 
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getPreparedStatement.apply(connection, isbn);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getPreparedStatement.apply(m_whelk.getStorage().getMyConnection(), isbn);
             ResultSet resultSet = statement.executeQuery())
         {
             duplicateIDs.addAll( collectIDs(resultSet) );
@@ -604,8 +611,9 @@ class XL
         int otherType = typedIsbn.getType() == Isbn.ISBN10 ? Isbn.ISBN13 : Isbn.ISBN10;
 
         String numericIsbn = typedIsbn.toString(hyphens);
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getPreparedStatement.apply(connection, numericIsbn);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getPreparedStatement.apply(m_whelk.getStorage().getMyConnection(), numericIsbn);
             ResultSet resultSet = statement.executeQuery())
         {
             duplicateIDs.addAll( collectIDs(resultSet) );
@@ -620,8 +628,9 @@ class XL
             return duplicateIDs;
         }
         numericIsbn = typedIsbn.toString(hyphens);
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getPreparedStatement.apply(connection, numericIsbn);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getPreparedStatement.apply(m_whelk.getStorage().getMyConnection(), numericIsbn);
             ResultSet resultSet = statement.executeQuery())
         {
             duplicateIDs.addAll( collectIDs(resultSet) );
@@ -636,8 +645,9 @@ class XL
         if (issn == null)
             return new ArrayList<>();
 
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getOnIssn_ps(connection, issn);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getOnIssn_ps(m_whelk.getStorage().getMyConnection(), issn);
             ResultSet resultSet = statement.executeQuery())
         {
             return collectIDs(resultSet);
@@ -650,8 +660,9 @@ class XL
         if (issn == null)
             return new ArrayList<>();
 
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getOnIssnHidden_ps(connection, issn);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getOnIssnHidden_ps(m_whelk.getStorage().getMyConnection(), issn);
             ResultSet resultSet = statement.executeQuery())
         {
             return collectIDs(resultSet);
@@ -669,8 +680,9 @@ class XL
         String sigel = df.getSubfields("b").get(0).getData();
         String library = LegacyIntegrationTools.legacySigelToUri(sigel);
 
-        try(Connection connection = m_whelk.getStorage().getConnection();
-            PreparedStatement statement = getOnHeldByHoldingFor_ps(connection, library, relatedWithBibResourceId);
+        try(PostgreSQLComponent.ConnectionContext ignored =
+                    new PostgreSQLComponent.ConnectionContext(m_whelk.getStorage().connectionContextTL);
+            PreparedStatement statement = getOnHeldByHoldingFor_ps(m_whelk.getStorage().getMyConnection(), library, relatedWithBibResourceId);
             ResultSet resultSet = statement.executeQuery())
         {
             return collectIDs(resultSet);

--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -72,12 +72,14 @@ class WhelkCopier {
                 queueSave(doc)
             }
             // links to this:
-            for (revDoc in selectBySqlWhere("""id in (select id from lddb__dependencies where dependsonid = '${id}')""")) {
-                if (revDoc.deleted) continue
-                revDoc.baseUri = source.baseUri
-                if (!alreadyImportedIDs.contains(revDoc.shortId)) {
-                    alreadyImportedIDs.add(revDoc.shortId)
-                    queueSave(revDoc)
+            source.storage.withDbConnection {
+                for (revDoc in selectBySqlWhere("""id in (select id from lddb__dependencies where dependsonid = '${id}')""")) {
+                    if (revDoc.deleted) continue
+                    revDoc.baseUri = source.baseUri
+                    if (!alreadyImportedIDs.contains(revDoc.shortId)) {
+                        alreadyImportedIDs.add(revDoc.shortId)
+                        queueSave(revDoc)
+                    }
                 }
             }
         }
@@ -94,7 +96,7 @@ class WhelkCopier {
             FROM lddb
             WHERE $whereClause
             """
-        def conn = source.storage.getConnection()
+        def conn = source.storage.getMyConnection()
         conn.setAutoCommit(false)
         def stmt = conn.prepareStatement(query)
         stmt.setFetchSize(DEFAULT_FETCH_SIZE)

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1552,42 +1552,40 @@ class PostgreSQLComponent {
      */
     boolean sparqlQueueTake(QueueHandler reader, int num, DataSource connectionPool) {
         Connection connection = null
-        return withDbConnection {
-            // The queue contains document ids.
-            // Items (rows) are locked and then finally removed from the queue when we commit the transaction.
-            // If the handler fails on any item, the transaction is cancelled and all items remain in the queue.
-            // SKIP LOCKED in the query guarantees that we will take the first <num> unlocked rows.
-            //
-            // Lock the actual documents while the reader is working on them. Otherwise two readers could end up
-            // working on two different versions of the same document concurrently.
-            // (T1 writes A, R1 starts working on A, T2 writes A', R2 starts working on A' => race between R1 and R2)
-            // Take locks in same order as lddb writers to avoid deadlocks.
-            connection = getMyConnection()
-            connection.setAutoCommit(false)
-            def ids = sparqlQueueTakeIds(num, connection)
+        // The queue contains document ids.
+        // Items (rows) are locked and then finally removed from the queue when we commit the transaction.
+        // If the handler fails on any item, the transaction is cancelled and all items remain in the queue.
+        // SKIP LOCKED in the query guarantees that we will take the first <num> unlocked rows.
+        //
+        // Lock the actual documents while the reader is working on them. Otherwise two readers could end up
+        // working on two different versions of the same document concurrently.
+        // (T1 writes A, R1 starts working on A, T2 writes A', R2 starts working on A' => race between R1 and R2)
+        // Take locks in same order as lddb writers to avoid deadlocks.
+        connection = connectionPool.getConnection()
+        connection.setAutoCommit(false)
+        def ids = sparqlQueueTakeIds(num, connection)
 
-            boolean anyReQueued = false
-            for (String id : ids.sort()) {
-                try {
-                    Document doc = lockAndLoad(id, connection)
-                    def result = reader.handle(doc)
-                    if (result == QueueHandler.Result.FAIL_REQUEUE) {
-                        sparqlQueueAdd(id, connection)
-                        anyReQueued = true
-                    }
-                    else if (result == QueueHandler.Result.FAIL_RETRY) {
-                        connection.rollback()
-                        return false
-                    }
+        boolean anyReQueued = false
+        for (String id : ids.sort()) {
+            try {
+                Document doc = lockAndLoad(id, connection)
+                def result = reader.handle(doc)
+                if (result == QueueHandler.Result.FAIL_REQUEUE) {
+                    sparqlQueueAdd(id, connection)
+                    anyReQueued = true
                 }
-                catch (DocumentNotFoundException e) {
-                    log.warn("sparqlQueueTake: document with id $id does not exist: $e")
+                else if (result == QueueHandler.Result.FAIL_RETRY) {
+                    connection.rollback()
+                    return false
                 }
             }
-
-            connection.commit()
-            return !ids.isEmpty() && !anyReQueued
+            catch (DocumentNotFoundException e) {
+                log.warn("sparqlQueueTake: document with id $id does not exist: $e")
+            }
         }
+
+        connection.commit()
+        return !ids.isEmpty() && !anyReQueued
     }
 
     private Collection<String> sparqlQueueTakeIds(int num, Connection connection) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2536,8 +2536,8 @@ class PostgreSQLComponent {
         return c.connection
     }
 
-    public <T> T withDbConnection(Runnable runnable) {
-        Preconditions.checkNotNull(runnable)
+    public <T> T withDbConnection(Closure closure) {
+        Preconditions.checkNotNull(closure)
         try {
             ConnectionContext c = connectionContextTL.get()
             if (!c) {
@@ -2547,7 +2547,7 @@ class PostgreSQLComponent {
                 c.level++
             }
 
-            runnable.run()
+            return (T) closure.call()
         }
         finally {
             ConnectionContext c = connectionContextTL.get()

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -587,7 +587,7 @@ class PostgreSQLComponent {
         Connection connection = null
         PreparedStatement collectionStatement = null
         ResultSet collectionResults = null
-        return withDbConnection {
+        withDbConnection {
             try {
                 connection = getMyConnection()
                 collectionStatement = connection.prepareStatement(LOAD_COLLECTIONS)

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -37,7 +37,7 @@ class LinkFinder {
     }
 
     List<URI> findLinks(List<Map> entities, List<String> recordIds) {
-        return postgres.withDbConnection {
+        return postgres.withDbConnection { notIt -> // Otherwise compliler error with: The current scope already contains a variable of the name it
             if(recordIds.any() && entities.any()) {
                 log.debug "Finding links for ${entities.size()} entities and ${recordIds.size()} record Ids"
 

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -37,17 +37,16 @@ class LinkFinder {
     }
 
     List<URI> findLinks(List<Map> entities, List<String> recordIds) {
-        if(recordIds.any() && entities.any()) {
-            log.debug "Finding links for ${entities.size()} entities and ${recordIds.size()} record Ids"
+        return postgres.withDbConnection {
+            if(recordIds.any() && entities.any()) {
+                log.debug "Finding links for ${entities.size()} entities and ${recordIds.size()} record Ids"
 
-            def paramsQuery = ENTITY_QUERY.replace('€', recordIds.collect { it -> '?' }.join(','))
-            def connection = postgres.getConnection()
-            try {
+                def paramsQuery = ENTITY_QUERY.replace('€', recordIds.collect { it -> '?' }.join(','))
+                def connection = postgres.getMyConnection()
+
                 PreparedStatement stmt = connection.prepareStatement(paramsQuery)
 
                 def foundLinks = entities.collect { entity ->
-                    //log.trace "Trying to match entity ${entity.inspect()}"
-
                     int i = 1
                     stmt.setObject(i, mapper.writeValueAsString([entity]), java.sql.Types.OTHER)
                     recordIds.each { recordId ->
@@ -69,13 +68,10 @@ class LinkFinder {
                 log.debug "Found ${foundLinks.count { it -> it }} links to replace in entities"
                 return foundLinks
             }
-            finally {
-                connection.close()
+            else{
+                log.debug "missing arguments. No linkfinding will be performed."
+                return [null]
             }
-        }
-        else{
-            log.debug "missing arguments. No linkfinding will be performed."
-            return [null]
         }
     }
 

--- a/whelk-core/src/test/groovy/PostgreSQLComponentSpec.groovy
+++ b/whelk-core/src/test/groovy/PostgreSQLComponentSpec.groovy
@@ -29,7 +29,7 @@ class PostgreSQLComponentSpec extends Specification {
         stmt.executeQuery() >> { result }
         storage = new PostgreSQLComponent((String) null) {
             @Override
-            Connection getConnection() {
+            Connection getMyConnection() {
                 log.info("Getting connection ...")
                 conn
             }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -173,19 +173,20 @@ class WhelkTool {
             FROM lddb__identifiers
             WHERE iri IN ($uriItems)
             """
-        def conn = whelk.storage.getConnection()
-        def stmt
-        def rs
-        try {
-            stmt = conn.prepareStatement(query)
-            rs = stmt.executeQuery()
-            while (rs.next()) {
-                uriIdMap[rs.getString("iri")] = rs.getString("id")
+        whelk.storage.withDbConnection {
+            def conn = whelk.storage.getMyConnection()
+            def stmt
+            def rs
+            try {
+                stmt = conn.prepareStatement(query)
+                rs = stmt.executeQuery()
+                while (rs.next()) {
+                    uriIdMap[rs.getString("iri")] = rs.getString("id")
+                }
+            } finally {
+                try { rs?.close() } catch (SQLException e) {}
+                try { stmt?.close() } catch (SQLException e) {}
             }
-        } finally {
-            try { rs?.close() } catch (SQLException e) {}
-            try { stmt?.close() } catch (SQLException e) {}
-            conn.close()
         }
         return uriIdMap
     }


### PR DESCRIPTION
Switch from using getConnection() to using:

withDbConnection() {
  getMyConnection()
}

Ultimately the point is that withDbConnection blocks can be nested, but will still always return only that one connection you're already holding. This way, there is no risk of accidentally taking a second connection, which would eventually result in a deadlock when connections start to run out (you can't release the one you have until you get one more).