### PR TITLE
Feature/fix prepared statement leaks

### DIFF
--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -70,17 +70,19 @@ class WhelkCopier {
             doc.baseUri = source.baseUri
 
             // this links to:
-            for (relDoc in selectBySqlWhere("""id in (select dependsonid from lddb__dependencies where id = '${id}')""")) {
-                if (relDoc.deleted) continue
-                relDoc.baseUri = source.baseUri
-                if (!alreadyImportedIDs.contains(relDoc.shortId)) {
-                    alreadyImportedIDs.add(relDoc.shortId)
-                    queueSave(relDoc)
+            source.storage.withDbConnection {
+                for (relDoc in selectBySqlWhere("""id in (select dependsonid from lddb__dependencies where id = '${id}')""")) {
+                    if (relDoc.deleted) continue
+                    relDoc.baseUri = source.baseUri
+                    if (!alreadyImportedIDs.contains(relDoc.shortId)) {
+                        alreadyImportedIDs.add(relDoc.shortId)
+                        queueSave(relDoc)
+                    }
                 }
-            }
-            if (!alreadyImportedIDs.contains(doc.shortId)) {
-                alreadyImportedIDs.add(doc.shortId)
-                queueSave(doc)
+                if (!alreadyImportedIDs.contains(doc.shortId)) {
+                    alreadyImportedIDs.add(doc.shortId)
+                    queueSave(doc)
+                }
             }
             // links to this:
             def linksToThisWhere

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -720,20 +720,21 @@ class PostgreSQLComponent {
 
     void reDenormalize() {
         log.info("Re-denormalizing data.")
-        withDbConnection {
-            Connection connection = getMyConnection()
-            boolean leaveCacheAlone = true
+        Connection connection = getOuterConnection()
+        connection.setAutoCommit(false)
+        boolean leaveCacheAlone = true
 
-            long count = 0
-            for (Document doc : loadAll(null, false, null, null)) {
-                refreshDerivativeTables(doc, connection, doc.getDeleted(), leaveCacheAlone)
+        long count = 0
+        for (Document doc : loadAll(null, false, null, null)) {
+            refreshDerivativeTables(doc, connection, doc.getDeleted(), leaveCacheAlone)
 
-                ++count
-                if (count % 500 == 0)
-                    log.info("$count records re-denormalized")
-            }
-            clearEmbellishedCache(connection)
+            ++count
+            if (count % 500 == 0)
+                log.info("$count records re-denormalized")
         }
+        clearEmbellishedCache(connection)
+        connection.commit()
+        connection.close()
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1371,9 +1371,13 @@ class PostgreSQLComponent {
 
     private void saveIdentifiers(Document doc, Connection connection, boolean deleted, boolean removeOnly = false) {
         PreparedStatement removeIdentifiers = connection.prepareStatement(DELETE_IDENTIFIERS)
-        removeIdentifiers.setString(1, doc.getShortId())
-        int numRemoved = removeIdentifiers.executeUpdate()
-        log.debug("Removed $numRemoved identifiers for id ${doc.getShortId()}")
+        try {
+            removeIdentifiers.setString(1, doc.getShortId())
+            int numRemoved = removeIdentifiers.executeUpdate()
+            log.debug("Removed $numRemoved identifiers for id ${doc.getShortId()}")
+        } finally {
+            close(removeIdentifiers)
+        }
 
         if (removeOnly)
             return
@@ -1411,6 +1415,8 @@ class PostgreSQLComponent {
         } catch (BatchUpdateException bue) {
             log.error("Failed saving identifiers for ${doc.getShortId()}")
             throw bue.getNextException()
+        } finally {
+            close(altIdInsert)
         }
     }
 


### PR DESCRIPTION
Using fab's `app.whelk.import_work_example_data` with a dataset much larger (~13M docs) than the "usual", small one resulted in Postgres eventually failing with an out of memory error during the `reDenormalize` step, after about 2027500 records processed, on a machine with 48 GB RAM. Suspicious:

```
  CacheMemoryContext: 1040384 total in 7 blocks; 406960 free (20 chunks); 633424 used
...
    2027750 more child contexts containing 20763196416 total in 10138316 blocks; 10235581288 free (2027632 chunks); 10527615128 used
```

`saveIdentifiers()` in `PostgreSQLComponent` wasn't closing its `PreparedStatement` resources, which meant that they would only disappear when the connection was closed, so at the time of error there were a couple of million of those (instead of 5 or so). Fixed that. Also:

- Added a missing `withDbConnection { ... }` to `WhelkCopier`
- Made `reDenormalize()` use `getOuterConnection()` instead of `withDbConnection`, since `loadAll()` uses the former which can't be inside the latter. Could of course make `loadAll()` use `withDbConnection`, but perhaps that's not desirable. In any case, `reDenormalize()` is _only_ used by `WhelkCopier`, so I don't think it matters much.
- Disabled autocommit in `reDenormalize()`, which should speed things up a bit