### PR TITLE
Do not accept hold imports of nonregistrant sigels.

### DIFF
--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -169,7 +169,20 @@ class XL
 
         Document rdfDoc = convertToRDF(marcRecord, incomingId);
         if (collection.equals("hold"))
+        {
+            String libraryUri = rdfDoc.getHeldBy();
+            String librarySystemId = m_whelk.getStorage().getSystemIdByIri(libraryUri);
+            if (librarySystemId == null)
+            {
+                return null;
+            }
+            Document libraryDoc = m_whelk.getDocument(librarySystemId);
+            if (!libraryDoc.libraryIsRegistrant())
+            {
+                return null;
+            }
             rdfDoc.setHoldingFor(relatedWithBibResourceId);
+        }
 
         String encodingLevel = rdfDoc.getEncodingLevel();
         if (encodingLevel == null || (

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -68,6 +68,7 @@ class Document {
     static final List generationDatePath = ["@graph", 0, "generationDate"]
     static final List descriptionCreatorPath = ["@graph", 0, "descriptionCreator", "@id"]
     static final List descriptionLastModifierPath = ["@graph", 0, "descriptionLastModifier", "@id"]
+    static final List categoryPath = ["@graph", 1, "category"]
 
     URI baseUri = BASE_URI
 
@@ -517,6 +518,20 @@ class Document {
         if (type != null)
             return type
         return null
+    }
+
+    public boolean libraryIsRegistrant() {
+        Object catObj = get(categoryPath)
+        if (catObj == null)
+            return false
+        List categories
+        if (catObj instanceof List)
+            categories = catObj
+        else
+            categories = [catObj]
+        return categories.any {
+            it["@id"] == "http://id.kb.se/bibdb/registrant"
+        }
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -530,7 +530,7 @@ class Document {
         else
             categories = [catObj]
         return categories.any {
-            it["@id"] == "http://id.kb.se/bibdb/registrant"
+            it["@id"] == "http://id.kb.se/term/bibdb/Registrant"
         }
     }
 


### PR DESCRIPTION
The registrant information is (periodically) synced with (from)
bibdb, and will now decide if the incoming record is allowed
or not.

This blocks such imports specifically in the batch import.
Other mechanisms prevent this from happening through the normal APIs.

Existing bad holds still need to be cleaned up.