### PR TITLE
Consistent version handling in load / loadDocumentByMainId

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -173,14 +173,16 @@ public class ProfileExport
         {
             List<Document> versions = m_whelk.getStorage().loadAllVersions(id);
 
-            // The 'versions' list is sorted, with the most recent version first.
+            // The 'versions' list is sorted, with the oldest version first.
+            // We go through it in reverse (i.e. starting with the newest version).
             // 1. We iterate through the list, skipping (continue) until we've found a
             // version inside the update interval.
             // 2. We keep iterating over versions and check if we're still inside the
             // interval _after_ each iteration, which means we will pass (export) all
             // versions inside the interval and exactly one version "before" the interval.
-            for (Document version : versions)
+            for (int i = versions.size()-1; i > -1; --i)
             {
+                Document version = versions.get(i);
                 String itemOf = version.getHoldingFor();
                 Instant modified = ZonedDateTime.parse(version.getModified()).toInstant();
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -150,14 +150,14 @@ class PostgreSQLComponent {
             SELECT id, data, deleted, created, modified, changedBy, changedIn 
             FROM lddb__versions
             WHERE id = ? 
-            ORDER BY GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) DESC
+            ORDER BY GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) ASC
             """.stripIndent()
 
     private static final String GET_ALL_DOCUMENT_VERSIONS_BY_MAIN_ID = """
             SELECT id, data, deleted, created, modified 
             FROM lddb__versions 
             WHERE id = (SELECT id FROM lddb__identifiers WHERE iri = ? AND mainid = 't')
-            ORDER BY modified
+            ORDER BY GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) ASC
             """.stripIndent()
 
     private static final String LOAD_ALL_DOCUMENTS =

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1639,7 +1639,7 @@ class PostgreSQLComponent {
         if (version && version.isInteger()) {
             int v = version.toInteger()
             def docList = loadAllVersionsByMainId(mainId)
-            if (v < docList.size()) {
+            if ((v >= 0 && v < docList.size()) || (v < 0 && v.abs()-1 < docList.size())) {
                 doc = docList[v]
             }
         } else if (version) {
@@ -1811,9 +1811,9 @@ class PostgreSQLComponent {
         if (version && version.isInteger()) {
             int v = version.toInteger()
             def docList = loadAllVersions(id)
-            if (v < docList.size()) {
+            if ((v >= 0 && v < docList.size()) || (v < 0 && v.abs()-1 < docList.size())) {
                 doc = docList[v]
-            } else {
+            } else if (v > -1) {
                 // looks like version might be a checksum, try loading
                 doc = loadFromSql(GET_DOCUMENT_VERSION, [1: id, 2: version])
             }

--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -20,11 +20,8 @@ public class History {
         m_jsonLd = jsonLd;
         m_pathOwnership = new HashMap<>();
 
-        // The list we get is sorted backwards chronologically,
-        // this needs to be the case for other uses of the same
-        // list, so "deal with it".
-        for (int i = versions.size()-1; i > -1 ; --i) {
-            DocumentVersion version = versions.get(i);
+        // The list we get is sorted chronologically, oldest first.
+        for (DocumentVersion version : versions) {
             addVersion(version);
         }
     }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -465,7 +465,7 @@ class WhelkTool {
 
     private boolean doRevertToTime(DocumentItem item) {
 
-        // The 'versions' list is sorted, with the most recent version first.
+        // The 'versions' list is sorted, with the oldest version first.
         List<Document> versions = whelk.storage.loadAllVersions(item.doc.shortId)
 
         ZonedDateTime restoreTime = ZonedDateTime.parse(item.restoreToTime)
@@ -477,11 +477,10 @@ class WhelkTool {
             return false
         }
 
-        // Go over the versions, oldest first (in reverse),
+        // Go over the versions, oldest first,
         // until you've found the oldest version that is younger than the desired time target.
         Document selectedVersion = null
-        for (int i = versions.size()-1; i > -1; --i) {
-            Document version = versions.get(i)
+        for (Document version : versions) {
             ZonedDateTime latestModificationTime = getLatestModification(version)
             if (restoreTime.isAfter(latestModificationTime))
                 selectedVersion = version

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -471,7 +471,7 @@ class WhelkTool {
         ZonedDateTime restoreTime = ZonedDateTime.parse(item.restoreToTime)
 
         // If restoreTime is older than any stored version (we can't go back that far)
-        ZonedDateTime oldestStoredTime = getLatestModification(versions.get(versions.size()-1))
+        ZonedDateTime oldestStoredTime = getLatestModification(versions.get(0))
         if ( restoreTime.isBefore( oldestStoredTime ) ) {
             errorLog.println("Cannot restore ${item.doc.shortId} to ${restoreTime}, oldest stored version from: ${oldestStoredTime}")
             return false


### PR DESCRIPTION
`whelk.storage.load(<id>, 0)` returned the latest version of a document while `whelk.storage.loadDocumentByMainId(<id>, 0)` returned the oldest. Now they both return the oldest.

* Changed the underlying query `GET_ALL_DOCUMENT_VERSIONS` to return things in ascending rather than descending order 
* Made `GET_ALL_DOCUMENT_VERSIONS_BY_MAIN_ID` consistent with a recent change to `GET_ALL_DOCUMENT_VERSIONS` (`ORDER BY modified` => `ORDER BY GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz)`)
* Adapted two instances where `loadAllVersions` was used (WhelkTool and marc_export). The marc_export integration test passes. I _think_ that's all :)
* Made it possible to use a negative version number. So now: 0 = oldest, 1 = second oldest, ..; -1 = newest, -2 = second newest, etc.