### PR TITLE
Feature/merge import rules

### DIFF
--- a/batchimport/integtest/batch14.xml
+++ b/batchimport/integtest/batch14.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record type="Bibliographic">
+    <leader>02625cam a22007458i 4500</leader>
+    <controlfield tag="001">20203738</controlfield>
+    <controlfield tag="003">SE-LIBR</controlfield>
+    <controlfield tag="005">20170713141440.0</controlfield>
+    <controlfield tag="008">170327s2017    sw ||||j     |00| 0|swe d</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">978-91-502-2231-9</subfield>
+      <subfield code="q">inbunden</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(BOKR)9789150222319_NEW</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">BOKR</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">Bently, Peter</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Polisbilen får INTE ett larm</subfield>
+    </datafield>
+    <datafield tag="263" ind1=" " ind2=" ">
+      <subfield code="a">201709</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="1">
+      <subfield code="b">Berghs,</subfield>
+      <subfield code="c">2017</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">32 sidor :</subfield>
+      <subfield code="b">illustrationer</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">En JÄTTEJÄTTEFIN sammanfattning</subfield>
+    </datafield>
+    <datafield tag="599" ind1=" " ind2=" ">
+      <subfield code="a">Maskinellt genererad post. AAAAAAAAAAAAAAAAAA Ändra kod för fullständighetsnivå (leader/17), annars kommer manuellt gjorda ändringar att försvinna.</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Lightfoot, Marta</subfield>
+      <subfield code="4">ill</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Vidén, Eva</subfield>
+      <subfield code="4">trl</subfield>
+    </datafield>
+  </record>
+  <record type="Holdings">
+    <leader>XXXXXax  a22XXXXX1n 4500</leader>
+    <controlfield tag="008">170714||0000|||||000||||||000000</controlfield>
+    <datafield tag="852" ind1="" ind2="">
+      <subfield code="b">Nyks</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/batchimport/integtest/mergerules0.json
+++ b/batchimport/integtest/mergerules0.json
@@ -1,0 +1,16 @@
+{
+    "rules": [
+        {
+            "operation": "replace",
+            "path": ["@graph", 1, "hasTitle"],
+            "priority":  {
+                "Utb1": 10,
+                "Utb2": 11
+            }
+        },
+	{
+            "operation": "add_if_none",
+            "path": ["@graph", 1, "summary"]
+        }
+    ]
+}

--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -1,0 +1,187 @@
+package whelk.importer;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import whelk.Document;
+import whelk.Whelk;
+import whelk.history.History;
+import whelk.history.Ownership;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class Merge {
+    /*
+    Merge rules are placed in files and look something like this:
+    {
+        "rules": [
+            {
+                "operation": "replace",
+                "path": ["@graph", 1, "hasTitle"],
+                "priority":  {
+                    "Utb1": 10,
+                    "Utb2": 11
+                }
+            },
+            {
+                "operation": "add_if_none",
+                "path": ["@graph", 1, "hasTitle"]
+            }
+        ]
+    }
+
+     */
+    enum Operation {
+        REPLACE,
+        ADD_IF_NONE
+    }
+
+    class Rule {
+        public Operation operation;
+        public Map sigelPriority;
+    }
+
+    // Maps a path to a rule.
+    private Map<List<Object>, Rule> m_pathRules = null;
+
+    public Merge(File ruleFile) throws IOException {
+        m_pathRules = new HashMap<>();
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map rulesMap = mapper.readValue(ruleFile, Map.class);
+        List rules = (List) rulesMap.get("rules");
+        for (Object rule : rules) {
+            Map ruleMap = (Map) rule;
+            String op = (String) ruleMap.get("operation");
+            List path = (List) ruleMap.get("path");
+            Map prioMap = (Map) ruleMap.get("priority");
+
+            Rule r = new Rule();
+            r.sigelPriority = prioMap;
+            if (op.equals("replace"))
+                r.operation = Operation.REPLACE;
+            else if (op.equals("add_if_none"))
+                r.operation = Operation.ADD_IF_NONE;
+            else
+                throw new RuntimeException("Malformed import rule, no such operation: " + op);
+            m_pathRules.put(path, r);
+        }
+    }
+
+    public void merge(Document base, Document incoming, String incomingAgent, Whelk whelk) {
+        History baseHistory = new History(whelk.getStorage().loadDocumentHistory(base.getShortId()), whelk.getJsonld());
+
+        List<Object> baseGraphList = (List<Object>) base.data.get("@graph");
+        List<Object> incomingGraphList = (List<Object>) incoming.data.get("@graph");
+        for (int i = 0; i < Integer.min(baseGraphList.size(), incomingGraphList.size()); ++i) {
+            List<Object> path = new ArrayList<>();
+            path.add("@graph");
+            path.add(i);
+            mergeInternal(
+                    baseGraphList.get(i),
+                    incomingGraphList.get(i),
+                    path,
+                    incomingAgent,
+                    baseHistory
+            );
+        }
+    }
+
+    /**
+     * Get the rule (of specified operation) that applies at this path, if any exists.
+     * this will be the most specific one of all rules, with that operation, that cover this path.
+     */
+    public Rule getRuleForPath(List<Object> path, Operation op) {
+        List<Object> temp = new ArrayList<>(path);
+        while (!temp.isEmpty()) {
+            Rule value = m_pathRules.get(temp);
+            if (value != null && value.operation == op)
+                return value;
+            temp.remove(temp.size()-1);
+        }
+        return null;
+    }
+
+    private void mergeInternal(Object base, Object correspondingIncoming,
+                                      List<Object> path,
+                                      String incomingAgent, History baseHistory) {
+        Rule replaceRule = getRuleForPath(path, Operation.REPLACE);
+        if (replaceRule != null) {
+            // Determine priority for existing and incoming versions at this path respectively
+            int incomingPriorityHere = 0;
+            if (replaceRule.sigelPriority.get(incomingAgent) != null) {
+                incomingPriorityHere = (Integer) replaceRule.sigelPriority.get(incomingAgent);
+            }
+            int basePriorityHere = Integer.MAX_VALUE; // A manual edit should never be replaced.
+            Ownership baseOwnership = baseHistory.getOwnership(path);
+            if (!baseHistory.containsHandEdits(path)) {
+                String baseAgent = baseOwnership.m_systematicEditor;
+                if (replaceRule.sigelPriority.get(baseAgent) != null) {
+                    basePriorityHere = (Integer) replaceRule.sigelPriority.get(baseAgent);
+                }
+            }
+
+            if (incomingPriorityHere > basePriorityHere) {
+                if (base instanceof Map) {
+                    Map map = ( (Map) base );
+                    if (!subtreeContainsLinks(map)) {
+                        map.clear();
+                        map.putAll( (Map) correspondingIncoming );
+                    }
+                }
+                else if (base instanceof List) {
+                    List list = ( (List) base );
+                    list.clear();
+                    list.addAll( (List) correspondingIncoming );
+                }
+
+                return; // scan no further (we've just replaced everything below us)
+            }
+        }
+
+        if (base instanceof Map && correspondingIncoming instanceof Map) {
+            for (Object key : ((Map) correspondingIncoming).keySet() ) {
+
+                // Does the incoming record have properties here that we don't have and are allowed to add?
+                List<Object> childPath = new ArrayList(path);
+                childPath.add(key);
+                if ( ((Map) base).get(key) == null ) {
+                    Rule addRule = getRuleForPath(childPath, Operation.ADD_IF_NONE);
+                    if (addRule != null) {
+                        ((Map) base).put(key, ((Map) correspondingIncoming).get(key));
+                    }
+                }
+
+                // Keep scanning further down the tree!
+                else {
+                    mergeInternal( ((Map) base).get(key),
+                            ((Map) correspondingIncoming).get(key),
+                            childPath,
+                            incomingAgent,
+                            baseHistory);
+                }
+            }
+        }
+    }
+
+    private boolean subtreeContainsLinks(Object object) {
+        if (object instanceof List) {
+            for (Object element : (List) object) {
+                if (subtreeContainsLinks(element))
+                    return true;
+            }
+        } else if (object instanceof Map) {
+            Map map = (Map) object;
+            if (map.keySet().size() == 1 && map.get("@id") != null) {
+                return true;
+            } else {
+                for (Object key : map.keySet()) {
+                    if (subtreeContainsLinks(map.get(key))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/batchimport/src/main/java/whelk/importer/Parameters.java
+++ b/batchimport/src/main/java/whelk/importer/Parameters.java
@@ -26,6 +26,7 @@ class Parameters
     private String changedIn = null;
     private boolean forceUpdate = false;
     private HashMap<String, String> specialRules = new HashMap<>();
+    private File mergeRuleFile = null;
 
     Path getPath() { return path; }
     INPUT_FORMAT getFormat() { return format; }
@@ -41,6 +42,7 @@ class Parameters
     String getChangedIn() { return changedIn; }
     boolean getForceUpdate() { return forceUpdate; }
     HashMap<String, String> getSpecialRules() { return specialRules; }
+    File getMergeRuleFile() { return mergeRuleFile; }
 
 
     enum INPUT_FORMAT
@@ -114,7 +116,7 @@ class Parameters
         System.err.println("              the xml document must be that of MARCXML at the latest after any XSLT");
         System.err.println("              transforms have been applied.");
         System.err.println("");
-        System.err.println("--transformer The path to an XSLT stylsheet that should be used to transform the input");
+        System.err.println("--transformer The path to an XSLT stylesheet that should be used to transform the input");
         System.err.println("              before importing. This parameter may be used even if the input format is");
         System.err.println("              \"iso2709\", in which case the stream will be translated to MARCXML before");
         System.err.println("              transformation. If more than one transformer is specified these will be");
@@ -127,9 +129,7 @@ class Parameters
         System.err.println("");
         System.err.println("--dupType     The type of duplication checking that should be done for each incoming");
         System.err.println("              record. The value of this parameter may be a comma-separated list of any");
-        System.err.println("              combination of duplication types. If a duplicate is found for an incoming");
-        System.err.println("              record, that record will be enriched with any additional information in the");
-        System.err.println("              incoming record.");
+        System.err.println("              combination of duplication types.");
         System.err.println("              Duplication types are checked in the order they are defined on the command line");
         System.err.println("              As soon as one duplication type has yielded one or more duplicates, no additional");
         System.err.println("              types will be checked. (in other words: THE ORDERING OF TYPES MATTER)");
@@ -158,6 +158,10 @@ class Parameters
         System.err.println("--replaceBib  If this flag is set, matching bibliographic records will be replaced.");
         System.err.println("");
         System.err.println("--replaceHold If this flag is set, matching holding records will be replaced.");
+        System.err.println("");
+        System.err.println("--mergeBibUsing Bibliographic records can be \"partially uppated\" (merged) with incoming");
+        System.err.println("              records according to some specified set of rules.");
+        System.err.println("              Using this option, a file containing such merge rules can be specified.");
         System.err.println("");
         System.err.println("--changedBy   A string to use as descriptionCreator (MARC 040) for imported records.");
         System.err.println("--changedIn   A string to use for the changedIn column, defaults to \"batch import\".");
@@ -228,6 +232,12 @@ class Parameters
                 specialRules.put(from, to);
                 break;
 
+            case "--mergeBibUsing":
+                if (getReplaceBib())
+                    throw new IllegalArgumentException("Encrich/replace are mutually exclusive");
+                mergeRuleFile = new File(value);
+                break;
+
             default:
                 throw new IllegalArgumentException(parameter);
         }
@@ -293,6 +303,8 @@ class Parameters
                 replaceHold = true;
                 break;
             case "--replaceBib":
+                if (getMergeRuleFile() != null)
+                    throw new IllegalArgumentException("Encrich/replace are mutually exclusive");
                 replaceBib = true;
                 break;
             case "--forceUpdate":

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -142,6 +142,8 @@ class XL
                         m_merge.merge(existing, incoming, m_parameters.getChangedBy(), m_whelk);
                     });
                 }
+
+                resultingResourceId = m_whelk.getStorage().getThingId(idToMerge);
             }
 
             // Keep existing

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -69,7 +69,8 @@ class XL
         m_repeatableTerms = m_whelk.getJsonld().getRepeatableTerms();
         m_marcFrameConverter = m_whelk.getMarcFrameConverter();
         m_linkfinder = new LinkFinder(m_whelk.getStorage());
-        m_merge = new Merge(parameters.getMergeRuleFile());
+        if (parameters.getMergeRuleFile() != null)
+            m_merge = new Merge(parameters.getMergeRuleFile());
         if (parameters.getChangedIn() != null)
             IMPORT_SYSTEM_CODE = parameters.getChangedIn();
         else

--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -46,16 +46,18 @@ public class History {
         return m_pathOwnership.get(new ArrayList<>()); // The root (first) owner
     }
 
-    public boolean containsHandEdits(List<Object> path) {
+    /**
+     * Get the set of owners for path and everything under it.
+     */
+    public Set<Ownership> getSubtreeOwnerships(List<Object> path) {
+        Set<Ownership> owners = new HashSet<>();
         for (Object keyObject : m_pathOwnership.keySet()) {
             List<Object> key = (List<Object>) keyObject;
             if (key.size() >= path.size() && key.subList(0, path.size()).equals(path)) { // A path below (more specific) than 'path'
-                if (m_pathOwnership.get(key).m_manualEditTime != null) {
-                    return true;
-                }
+                owners.add(m_pathOwnership.get(key));
             }
         }
-        return false;
+        return owners;
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -46,6 +46,18 @@ public class History {
         return m_pathOwnership.get(new ArrayList<>()); // The root (first) owner
     }
 
+    public boolean containsHandEdits(List<Object> path) {
+        for (Object keyObject : m_pathOwnership.keySet()) {
+            List<Object> key = (List<Object>) keyObject;
+            if (key.size() >= path.size() && key.subList(0, path.size()).equals(path)) { // A path below (more specific) than 'path'
+                if (m_pathOwnership.get(key).m_manualEditTime != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Examine differences between (what would presumably be) the same entity
      * in two versions of a record.


### PR DESCRIPTION
This adds a commandline option to the batch-import which enables selective merging of incoming (bibliograhpic) records with existing ones.
This is done using a (json) rule-file and the computed history of existing records.