### PR TITLE
Don't fail to generate reverse links if thing IRI missing for one doc

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -97,7 +97,7 @@ class DependencyCache {
             Set<String> load(Link link) {
                 try {
                     def iris = func.apply(storage.getSystemIdByThingId(link.iri), link.relation)
-                            .collect(storage.&getThingMainIriBySystemId)
+                            .findResults (this.&tryGetThingMainIriBySystemId)
 
                     return iris.isEmpty()
                             ? Collections.EMPTY_SET
@@ -106,6 +106,16 @@ class DependencyCache {
                 catch (MissingMainIriException e) {
                     log.warn("Missing Main IRI: $e")
                     return Collections.EMPTY_SET
+                }
+            }
+            
+            private String tryGetThingMainIriBySystemId(String systemId) {
+                try {
+                    return storage.getThingMainIriBySystemId(systemId)
+                }
+                catch (MissingMainIriException ignored) {
+                    log.warn("Missing thing main IRI for $systemId. Deleted?")
+                    return null
                 }
             }
 


### PR DESCRIPTION
At the time of writing `lddb__dependencies` contains 62 ids
where the document is deleted. This has to be investigated
and fixed. Since they are deleted all IRIs are gone from
`lddb__identifiers`. This fix makes it so that we don't
drop all other `@reverse` links when one of these is among
the incoming links.