### PR TITLE
Make embellished responses cachable

### DIFF
--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -32,11 +32,6 @@ sourceSets {
 }
 
 test {
-    systemProperty 'xl.secret.properties', '../secret.properties'
-}
-
-test {
-    systemProperty 'xl.secret.properties', '../secret.properties'
     jacoco {
         destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
         classDumpDir = file("$buildDir/jacoco/classpathdumps")

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -1,6 +1,5 @@
 package whelk.rest.api
 
-
 import groovy.transform.PackageScope
 import groovy.util.logging.Log4j2 as Log
 import io.prometheus.client.Counter
@@ -34,7 +33,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
-import static whelk.rest.api.CrudUtils.*
+import static whelk.rest.api.CrudUtils.ETag
 import static whelk.rest.api.HttpTools.sendError
 import static whelk.rest.api.HttpTools.sendResponse
 
@@ -228,7 +227,7 @@ class Crud extends HttpServlet {
             ETag eTag = request.shouldEmbellish()
                     ? ETag.embellished(checksum, doc.getChecksum(jsonld))
                     : ETag.plain(checksum)
-            
+
             if (request.getIfNoneMatch().map(eTag.&isNotModified).orElse(false)) {
                 sendNotModified(response, eTag)
                 return
@@ -242,7 +241,7 @@ class Crud extends HttpServlet {
                     request.getContentType())
         }
     }
-    
+
     private void sendNotModified(HttpServletResponse response, ETag eTag) {
         setVary(response)
         response.setHeader("ETag", eTag.toString())

--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -2,6 +2,8 @@ package whelk.rest.api
 
 import javax.servlet.http.HttpServletRequest
 
+import static whelk.rest.api.CrudUtils.*
+
 class CrudGetRequest {
     private HttpServletRequest request
     private String resourceId
@@ -16,7 +18,7 @@ class CrudGetRequest {
     private CrudGetRequest(HttpServletRequest request) {
         this.request = request
         parsePath(getPath())
-        contentType = CrudUtils.getBestContentType(request)
+        contentType = getBestContentType(request)
         lens = parseLens(request)
     }
 
@@ -36,10 +38,10 @@ class CrudGetRequest {
         return Optional.ofNullable(request.getParameter("version"))
     }
 
-    Optional<String> getIfNoneMatch() {
+    Optional<ETag> getIfNoneMatch() {
         return Optional
                 .ofNullable(request.getHeader("If-None-Match"))
-                .map(CrudUtils.&cleanEtag)
+                .map(ETag.&parse)
     }
 
     String getContentType() {

--- a/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
@@ -10,6 +10,7 @@ import org.apache.http.NameValuePair
 import org.apache.http.message.BasicHeaderValueParser
 
 import javax.servlet.http.HttpServletRequest
+import java.lang.management.ManagementFactory
 
 @Log
 class CrudUtils {
@@ -86,15 +87,7 @@ class CrudUtils {
          */
         return allowedMimeTypes.isEmpty() ? JSONLD : allowedMimeTypes[0]
     }
-
-    static String cleanEtag(String str) {
-        return stripQuotes(str)?.replaceAll('-gzip', '')
-    }
-
-    private static String stripQuotes(String str) {
-        return str?.replaceAll('"', '')
-    }
-
+    
     /**
      * Returns a sorted list of media types accepted by the client
      */
@@ -164,8 +157,8 @@ class CrudUtils {
                 MediaType m = MediaType.parse(element.name).withParameters(parameters)
                 return new AcceptMediaType(m, q)
             }
-            catch (IllegalArgumentException e) {
-                throw new BadRequestException('Invalid media type in Accept header': element.toString())
+            catch (IllegalArgumentException ignored) {
+                throw new BadRequestException("Invalid media type in Accept header': $element")
             }
         }
 
@@ -176,6 +169,75 @@ class CrudUtils {
             catch (NumberFormatException e) {
                 throw new BadRequestException("Invalid q value in Accept header:" + value)
             }
+        }
+    }
+
+    static class ETag {
+        static final ETag SYSTEM_START = plain("${ManagementFactory.getRuntimeMXBean().getStartTime()}")
+        
+        private static final String SEPARATOR = ':'
+        
+        private String plain = null
+        private String embellished = null
+
+        private ETag(String checksum) {
+            plain = checksum
+        }
+
+        private ETag(String checksum, String checksumEmbellished) {
+            plain = checksum
+            embellished = checksumEmbellished
+        }
+
+        String documentCheckSum() {
+            return plain
+        }
+        
+        static ETag parse(String eTag) {
+            if(!eTag) {
+                return plain(null)
+            }
+            
+            eTag = cleanEtag(eTag)
+            
+            if (eTag.contains(SEPARATOR)) {
+                def e = eTag.split(SEPARATOR)
+                embellished(e[0], e[1])
+            }
+            else {
+                plain(eTag)
+            }
+        }
+
+
+        static ETag plain(String checksum) {
+            new ETag(checksum)
+        }
+
+        static ETag embellished(String checksum, String checksumEmbellish) {
+            new ETag(checksum, checksumEmbellish)
+        }
+
+        String toString() {
+            embellished ? "$plain$SEPARATOR$embellished" : plain
+        }
+        
+        boolean isNotModified(ETag ifNoneMatch) {
+            if (plain != ifNoneMatch.plain) {
+                return false
+            }
+            if (embellished && embellished != ifNoneMatch.embellished) {
+                return false
+            }
+            return true
+        }
+
+        private static String cleanEtag(String str) {
+            return stripQuotes(str)?.replaceAll('-gzip', '')
+        }
+
+        private static String stripQuotes(String str) {
+            return str?.replaceAll('"', '')
         }
     }
 }

--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -427,10 +427,9 @@ class CrudSpec extends Specification {
         given:
         def id = BASE_URI.resolve("/1234").toString()
         def doc = new Document(["@graph": [
-                ["@id": id, 'mainEntity': ["@id": "$id#it"]], 
-                ["@id": "$id#it", '@type': 'Instance', 'prop1': ['@id': 'https://foo']]
+                ['@id': id, 'mainEntity': ['@id': "$id#it"]], 
+                ['@id': "$id#it", '@type': 'Instance', 'prop1': ['@id': 'https://foo']]
         ]])
-        doc.setModified(new Date())
         request.getPathInfo() >> { '/' + id}
         request.getHeader("Accept") >> { "*/*" }
         request.getHeader("If-None-Match") >> { eTag }
@@ -442,8 +441,8 @@ class CrudSpec extends Specification {
             def iris = ['https://foo']
             iris.collect {
                 ["@graph": [
-                        ["@id": it, 'mainEntity': ["@id": "$it#it"]],
-                        ["@id": "$it#it"]
+                        ['@id': it, 'mainEntity': ['@id': "$it#it"]],
+                        ['@id': "$it#it"]
                 ]]
             }
         }
@@ -453,17 +452,17 @@ class CrudSpec extends Specification {
         response.getStatus() == status
 
         where:
-        // checksum             -1856151741
-        // checksum embellished -5527327606
+        // checksum             -1856152111
+        // checksum embellished -5527328642
 
         embellished | eTag                      || status
-        false       | '-1856151741'             || SC_NOT_MODIFIED
-        false       | "-1856151741:-5527327606" || SC_NOT_MODIFIED
-        false       | "-1856151741:other"       || SC_NOT_MODIFIED
+        false       | '-1856152111'             || SC_NOT_MODIFIED
+        false       | "-1856152111:-5527328642" || SC_NOT_MODIFIED
+        false       | "-1856152111:other"       || SC_NOT_MODIFIED
         false       | "other"                   || SC_OK
 
-        true        | '-1856151741'             || SC_OK
-        true        | '-1856151741:-5527327606' || SC_NOT_MODIFIED
+        true        | '-1856152111'             || SC_OK
+        true        | '-1856152111:-5527328642' || SC_NOT_MODIFIED
         true        | "-1856151741:other"       || SC_OK
         true        | "other"                   || SC_OK
     }

--- a/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/RemoteSearchAPISpec.groovy
@@ -2,11 +2,13 @@ package whelk.rest.api
 
 import spock.lang.Specification
 import whelk.Document
+import whelk.util.PropertyLoader
 
 class RemoteSearchAPISpec extends Specification {
     RemoteSearchAPI remote
 
     void setup() {
+        PropertyLoader.setUserEnteredProperties('secret', 'foo')
         remote = new RemoteSearchAPI()
     }
 

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -883,6 +883,8 @@ class Document {
             return term
         else if (node instanceof String)
             return node.hashCode() * depth
+        else if (node instanceof GString)
+            return node.toString().hashCode() * depth
         else if (node instanceof Boolean)
             return node.booleanValue() ? depth : term
         else if (node instanceof Integer)


### PR DESCRIPTION
Make ETag/If-None-Match (304 NOT MODIFIED) work with embellish.

(ETag is an opaque string so we can put whatever we want inside)
When `embellish==false` ETag is checksum of document
When `embellish==true` include checksum of both document and embellished document in ETag.

Both ETag forms can be used in PUT.