### PR TITLE
Add custom Jackson JSON serializer for GString

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -1,6 +1,5 @@
 package whelk.importer;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import whelk.Document;
 import whelk.Whelk;
 import whelk.history.History;
@@ -8,7 +7,13 @@ import whelk.history.Ownership;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static whelk.util.Jackson.mapper;
 
 public class Merge {
     /*
@@ -46,8 +51,7 @@ public class Merge {
 
     public Merge(File ruleFile) throws IOException {
         m_pathRules = new HashMap<>();
-
-        ObjectMapper mapper = new ObjectMapper();
+        
         Map rulesMap = mapper.readValue(ruleFile, Map.class);
         List rules = (List) rulesMap.get("rules");
         for (Object rule : rules) {

--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -1,15 +1,14 @@
 package whelk.importer
 
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.Whelk
 import whelk.exception.CancelUpdateException
 
+import static whelk.util.Jackson.mapper
+
 @Log
 class DatasetImporter {
-    static final ObjectMapper mapper = new ObjectMapper()
-
     static void importDataset(Whelk whelk, String filePath, String dataset) {
 
         if (Runtime.getRuntime().maxMemory() < 2l * 1024l * 1024l * 1024l) {

--- a/importers/src/main/groovy/whelk/importer/DefinitionsImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DefinitionsImporter.groovy
@@ -1,16 +1,15 @@
 package whelk.importer
 
-import org.codehaus.jackson.map.ObjectMapper
+
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import whelk.Document
 import whelk.IdGenerator
 import whelk.Whelk
 import whelk.reindexer.CardRefresher
 
+import static whelk.util.Jackson.mapper
+
 class DefinitionsImporter extends Importer {
-
-    static final ObjectMapper mapper = new ObjectMapper()
-
     String definitionsFilename
 
     DefinitionsImporter(Whelk w) {

--- a/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
+++ b/importers/src/main/groovy/whelk/importer/WhelkCopier.groovy
@@ -1,9 +1,11 @@
 package whelk.importer
 
-import whelk.Whelk
 import whelk.Document
+import whelk.Whelk
 import whelk.util.LegacyIntegrationTools
 import whelk.util.ThreadPool
+
+import static whelk.util.Jackson.mapper
 
 class WhelkCopier {
 
@@ -156,7 +158,7 @@ class WhelkCopier {
                 '"\\Q' + libUriPlaceholder + '\\E',
                 '"' + source.baseUri.resolve("library/").toString())
 
-        def newDoc = new Document(doc.mapper.readValue(newDataRepr, Map))
+        def newDoc = new Document(mapper.readValue(newDataRepr, Map))
 
         def newId = dest.baseUri.resolve(doc.shortId).toString()
         newDoc.id = newId

--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -7,9 +7,22 @@ import whelk.util.LegacyIntegrationTools;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Stack;
+import java.util.StringJoiner;
+
+import static whelk.util.Jackson.mapper;
 
 public class Helpers
 {
@@ -157,7 +170,7 @@ public class Helpers
                     {
                         String data = resultSet.getString("data");
 
-                        Document updated = new Document(ResponseCommon.mapper.readValue(data, HashMap.class));
+                        Document updated = new Document(mapper.readValue(data, HashMap.class));
                         emitAffected(updated);
 
                         // Did reading this record from the DB result in anything new in the export flow?

--- a/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResponseCommon.java
@@ -1,6 +1,6 @@
 package whelk.export.servlet;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import whelk.Document;
@@ -10,7 +10,10 @@ import whelk.util.LegacyIntegrationTools;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.stream.*;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.sql.SQLException;
@@ -19,12 +22,9 @@ import java.time.ZonedDateTime;
 import java.util.Enumeration;
 import java.util.List;
 
-import org.apache.cxf.staxutils.StaxUtils;
-
 public class ResponseCommon
 {
     private static final Logger logger = LogManager.getLogger(ResponseCommon.class);
-    static final ObjectMapper mapper = new ObjectMapper();
     private static final XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
 
     /**

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -6,7 +6,6 @@ import io.prometheus.client.Counter
 import io.prometheus.client.Gauge
 import io.prometheus.client.Summary
 import org.apache.http.entity.ContentType
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.IdGenerator
 import whelk.IdType
@@ -34,10 +33,10 @@ import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
 import static whelk.rest.api.CrudUtils.ETag
-
+import static whelk.rest.api.HttpTools.getBaseUri
 import static whelk.rest.api.HttpTools.sendError
 import static whelk.rest.api.HttpTools.sendResponse
-import static whelk.rest.api.HttpTools.getBaseUri
+import static whelk.util.Jackson.mapper
 
 /**
  * Handles all GET/PUT/POST/DELETE requests against the backend.
@@ -77,7 +76,6 @@ class Crud extends HttpServlet {
     JsonLdValidator validator
 
     SearchUtils search
-    static final ObjectMapper mapper = new ObjectMapper()
     AccessControl accessControl = new AccessControl()
     ConverterUtils converterUtils
     Map siteConfig

--- a/rest/src/main/groovy/whelk/rest/api/HoldAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HoldAPI.groovy
@@ -4,12 +4,15 @@ import whelk.Document
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.converter.marc.JsonLD2MarcXMLConverter
+import whelk.util.Jackson
 import whelk.util.LegacyIntegrationTools
 import whelk.util.WhelkFactory
 
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+
+import static whelk.util.Jackson.mapper
 
 class HoldAPI extends HttpServlet {
 
@@ -72,7 +75,7 @@ class HoldAPI extends HttpServlet {
                 holdingIDs.add(holding.getCompleteId())
         }
 
-        String jsonString = PostgreSQLComponent.mapper.writeValueAsString(holdingIDs)
+        String jsonString = mapper.writeValueAsString(holdingIDs)
         response.setContentType("application/json")
         response.setHeader("Expires", "0")
         response.setHeader('Cache-Control', 'no-cache')

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -1,24 +1,20 @@
 package whelk.rest.api
 
-
 import groovy.util.logging.Log4j2 as Log
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.codehaus.groovy.runtime.StackTraceUtils
-import org.codehaus.jackson.map.ObjectMapper
 
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import static org.eclipse.jetty.http.HttpStatus.getMessage
+import static whelk.util.Jackson.mapper
 
 /**
  * Created by markus on 2015-10-09.
  */
 @Log
 class HttpTools {
-
-    static final ObjectMapper mapper = new ObjectMapper()
-
     static void sendResponse(HttpServletResponse response, Map data, String contentType, int statusCode = 200) {
         if (!data) {
             sendResponse(response, new byte[0], contentType, statusCode)

--- a/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RecordRelationAPI.groovy
@@ -2,13 +2,14 @@ package whelk.rest.api
 
 import whelk.Document
 import whelk.Whelk
-import whelk.component.PostgreSQLComponent
 import whelk.util.LegacyIntegrationTools
 import whelk.util.WhelkFactory
 
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+
+import static whelk.util.Jackson.mapper
 
 class RecordRelationAPI extends HttpServlet {
 
@@ -86,21 +87,21 @@ class RecordRelationAPI extends HttpServlet {
             for (String resultId : result) {
                 ids.add(Document.getBASE_URI().toString() + resultId)
             }
-            jsonString = PostgreSQLComponent.mapper.writeValueAsString(ids)
+            jsonString = mapper.writeValueAsString(ids)
         }
         else if (returnMode.equals("bare_record")) {
             List<Map> records = new ArrayList<>(result.size())
             for (String resultId : result) {
                 records.add(whelk.storage.load(resultId).data)
             }
-            jsonString = PostgreSQLComponent.mapper.writeValueAsString(records)
+            jsonString = mapper.writeValueAsString(records)
         }
         else if (returnMode.equals("embellished_record")) {
             List<Map> records = new ArrayList<>(result.size())
             for (String resultId : result) {
                 records.add( whelk.loadEmbellished(resultId).data )
             }
-            jsonString = PostgreSQLComponent.mapper.writeValueAsString(records)
+            jsonString = mapper.writeValueAsString(records)
         }
         else {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST,

--- a/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
@@ -1,7 +1,6 @@
 package whelk.rest.api
 
 import org.codehaus.jackson.JsonParseException
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.Whelk
 import whelk.util.WhelkFactory
@@ -9,6 +8,8 @@ import whelk.util.WhelkFactory
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+
+import static whelk.util.Jackson.mapper
 
 /**
  * The purpose of this class is to facilitate refreshing of records that have been modified in authoritative storage
@@ -20,7 +21,6 @@ import javax.servlet.http.HttpServletResponse
  */
 class RefreshAPI extends HttpServlet
 {
-    public final static mapper = new ObjectMapper()
     private Whelk whelk
 
     RefreshAPI() {

--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -3,7 +3,6 @@ package whelk.rest.api
 import groovy.util.logging.Log4j2 as Log
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
-import org.codehaus.jackson.map.ObjectMapper
 import se.kb.libris.util.marc.Field
 import se.kb.libris.util.marc.MarcRecord
 import se.kb.libris.util.marc.io.MarcXmlRecordReader
@@ -24,11 +23,10 @@ import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
+import static whelk.util.Jackson.mapper
+
 @Log
 class RemoteSearchAPI extends HttpServlet {
-
-    final static mapper = new ObjectMapper()
-
     MarcFrameConverter marcFrameConverter
     static final URL metaProxyInfoUrl
     static final String metaProxyBaseUrl

--- a/rest/src/main/java/whelk/AuthenticationFilter.java
+++ b/rest/src/main/java/whelk/AuthenticationFilter.java
@@ -6,7 +6,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import whelk.util.PropertyLoader;
 
@@ -29,9 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-public class AuthenticationFilter implements Filter {
+import static whelk.util.Jackson.mapper;
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+public class AuthenticationFilter implements Filter {
     private static final String XL_ACTIVE_SIGEL_HEADER = "XL-Active-Sigel";
     private List<String> supportedMethods;
     private List<String> whitelistedPostEndpoints;

--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -1,6 +1,6 @@
 package whelk.rest.api
 
-import org.codehaus.jackson.map.ObjectMapper
+
 import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -25,6 +25,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_MODIFIED
 import static javax.servlet.http.HttpServletResponse.SC_OK
 import static whelk.rest.api.MimeTypes.JSON
 import static whelk.rest.api.MimeTypes.JSONLD
+import static whelk.util.Jackson.mapper
 
 /**
  * Created by markus on 2015-10-16.
@@ -39,9 +40,7 @@ class CrudSpec extends Specification {
     HttpServletResponse response
 
     static final URI BASE_URI = Document.BASE_URI
-    private static final ObjectMapper mapper = new ObjectMapper()
-
-
+    
     void setup() {
         request = GroovyMock(HttpServletRequest.class)
         request.getRequestURI() >> {

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -1,8 +1,6 @@
 package whelk
 
-
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.util.DocumentUtil
 import whelk.util.LegacyIntegrationTools
 import whelk.util.PropertyLoader
@@ -14,6 +12,8 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Predicate
+
+import static whelk.util.Jackson.mapper
 
 /**
  * A document is represented as a data Map (containing Maps, Lists and Value objects).
@@ -38,8 +38,6 @@ class Document {
             BASE_URI = new URI("https://libris.kb.se/")
         }
     }
-
-    static final ObjectMapper mapper = new ObjectMapper()
 
     static final List thingPath = ["@graph", 1]
     static final List thingIdPath = ["@graph", 0, "mainEntity", "@id"]

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -6,7 +6,6 @@ import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.exception.FramingException
 import whelk.exception.WhelkRuntimeException
 import whelk.util.DocumentUtil
@@ -54,8 +53,6 @@ class JsonLd {
     static final List<String> NON_DEPENDANT_RELATIONS = ['narrower', 'broader', 'expressionOf', 'related', 'derivedFrom']
 
     static final Set<String> LD_KEYS
-
-    static final ObjectMapper mapper = new ObjectMapper()
 
     static {
         LD_KEYS = [

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -3,7 +3,6 @@ package whelk.component
 import groovy.json.JsonOutput
 import groovy.util.logging.Log4j2 as Log
 import org.apache.commons.codec.binary.Base64
-import org.codehaus.jackson.map.ObjectMapper
 import se.kb.libris.utils.isbn.ConvertException
 import se.kb.libris.utils.isbn.Isbn
 import se.kb.libris.utils.isbn.IsbnException
@@ -11,12 +10,14 @@ import se.kb.libris.utils.isbn.IsbnParser
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
-import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.InvalidQueryException
+import whelk.exception.UnexpectedHttpStatusException
 import whelk.util.DocumentUtil
 import whelk.util.Unicode
 
 import java.util.concurrent.LinkedBlockingQueue
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class ElasticSearch {
@@ -31,8 +32,6 @@ class ElasticSearch {
             'http://id.kb.se/',
             'https://id.kb.se/',
     ]
-
-    private static final ObjectMapper mapper = new ObjectMapper()
 
     public int maxResultWindow = 10000 // Elasticsearch default (fallback value)
     

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -7,12 +7,10 @@ import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
 import groovy.json.StringEscapeUtils
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import org.postgresql.PGStatement
 import org.postgresql.util.PGobject
 import org.postgresql.util.PSQLException
 import whelk.Document
-import whelk.history.DocumentVersion
 import whelk.IdType
 import whelk.JsonLd
 import whelk.Link
@@ -25,6 +23,7 @@ import whelk.exception.TooHighEncodingLevelException
 import whelk.exception.WhelkException
 import whelk.exception.WhelkRuntimeException
 import whelk.filter.LinkFinder
+import whelk.history.DocumentVersion
 import whelk.util.DocumentUtil
 import whelk.util.LegacyIntegrationTools
 
@@ -44,6 +43,7 @@ import java.util.regex.Pattern
 
 import static groovy.transform.TypeCheckingMode.SKIP
 import static java.sql.Types.OTHER
+import static whelk.util.Jackson.mapper
 
 /**
  *  It is important to not grab more than one connection per request/thread to avoid connection related deadlocks.
@@ -72,8 +72,6 @@ class PostgreSQLComponent {
     public static final String PROPERTY_SQL_URL = "sqlUrl"
     public static final String PROPERTY_SQL_MAX_POOL_SIZE = "sqlMaxPoolSize"
     public static final String PROPERTY_EMBELLISH_CACHE_MAX_SIZE = "embellishCacheMaxSizeBytes"
-
-    public static final ObjectMapper mapper = new ObjectMapper()
 
     private static final int DEFAULT_MAX_POOL_SIZE = 16
     private static final String driverClass = "org.postgresql.Driver"

--- a/whelk-core/src/main/groovy/whelk/converter/JSONMarcConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JSONMarcConverter.groovy
@@ -1,26 +1,25 @@
 package whelk.converter
 
-import javax.xml.transform.*
-import javax.xml.transform.dom.*
-import javax.xml.transform.stream.*
-import org.w3c.dom.*
-
+import groovy.util.logging.Log4j2 as Log
+import org.w3c.dom.DocumentFragment
+import se.kb.libris.util.marc.Controlfield
 import se.kb.libris.util.marc.Datafield
+import se.kb.libris.util.marc.MarcRecord
 import se.kb.libris.util.marc.impl.ControlfieldImpl
 import se.kb.libris.util.marc.impl.DatafieldImpl
 import se.kb.libris.util.marc.impl.MarcRecordImpl
 import se.kb.libris.util.marc.io.DomSerializer
 
-import groovy.util.logging.Log4j2 as Log
+import javax.xml.transform.Result
+import javax.xml.transform.Source
+import javax.xml.transform.Transformer
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
 
-import se.kb.libris.util.marc.Controlfield
-import se.kb.libris.util.marc.MarcRecord
-import org.codehaus.jackson.map.ObjectMapper
-
+import static whelk.util.Jackson.mapper
 
 @Log
 class JSONMarcConverter {
-    protected final static ObjectMapper mapper = new ObjectMapper()
 
     static MarcRecord fromJson(String marcJson) {
         Map resultJson = mapper.readValue(marcJson, Map)

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLD2N3Converter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLD2N3Converter.groovy
@@ -4,16 +4,15 @@ import org.apache.commons.io.IOUtils
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.RDFWriter
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.util.PropertyLoader
 
-class JsonLD2N3Converter implements FormatConverter {
+import static whelk.util.Jackson.mapper
 
-    static final ObjectMapper mapper = new ObjectMapper()
+class JsonLD2N3Converter implements FormatConverter {
 
     Map m_context = null
 

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLD2RdfXml.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLD2RdfXml.groovy
@@ -4,16 +4,15 @@ import org.apache.commons.io.IOUtils
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.RDFWriter
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.util.PropertyLoader
 
-class JsonLD2RdfXml implements FormatConverter {
+import static whelk.util.Jackson.mapper
 
-    static final ObjectMapper mapper = new ObjectMapper()
+class JsonLD2RdfXml implements FormatConverter {
 
     Map m_context = null
 

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLDLinkCompleterFilter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLDLinkCompleterFilter.groovy
@@ -1,22 +1,15 @@
 package whelk.converter
 
 import groovy.util.logging.Log4j2 as Log
-
 import whelk.Document
 
-//import static whelk.util.Tools.*
-
-import org.codehaus.jackson.map.ObjectMapper
+import static whelk.util.Jackson.mapper
 
 @Log
 @Deprecated
 class JsonLDLinkCompleterFilter {
 
     static String BNODE_ID_PREFIX = "_:"
-
-    ObjectMapper mapper = new ObjectMapper()
-
-    String requiredContentType = "application/ld+json"
 
     Map entityShapes
     Map bnodeIdMap
@@ -27,11 +20,7 @@ class JsonLDLinkCompleterFilter {
             this.entityShapes = mapper.readValue(it, Map)
         }
     }
-
-    public JsonLDLinkCompleterFilter(Map entityShapes) {
-        this.entityShapes = entityShapes
-    }
-
+    
     protected buildRelatedItemsIndex(Document doc) {
         def byType = [:]
         def byIdOrSameAs = [:]

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLDTrigConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLDTrigConverter.groovy
@@ -1,10 +1,12 @@
 package whelk.converter
 
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
-import whelk.*
+import whelk.JsonLd
+import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.util.PropertyLoader
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class JsonLDTrigConverter implements FormatConverter {
@@ -12,8 +14,7 @@ class JsonLDTrigConverter implements FormatConverter {
     String requiredContentType = "application/ld+json"
     def context
     def base
-    def mapper = new ObjectMapper()
-
+    
     JsonLDTrigConverter(String base = null, Whelk whelk = null) {
         if (whelk) {
             context = JsonLdToTurtle.parseContext(['@context': whelk.jsonld.context])
@@ -27,7 +28,7 @@ class JsonLDTrigConverter implements FormatConverter {
         if (context == null) {
             Properties props = PropertyLoader.loadProperties("secret")
             PostgreSQLComponent postgreSQLComponent = new PostgreSQLComponent(props.getProperty("sqlUrl"))
-            context = JsonLdToTurtle.parseContext( mapper.readValue(postgreSQLComponent.getContext(), HashMap.class) )
+            context = JsonLdToTurtle.parseContext(mapper.readValue(postgreSQLComponent.getContext(), HashMap.class) )
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLDTurtleConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLDTurtleConverter.groovy
@@ -1,10 +1,12 @@
 package whelk.converter
 
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
-import whelk.*
+import whelk.JsonLd
+import whelk.Whelk
 import whelk.component.PostgreSQLComponent
 import whelk.util.PropertyLoader
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class JsonLDTurtleConverter implements FormatConverter {
@@ -13,8 +15,7 @@ class JsonLDTurtleConverter implements FormatConverter {
     String requiredContentType = "application/ld+json"
     def context
     def base
-    def mapper = new ObjectMapper()
-
+    
     JsonLDTurtleConverter(String base = null, Whelk whelk = null) {
         if (whelk) {
             context = JsonLdToTurtle.parseContext(['@context': whelk.jsonld.context])
@@ -28,7 +29,7 @@ class JsonLDTurtleConverter implements FormatConverter {
         if (context == null) {
             Properties props = PropertyLoader.loadProperties("secret")
             PostgreSQLComponent postgreSQLComponent = new PostgreSQLComponent(props.getProperty("sqlUrl"))
-            context = JsonLdToTurtle.parseContext( mapper.readValue(postgreSQLComponent.getContext(), HashMap.class) )
+            context = JsonLdToTurtle.parseContext(mapper.readValue(postgreSQLComponent.getContext(), HashMap.class) )
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
@@ -1,11 +1,11 @@
 package whelk.converter
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJava
-import org.apache.jena.iri.*
-
-import org.codehaus.jackson.map.ObjectMapper
-
 import groovy.util.logging.Log4j2 as Log
+import org.apache.jena.iri.IRI
+import org.apache.jena.iri.IRIFactory
+
+import static org.apache.commons.lang3.StringEscapeUtils.escapeJava
+import static whelk.util.Jackson.mapper
 
 @Log
 class JsonLdToTurtle {
@@ -443,7 +443,6 @@ class JsonLdToTurtle {
     }
 
     static void main(args) {
-        def mapper = new ObjectMapper()
         def contextSrc = new File(args[0]).withInputStream { mapper.readValue(it, Map) }
         def context = JsonLdToTurtle.parseContext(contextSrc)
         if (args.length == 2) {

--- a/whelk-core/src/main/groovy/whelk/converter/MarcJSONConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/MarcJSONConverter.groovy
@@ -1,15 +1,15 @@
 package whelk.converter
 
-import java.text.Normalizer
 import groovy.util.logging.Log4j2 as Log
-
+import org.codehaus.jackson.node.ObjectNode
 import se.kb.libris.util.marc.Controlfield
 import se.kb.libris.util.marc.MarcRecord
 import se.kb.libris.util.marc.io.Iso2709MarcRecordReader
 import se.kb.libris.util.marc.io.MarcXmlRecordReader
-import org.codehaus.jackson.map.ObjectMapper
-import org.codehaus.jackson.node.ObjectNode
 
+import java.text.Normalizer
+
+import static whelk.util.Jackson.mapper
 
 /**
  *
@@ -18,8 +18,6 @@ import org.codehaus.jackson.node.ObjectNode
  */
 @Log
 class MarcJSONConverter {
-
-    protected final static ObjectMapper mapper = new ObjectMapper()
 
     static String old_toJSONString(MarcRecord record) {
         def builder = new groovy.json.JsonBuilder()

--- a/whelk-core/src/main/groovy/whelk/converter/marc/JsonLD2MarcConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/JsonLD2MarcConverter.groovy
@@ -1,17 +1,13 @@
 package whelk.converter.marc
 
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
-import whelk.*
 import whelk.converter.FormatConverter
 
 @Log
 class JsonLD2MarcConverter implements FormatConverter {
 
     protected MarcFrameConverter marcFrameConverter
-    final static ObjectMapper mapper = new ObjectMapper()
-
-
+    
     @Override
     String getResultContentType() { "application/x-marc-json" }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/JsonLD2MarcXMLConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/JsonLD2MarcXMLConverter.groovy
@@ -1,13 +1,14 @@
 package whelk.converter.marc
 
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import org.w3c.dom.DocumentFragment
 import se.kb.libris.util.marc.MarcRecord
 import whelk.Document
 import whelk.JsonLd
 import whelk.converter.FormatConverter
 import whelk.converter.JSONMarcConverter
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class JsonLD2MarcXMLConverter implements FormatConverter {
@@ -28,8 +29,7 @@ class JsonLD2MarcXMLConverter implements FormatConverter {
     }
 
     JsonLD2MarcConverter jsonldConverter = null
-    final static ObjectMapper mapper = new ObjectMapper()
-
+    
     JsonLD2MarcXMLConverter(MarcFrameConverter marcFrameConverter) {
         jsonldConverter = new JsonLD2MarcConverter(marcFrameConverter)
     }
@@ -58,7 +58,7 @@ class JsonLD2MarcXMLConverter implements FormatConverter {
             if (!field.getSubfields("2").isEmpty() && field.getSubfields("2").first().data == "librisxl") {
                 has887Field = true
                 def subFieldA = field.getSubfields("a").first()
-                subFieldA.setData(mapper.writeValueAsString(["@id":identifier,"modified":modified,"checksum":checksum]))
+                subFieldA.setData(mapper.writeValueAsString(["@id":identifier, "modified":modified, "checksum":checksum]))
             }
         }
         if (!has887Field) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameCli.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameCli.groovy
@@ -7,6 +7,7 @@ import whelk.JsonLdValidator.Error
 import whelk.Whelk
 import whelk.filter.LinkFinder
 
+import static whelk.util.Jackson.mapper
 
 List fpaths
 def cmd = "convert"
@@ -86,8 +87,8 @@ static void addJsonLd(converter) {
     def displayFile = new File("$defsbuild/vocab/display.jsonld")
     assert displayFile.exists(), "Missing display file: ${displayFile}"
 
-    def contextData = converter.mapper.readValue(contextFile, Map)
-    def displayData = converter.mapper.readValue(displayFile, Map)
-    def vocabData = converter.mapper.readValue(vocabFile, Map)
+    def contextData = mapper.readValue(contextFile, Map)
+    def displayData = mapper.readValue(displayFile, Map)
+    def vocabData = mapper.readValue(vocabFile, Map)
     converter.ld = new JsonLd(contextData, displayData, vocabData)
 }

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -1,8 +1,6 @@
 package whelk.filter
 
-
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.JsonLd
 import whelk.component.PostgreSQLComponent
@@ -10,7 +8,8 @@ import whelk.exception.LinkValidationException
 
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import java.util.concurrent.ConcurrentHashMap
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class LinkFinder {
@@ -18,8 +17,6 @@ class LinkFinder {
     PostgreSQLComponent postgres
 
     static String ENTITY_QUERY
-    static final ObjectMapper mapper = new ObjectMapper()
-    static final ConcurrentHashMap<String, String> uriCache = new ConcurrentHashMap()
 
     LinkFinder(PostgreSQLComponent pgsql) {
         postgres = pgsql

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -5,13 +5,14 @@ import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Log4j2 as Log
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.JsonLd
 import whelk.Whelk
 import whelk.component.ElasticSearch
 import whelk.exception.InvalidQueryException
 import whelk.util.DocumentUtil
 import whelk.util.Unicode
+
+import static whelk.util.Jackson.mapper
 
 @CompileStatic
 @Log
@@ -21,7 +22,6 @@ class ESQuery {
     private Set keywordFields
     private Set dateFields
     
-    private static final ObjectMapper mapper = new ObjectMapper()
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
         'q', 'o', '_limit', '_offset', '_sort', '_statsrepr', '_site_base_uri', '_debug', '_boost', '_lens', '_suggest', '_site'

--- a/whelk-core/src/main/groovy/whelk/util/DataViewCli.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DataViewCli.groovy
@@ -3,6 +3,8 @@ package whelk.util
 import whelk.Document
 import whelk.Whelk
 
+import static whelk.util.Jackson.mapper
+
 // TODO: factor out and use MarcFrameCli.addJsonLd to allow for local data.
 assert 'xl.secret.properties' in System.properties
 
@@ -20,7 +22,7 @@ def view(cmd, source) {
         //case 'chip':
         //    break
         case 'embellish':
-            return ld.mapper.writeValueAsString(ld.embellish(source))
+            return mapper.writeValueAsString(ld.embellish(source))
         case 'index':
             def doc = new Document(source)
             return whelk.elastic.getShapeForIndex(doc, whelk, null)
@@ -39,7 +41,7 @@ if (args.length > 1) {
 }
 
 for (fpath in fpaths) {
-    def source = ld.mapper.readValue(new File(fpath), Map)
+    def source = mapper.readValue(new File(fpath), Map)
     def result = view(cmd, source)
     println result
 }

--- a/whelk-core/src/main/groovy/whelk/util/Jackson.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Jackson.groovy
@@ -1,0 +1,30 @@
+package whelk.util
+
+import org.codehaus.jackson.JsonGenerator
+import org.codehaus.jackson.JsonProcessingException
+import org.codehaus.jackson.Version
+import org.codehaus.jackson.map.JsonSerializer
+import org.codehaus.jackson.map.ObjectMapper
+import org.codehaus.jackson.map.SerializerProvider
+import org.codehaus.jackson.map.module.SimpleModule
+
+class Jackson {
+    public static final ObjectMapper mapper = mapper()
+    
+    static ObjectMapper mapper() {
+        ObjectMapper mapper = new ObjectMapper()
+        def module = new SimpleModule(GStringSerializer.class.getSimpleName(), GStringSerializer.version)
+        module.addSerializer(GString, new GStringSerializer())
+        mapper.registerModule(module)
+        return mapper
+    }
+
+    static class GStringSerializer extends JsonSerializer<GString> {
+        static Version version = new Version(1, 0, 0, null)
+        
+        @Override
+        void serialize(GString value, JsonGenerator generator, SerializerProvider provider) throws IOException, JsonProcessingException {
+            generator.writeString(value.toString())
+        }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/util/Tools.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Tools.groovy
@@ -1,14 +1,8 @@
 package whelk.util
 
-
-import org.codehaus.jackson.map.ObjectMapper
-import whelk.Document
-
 import java.text.Normalizer
 
 class Tools {
-    static ObjectMapper staticMapper = new ObjectMapper()
-
     /**
      * Detects the content-type of supplied data.
      * TODO: Implement properly.
@@ -143,13 +137,5 @@ class Tools {
         def progressSpinner = ['/','-','\\','|']
         int state = currentCount % (progressSpinner.size()-1)
         print "${message}  ${progressSpinner[state]}                                                                 \r"
-    }
-
-    static Map getDataAsMap(Document doc) {
-        return staticMapper.readValue(doc.getDataAsString(), Map)
-    }
-
-    static String getMapAsString(Map map) {
-        return staticMapper.writeValueAsString(map)
     }
 }

--- a/whelk-core/src/test/groovy/whelk/util/JacksonSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/JacksonSpec.groovy
@@ -1,0 +1,13 @@
+package whelk.util
+
+import spock.lang.Specification
+
+class JacksonSpec extends Specification {
+
+    def "Serialize GString"() {
+        given:
+        def w = 'world'
+        expect:
+        Jackson.mapper.writeValueAsString("Hello, $w!") == '"Hello, world!"'
+    }
+}

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -2,7 +2,6 @@ package whelk.datatool
 
 import com.google.common.util.concurrent.MoreExecutors
 import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl
-import org.codehaus.jackson.map.ObjectMapper
 import whelk.Document
 import whelk.IdGenerator
 import whelk.Whelk
@@ -31,6 +30,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import static java.util.concurrent.TimeUnit.SECONDS
+import static whelk.util.Jackson.mapper
 
 class WhelkTool {
 
@@ -69,7 +69,7 @@ class WhelkTool {
 
     private Throwable errorDetected
 
-    private def jsonWriter = new ObjectMapper().writerWithDefaultPrettyPrinter()
+    private def jsonWriter = mapper.writerWithDefaultPrettyPrinter()
 
     Map<String, Closure> compiledScripts = [:]
 

--- a/whelktool/src/test/groovy/datatool/util/DocumentComparatorSpec.groovy
+++ b/whelktool/src/test/groovy/datatool/util/DocumentComparatorSpec.groovy
@@ -1,13 +1,12 @@
 package datatool.util
 
-import org.codehaus.jackson.map.ObjectMapper
-import spock.lang.Shared
+
 import spock.lang.Specification
 
-class DocumentComparatorSpec extends Specification {
-    @Shared
-    ObjectMapper mapper = new ObjectMapper()
+import static whelk.util.Jackson.mapper
 
+class DocumentComparatorSpec extends Specification {
+    
     def "isEqual"() {
         given:
         DocumentComparator d = new DocumentComparator({ o -> ("ordered" == o) })


### PR DESCRIPTION
Eliminate annoying serialization mishaps.

```
def w = 'world'
mapper.writeValueAsString("Hello, $w!")

// BAD: {"values":["world"],"strings":["Hello, ","!"],"valueCount":1,"bytes":"SGVsbG8sIHdvcmxkIQ=="}
// GOOD: "Hello, world!"
```