### PR TITLE
Add script for adding DST to (more) records 

### DIFF
--- a/whelktool/scripts/cleanups/2021/10/lxl-3696-add-sigel-dst-to-digi-2.groovy
+++ b/whelktool/scripts/cleanups/2021/10/lxl-3696-add-sigel-dst-to-digi-2.groovy
@@ -23,7 +23,6 @@ String where = """
 """
 
 selectBySqlWhere(where) { data ->
-    boolean modified = false
     Map record = data.graph[0]
     Map thing = data.graph[1]
 
@@ -33,10 +32,6 @@ selectBySqlWhere(where) { data ->
 
     if (isDst(record, thing)) {
         record.bibliography << ['@id': 'https://libris.kb.se/library/DST']
-        modified = true
-    }
-
-    if (modified) {
         data.scheduleSave()
     }
 }


### PR DESCRIPTION
LXL-3696:
```
Att göra:

Lägg till i meta.bibliography sigel DST på poster som har

    sigel DIGI "bibliography": [{"@type": "Library","sigel": "DIGI"
    utgivningsland Sverige "country": {"@id": "https://id.kb.se/country/sw" alternativt utgivningsland Finland "country": {"@id": "https://id.kb.se/country/fi" OCH "publication": [ "year" alternativt "date": T.O.M. 1809
    "@type": "Electronic" 
    anmärkning och uri vid "associatedMedia": [{
    "@type": "MediaObject",
    "marc:publicNote": "Fritt tillgänglig...",
    "uri":
    Alternativt (i stället för anmärkningen Fritt tillgänglig) "usageAndAccessPolicy": [
    {
    "@type": "UsageAndAccessPolicy",
    "label": "gratis",
```