### PR TITLE
Change bib 653[i2=5] from Geographic to Place

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -16582,7 +16582,7 @@
         },
         {
           "when": "i2=5",
-          "resourceType": "Geographic"
+          "resourceType": "Place"
         },
         {
           "when": "i2=6",
@@ -16630,7 +16630,7 @@
           }}
         },
         {
-          "name": "Geographic subject",
+          "name": "Place as subject",
           "source": {
             "653": {"ind1": " ", "ind2": "5", "subfields":[
               {"a": "Stockholm"}]
@@ -16641,12 +16641,31 @@
               "@type": "Text",
               "subject": [
                 {
-                  "@type": "Geographic",
+                  "@type": "Place",
                   "label": "Stockholm"
                 }
               ]
             }
           }}
+        },
+        {
+          "name": "Geographic subject should revert to place",
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "subject": [
+                {
+                  "@type": "Geographic",
+                  "label": "Stockholm"
+                }
+              ]
+            }
+          }},
+          "normalized": {
+            "653": {"ind1": " ", "ind2": "5", "subfields":[
+              {"a": "Stockholm"}]
+            }
+          }
         },
         {
           "name": "Change i2=0 to blank (none of our 653s belongs to lcsh)",


### PR DESCRIPTION
This is mainly to be able to use general Place links as geographic subjects when reverting to MARC21.

While incoming MARC21 in practise might intend for these to be Geographic subjects (unlinked), we do not foresee any practical issues with this slight generalization. The semantic difference is just that the implicit Geographic type should/might indicate that the thing is defined by a controlled concept scheme while Place does not imply such formalization. And in practise, this distinction does not hold for incoming data with unlinked geographic names (i.e. they are "just names referring to places").

This depends on https://github.com/libris/definitions/pull/335 to work upon revert.