### PR TITLE
Add API for creating digital reproductions

### DIFF
--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -160,7 +160,7 @@ class ReproductionService {
     private static final def DST = ['@id': 'https://libris.kb.se/library/DST']
     private static final def FACSIMILE = ['@id': 'https://id.kb.se/term/saogf/Faksimiler']
     private static final def ONLINE = ['@id': 'https://id.kb.se/term/rda/OnlineResource']
-    private static final def FREELY_AVAILABLE = ['@id': 'https://id.kb.se/term/freelyAvailable'] //TODO
+    private static final def FREELY_AVAILABLE = ['@id': 'https://id.kb.se/policy/freely-available']
 
     XL xl
     

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -154,8 +154,7 @@ class DigitalReproductionAPI extends HttpServlet {
         response.setHeader('Content-Type', 'application/json')
         mapper.writeValue(response.getOutputStream(), ['code': code, 'msg' : msg ?: ''])
     }
-
-    //TODO
+    
     static String getXlAPI(HttpServletRequest request) {
         "http://localhost:${request.getServerPort()}/"
     }

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -41,6 +41,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK
  - Adds DIGI and DST bibliographies if applicable
  - Adds carrierType rda/OnlineResource if applicable
  - Creates holdings if specified in @reverse.itemOf
+ - Record data can be specified in meta
  
  
  Example (without required authentication headers):

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -297,7 +297,7 @@ class XL {
     void update(Doc doc) {
         String id = doc.data['@graph'][1]['@id']
         def request = requestForPath(id)
-                .header('Content-Type', Util.JSONLD)
+                .header('Content-Type', JSONLD)
                 .header('If-Match', doc.eTag)
                 .PUT(HttpRequest.BodyPublishers.ofByteArray(mapper.writeValueAsBytes(doc.data)))
                 .build()
@@ -323,7 +323,7 @@ class XL {
         ]
 
         def request = requestForPath('')
-                .header('Content-Type', Util.JSONLD)
+                .header('Content-Type', JSONLD)
                 .POST(HttpRequest.BodyPublishers.ofByteArray(mapper.writeValueAsBytes(data)))
                 .build()
         
@@ -338,7 +338,7 @@ class XL {
     
     Optional<Doc> get(String id) {
         def request = requestForPath("${id.split('#').first()}?embellished=false")
-                .header('Accept', Util.JSONLD)
+                .header('Accept', JSONLD)
                 .GET()
                 .build()
         

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -215,7 +215,7 @@ class ReproductionService {
         }
     }
     static boolean isFreelyAvailable(Map thing) {
-        def usageAndAccess = asList(thing.usageAndAccessPolicy) + asList(getAtPath(thing, ['associatedMedia', '*', 'usageAndAccessPolicy', []]))
+        def usageAndAccess = asList(thing.usageAndAccessPolicy) + asList(getAtPath(thing, ['associatedMedia', '*', 'usageAndAccessPolicy'], []))
         usageAndAccess.any { it['@id'] == FREELY_AVAILABLE}
     }
 

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -31,6 +31,18 @@ import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT
 import static javax.servlet.http.HttpServletResponse.SC_OK
 
 /**
+ Creates a record for a digital reproduction.
+ Takes JSON-LD with an Electronic describing the reproduction as input.
+ 
+ - Validates that minimal required data is present in Electronic (all additional data is kept).
+ - Extracts and links work entity from reproduction and original (physical thing)
+ - Copies title from original
+ - Adds genreFrom saofg/Faksimiler
+ - Adds DIGI and DST bibliographies if applicable
+ - Adds carrierType rda/OnlineResource if applicable
+ - Creates holdings if specified in @reverse.itemOf
+ 
+ 
  Example (without required authentication headers):
  
  curl -v -XPOST 'http://localhost:8180/_reproduction' -H 'Content-Type: application/ld+json' --data-binary @- << EOF

--- a/rest/src/main/resources/log4j2.xml
+++ b/rest/src/main/resources/log4j2.xml
@@ -11,9 +11,16 @@
         <File name="File" fileName="${sys:catalina.base}/logs/whelk.log">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </File>
+        <File name="DigitalReproductionApi" fileName="${sys:catalina.base}/logs/digital-reproduction-api.log">
+            <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
     </Appenders>
 
     <Loggers>
+        <Logger name="se.kb.libris.digi" level="info" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="DigitalReproductionApi"/>
+        </Logger>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
             <AppenderRef ref="File" />

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -85,6 +85,10 @@
         <servlet-name>UserDataAPI</servlet-name>
         <servlet-class>whelk.rest.api.UserDataAPI</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>DigitalReproductionAPI</servlet-name>
+        <servlet-class>se.kb.libris.digi.DigitalReproductionAPI</servlet-class>
+    </servlet>
 
 
     <servlet>
@@ -121,6 +125,11 @@
     <servlet-mapping>
         <servlet-name>LegacyVirtualMarc</servlet-name>
         <url-pattern>/_compilemarc</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>DigitalReproductionAPI</servlet-name>
+        <url-pattern>/_reproduction</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>


### PR DESCRIPTION
* Uses XL CRUD API (so that we can move it outside XL if we want)
* Maybe it is too helpful with the bibliographies.

 Creates a record for a digital reproduction.
 Takes JSON-LD with an Electronic describing the reproduction as input.
 
 - Validates that minimal required data is present in Electronic (all additional data is kept).
 - Extracts and links work entity from reproduction and original (physical thing)
 - Copies title from original
 - Adds genreFrom saofg/Faksimiler
 - Adds DIGI and DST bibliographies if applicable
 - Adds carrierType rda/OnlineResource if applicable
 - Creates holdings if specified in @reverse.itemOf
  - Record data can be specified in meta
  
 
 Example (without required authentication headers):
 ```
curl -v -XPOST 'http://localhost:8180/_reproduction' -H 'Content-Type: application/ld+json' --data-binary @- << EOF
{
  "@type": "Electronic",
  "reproductionOf": { "@id": "http://kblocalhost.kb.se:5000/q822pht24j3ljjr#it" },
  "production": [ 
    {
      "@type": "Reproduction",
      "agent": { "@id": "http://kblocalhost.kb.se:5000/jgvxv7m23l9rxd3#it" },
      "place": { "@type": "Place", "label": "Stockholm" },
      "year": "2021"
    } 
  ],
  "meta" : {
    "bibliography": [ {"@id" : "https://libris.kb.se/library/ARB"} ]
  },
  "@reverse" : {
    "itemOf": [
      { "heldBy": { "@id": "https://libris.kb.se/library/S" }},
      { "heldBy": { "@id": "https://libris.kb.se/library/Utb1" }}
    ]
  }
}
EOF
```