### PR TITLE
Generate fallback string for _sortKeyByLang when no lens found

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -852,7 +852,10 @@ class JsonLd {
         }
 
         if (!lens) {
-            throw new FresnelException("No suitable lens found for ${thing.get(ID_KEY)}, tried: ${lensesToTry}")
+            String id = (String) thing.get(ID_KEY)
+            log.warn('applyLensAsMapByLang() No lens found for {}, tried {}', id, lensesToTry)
+            String fallback = id.split('/').last()
+            return languagesToKeep.collectEntries{ [(it) : fallback] }
         }
 
         // Transform the list of language/property value pairs to a map


### PR DESCRIPTION
Instead of throwing an exception that makes the document not getting
indexed at all. This is mostly to avoid a stacktrace when
reindexing definitions (vocab/display and vocab/context) that
might cause unnecessary worry. Even though we maybe don't
care much about these particular documents getting indexed.

Instead just log and return the last URI component as a fallback string

```
2021-11-25T12:13:03,448 [Thread-10] WARN  whelk.JsonLd - applyLensAsMapByLang() No lens found for https://id.kb.se/vocab/display, tried [chips]
2021-11-25T12:13:03,471 [Thread-10] WARN  whelk.JsonLd - applyLensAsMapByLang() No lens found for https://id.kb.se/vocab/context, tried [chips]
```