### PR TITLE
Feature/improve produce if missing

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -260,6 +260,18 @@ class JsonLd {
         return dfn instanceof Map && dfn[CONTAINER_KEY] == LANGUAGE_KEY
     }
 
+    def getPropertyValue(Map entity, String property) {
+        def propertyValue = property ? entity[property] : null
+        if (propertyValue == null) {
+            def alias = langContainerAlias[property]
+            propertyValue = alias ? entity[alias] : null
+            if (propertyValue instanceof Map) {
+                propertyValue = locales.findResult { propertyValue[it] }
+            }
+        }
+        return propertyValue
+    }
+
     String toTermKey(String termId) {
         Integer splitPos = NS_SEPARATORS.findResult {
             int idx = termId.lastIndexOf(it)

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -140,7 +140,6 @@ class MarcConversion {
     Map marcTypeMap = [:]
     Map tokenMaps
     Map defaultPunctuation
-    String locale
 
     private Set missingTerms = [] as Set
     private Set badRepeats = [] as Set
@@ -152,7 +151,6 @@ class MarcConversion {
         this.tokenMaps = tokenMaps
         this.converter = converter
         //this.baseUri = new URI(config.baseUri ?: '/')
-        this.locale = config.locale
         this.keepGroupIds = config.keepGroupIds == true
 
         this.sharedPostProcSteps = config.postProcessing.collect {
@@ -2884,7 +2882,7 @@ class MarcSubFieldHandler extends ConversionPart {
 
             String entityId = entity['@id']
 
-            def propertyValue = getPropertyValue(entity, property)
+            def propertyValue = ld ? ld.getPropertyValue(entity, property) : entity[property]
 
             if (ignoreOnRevert) {
                 continue
@@ -2906,7 +2904,7 @@ class MarcSubFieldHandler extends ConversionPart {
 
             if (propertyValue == null && infer) {
                 for (subProp in ld.getSubProperties(property)) {
-                    propertyValue = getPropertyValue(entity, subProp)
+                    propertyValue = ld.getPropertyValue(entity, subProp)
                     if (propertyValue)
                         break
                 }
@@ -2998,18 +2996,6 @@ class MarcSubFieldHandler extends ConversionPart {
             return null
         else
             return values
-    }
-
-    def getPropertyValue(Map entity, String property) {
-        def propertyValue = property ? entity[property] : null
-        if (propertyValue == null) {
-            def alias = ld ? ld.langContainerAlias[property] : null
-            propertyValue = alias ? entity[alias] : null
-            if (propertyValue instanceof Map) {
-                propertyValue = propertyValue[ruleSet.conversion.locale]
-            }
-        }
-        return propertyValue
     }
 }
 

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -2066,11 +2066,11 @@
             "mainTitle",
             {
               "property": "partNumber",
-              "useValueFormat": {"contentBefore": ", "}
+              "useValueFormat": {"contentBefore": ", ", "contentNoValue": ""}
             },
             {
               "property": "partName",
-              "useValueFormat": {"contentBefore": ". "}
+              "useValueFormat": {"contentBefore": ". ", "contentNoValue": ""}
             }
           ]
         },
@@ -2248,13 +2248,19 @@
         "produceMissing": {
           "produceProperty": "marc:publicNote",
           "showProperties": [
-            {"property": ["usageAndAccessPolicy", "label"]},
+            {
+              "property": ["usageAndAccessPolicy", "label"],
+              "useValueFormat": {
+                "contentNoValue": "Tillgänglig"
+              }
+            },
             {
               "property": ["publisher", "name"],
               "useValueFormat": {
                 "contentFirst": " via ",
                 "contentAfter": " och ",
-                "contentLast": ""
+                "contentLast": "",
+                "contentNoValue": ""
               }
             }
           ]
@@ -2266,9 +2272,88 @@
                 "associatedMedia": [
                   {
                     "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"]
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
                     "uri": ["http://example.com/doc.pdf"],
                     "usageAndAccessPolicy": [
                       {"label": "Fritt tillgänglig"}
+                    ]
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"],
+                    "marc:publicNote": "Fritt tillgänglig",
+                    "usageAndAccessPolicy": [
+                      {"label": "Fritt tillgänglig"}
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"],
+                    "publisher": {"name": "Kungliga biblioteket"}
+                  }
+                ]
+              }
+            },
+            "result": "source",
+            "back": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"],
+                    "marc:publicNote": "Tillgänglig via Kungliga biblioteket",
+                    "publisher": {"name": "Kungliga biblioteket"}
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "source": {
+              "mainEntity": {
+                "associatedMedia": [
+                  {
+                    "@type": "MediaObject",
+                    "uri": ["http://example.com/doc.pdf"],
+                    "usageAndAccessPolicy": [
+                      {"prefLabelByLang": {"sv": "Fritt tillgänglig"}}
                     ],
                     "publisher": [
                       {"name": "Kungliga biblioteket"},
@@ -2287,7 +2372,7 @@
                     "uri": ["http://example.com/doc.pdf"],
                     "marc:publicNote": "Fritt tillgänglig via Kungliga biblioteket och Umeå universitetsbibliotek",
                     "usageAndAccessPolicy": [
-                      {"label": "Fritt tillgänglig"}
+                      {"prefLabelByLang": {"sv": "Fritt tillgänglig"}}
                     ],
                     "publisher": [
                       {"name": "Kungliga biblioteket"},

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -4,8 +4,6 @@
 
   "keepGroupIds": false,
 
-  "locale": "sv",
-
   "TODO:s": [
     "addLink:identifiedBy (+ NOTE:marc-repeatable: false where link)"
   ],


### PR DESCRIPTION
This is done to improve the use of `showProperties` for the `marc:publicNote` added on `associatedMedia` upon revert, specifically handling various combinations and missing values thereof.

This required an adjustment of the generated`seriesStatement` configuration (now requires that to explicitly allow for presence of partial values).

This also dropped the need for the singular (albieit configured) `locale` in `marcframe.json`, instead relying on `locales` in `JsonLd` (alas not yet configurable).