### PR TITLE
Prevent work titles with source from reverting

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2273,6 +2273,10 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         // If this overproduces, it's because _revertedBy fails to prevent it.
         for (rule in matchRules) {
             def matchres = rule.handler.revert(state, data, result, usedMatchRules + [rule])
+            if (rule.handler.ignored && matchres) {
+                return null
+            }
+
             if (matchres) {
                 matchedResults += matchres
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -9859,6 +9859,14 @@
       "match": [
         {
           "when": {
+            "NOTE": "Ignore title with source",
+            "IMPORTANT": "As this is defined, *any* title with source blocks *all* titles from reverting to 240. This is OK as things stand, since titles using source are only added if there is no formal title on the work.",
+            "onRevert": {"hasTitle": [{"source": []}]}
+          },
+          "ignored": true
+        },
+        {
+          "when": {
             "NOTE": "Drop undefined language label",
             "onRevert": {"language": {"@id": "https://id.kb.se/language/und"}}
           },
@@ -10215,6 +10223,23 @@
               }
             }
           }
+        },
+        {
+          "result": {"mainEntity": {
+            "instanceOf": {
+              "@type": "Text",
+              "hasTitle": [{
+                "@type": "Title",
+                "mainTitle": "En bok",
+                "subtitle": "med undertitel",
+                "source": [
+                  {"@id": "https://libris.kb.se/x#it"}
+                ]
+              }]
+            }
+          }},
+          "normalized": [
+          ]
         }
       ]
     },


### PR DESCRIPTION
As this is defined, *any* title with source blocks *all* titles from reverting to 240. This is OK as things stand, since titles using source are only added if there is no formal title on the work.