### PR TITLE
Let kbv: be the prefix for KBV

### DIFF
--- a/librisxl-tools/virtuoso/namespace_prefixes.tsv
+++ b/librisxl-tools/virtuoso/namespace_prefixes.tsv
@@ -4,6 +4,7 @@ ctry	https://id.kb.se/country/
 dce	http://purl.org/dc/elements/1.1/
 dct	http://purl.org/dc/terms/
 foaf	http://xmlns.com/foaf/0.1/
+kbv	https://id.kb.se/vocab/
 lge	https://id.kb.se/language/
 lib	https://libris.kb.se/library/
 madsrdf	http://www.loc.gov/mads/rdf/v1#
@@ -21,4 +22,3 @@ void	http://rdfs.org/ns/void#
 wd	http://www.wikidata.org/entity/
 wdt	http://www.wikidata.org/prop/direct/
 xsd	http://www.w3.org/2001/XMLSchema#
-	https://id.kb.se/vocab/


### PR DESCRIPTION
Since we'll still have terms from different vocabularies I think it makes sense to keep `kbv:` instead of an empty prefix for now.