### PR TITLE
Expose record history summaries via the REST API.

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -21,6 +21,7 @@ import whelk.exception.StaleUpdateException
 import whelk.exception.StorageCreateFailedException
 import whelk.exception.UnexpectedHttpStatusException
 import whelk.exception.WhelkRuntimeException
+import whelk.history.History
 import whelk.rest.api.CrudGetRequest.Lens
 import whelk.rest.security.AccessControl
 import whelk.util.LegacyIntegrationTools
@@ -335,8 +336,12 @@ class Crud extends HttpServlet {
     }
 
     private Object getFormattedResponseBody(CrudGetRequest request, Document doc) {
-        log.debug("Formatting document {}. embellished: {}, framed: {}, lens: {}",
-                doc.getCompleteId(), request.shouldEmbellish(), request.shouldFrame(), request.getLens())
+        log.debug("Formatting document {}. embellished: {}, framed: {}, lens: {}, view: {}",
+                doc.getCompleteId(), request.shouldEmbellish(), request.shouldFrame(), request.getLens(), request.getView())
+        if (request.getView() == CrudGetRequest.View.CHANGE_SETS) {
+            History history = new History(whelk.storage.loadDocumentHistory(doc.getShortId()), jsonld)
+            return history.m_changeSetsMap;
+        }
 
         def transformedResponse
         if (request.getLens() != Lens.NONE) {

--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -77,7 +77,7 @@ class CrudGetRequest {
      * where view is 'data' or 'data-view'
      */
     private void parsePath(String path) {
-        def matcher = path =~ ~/^\/(.+?)(\/(data|data-view)(\.(\w+))?)?$/
+        def matcher = path =~ ~/^\/(.+?)(\/(data|data-view|changesets)(\.(\w+))?)?$/
         if (matcher.matches()) {
             resourceId = matcher[0][1]
             view = View.fromString(matcher[0][3])
@@ -108,7 +108,8 @@ class CrudGetRequest {
     enum View {
         RESOURCE(''),
         DATA('data'),
-        DATA_VIEW('data-view');
+        DATA_VIEW('data-view'),
+        CHANGE_SETS('changesets');
 
         private String name
 

--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -77,7 +77,7 @@ class CrudGetRequest {
      * where view is 'data' or 'data-view'
      */
     private void parsePath(String path) {
-        def matcher = path =~ ~/^\/(.+?)(\/(data|data-view|changesets)(\.(\w+))?)?$/
+        def matcher = path =~ ~/^\/(.+?)(\/(data|data-view|_changesets)(\.(\w+))?)?$/
         if (matcher.matches()) {
             resourceId = matcher[0][1]
             view = View.fromString(matcher[0][3])
@@ -109,7 +109,7 @@ class CrudGetRequest {
         RESOURCE(''),
         DATA('data'),
         DATA_VIEW('data-view'),
-        CHANGE_SETS('changesets');
+        CHANGE_SETS('_changesets');
 
         private String name
 

--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -52,9 +52,9 @@ public class History {
             Map versionLink = new HashMap();
             versionLink.put("@id", version.doc.getCompleteId() + "/data?version=" + i);
             changeSet.put("version", versionLink);
-            changeSet.put("added", new ArrayList<>());
-            changeSet.put("modified", new ArrayList<>());
-            changeSet.put("removed", new ArrayList<>());
+            changeSet.put("addedPaths", new ArrayList<>());
+            changeSet.put("modifiedPaths", new ArrayList<>());
+            changeSet.put("removedPaths", new ArrayList<>());
             changeSet.put("agent", version.changedBy);
             List changeSets = (List) m_changeSetsMap.get("changeSets");
             Map agent = new HashMap();
@@ -96,12 +96,12 @@ public class History {
             addVersion(version, changeSet);
 
             // Clean up empty fields
-            if ( ((List) changeSet.get("added")).isEmpty() )
-                changeSet.remove("added");
-            if ( ((List) changeSet.get("removed")).isEmpty() )
-                changeSet.remove("removed");
-            if ( ((List) changeSet.get("modified")).isEmpty() )
-                changeSet.remove("modified");
+            if ( ((List) changeSet.get("addedPaths")).isEmpty() )
+                changeSet.remove("addedPaths");
+            if ( ((List) changeSet.get("removedPaths")).isEmpty() )
+                changeSet.remove("removedPaths");
+            if ( ((List) changeSet.get("modifiedPaths")).isEmpty() )
+                changeSet.remove("modifiedPaths");
         }
     }
 
@@ -190,7 +190,7 @@ public class History {
                     newPath.add(key);
                     setOwnership(newPath, compositePath, version);
 
-                    ((List) changeSet.get("added")).add(newPath);
+                    ((List) changeSet.get("addedPaths")).add(newPath);
                 }
             }
 
@@ -204,7 +204,7 @@ public class History {
                     removedPath.add(key);
                     clearOwnership(removedPath);
 
-                    ((List) changeSet.get("removed")).add(removedPath);
+                    ((List) changeSet.get("removedPaths")).add(removedPath);
                 }
             }
         }
@@ -212,7 +212,7 @@ public class History {
         if (examining instanceof List) {
             if (! (correspondingPrevious instanceof List) ) {
                 setOwnership(path, compositePath, version);
-                ((List) changeSet.get("modified")).add(path);
+                ((List) changeSet.get("modifiedPaths")).add(path);
                 return;
             }
         }
@@ -221,7 +221,7 @@ public class History {
                 examining instanceof Float || examining instanceof Boolean) {
             if (!examining.equals(correspondingPrevious)) {
                 setOwnership(path, compositePath, version);
-                ((List) changeSet.get("modified")).add(path);
+                ((List) changeSet.get("modifiedPaths")).add(path);
                 return;
             }
         }

--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -271,12 +271,16 @@ public class History {
     }
 
     private boolean wasSavedManually(DocumentVersion version) {
+        return version.changedIn.equals("xl") && !wasScriptEdit(version);
+    }
+
+    public static boolean wasScriptEdit(DocumentVersion version) {
         Instant modifiedInstant = ZonedDateTime.parse(version.doc.getModified()).toInstant();
         Instant generatedInstant = ZonedDateTime.parse(version.doc.getGenerationDate()).toInstant();
         if (generatedInstant != null && generatedInstant.isAfter( modifiedInstant )) {
-            return false;
+            return true;
         }
-        return true;
+        return false;
     }
 
     // DEBUG CODE BELOW THIS POINT

--- a/whelk-core/src/main/groovy/whelk/history/Ownership.java
+++ b/whelk-core/src/main/groovy/whelk/history/Ownership.java
@@ -61,14 +61,17 @@ public class Ownership {
         return sb.toString();
     }
 
+    public static String getSystemChangeDescription(String changedBy, String changedIn) {
+        if (changedBy != null && changedIn != null && changedIn.equals("APIX")) {
+            return "APIX (" + changedBy + ")";
+        } else if (changedBy != null && changedIn != null && changedIn.equals("batch import")) {
+            return "Metadatatratten (" + changedBy + ")";
+        }
+        return "Scripted (XL administrative)";
+    }
+
     private void setSystemChangeDescription(String changedBy, String changedIn) {
         m_systematicEditor = changedBy;
-        if (changedBy != null && changedBy.endsWith(".groovy")) {
-            m_systematicEditorComment = "scripted";
-        } else if (changedBy != null && changedIn != null && changedIn.equals("APIX")) {
-            m_systematicEditorComment = "apix";
-        } else if (changedBy != null && changedIn != null && changedIn.equals("batch import")) {
-            m_systematicEditorComment = "metadatatratten";
-        }
+        m_systematicEditorComment = getSystemChangeDescription(changedBy, changedIn);
     }
 }

--- a/whelk-core/src/main/groovy/whelk/history/Ownership.java
+++ b/whelk-core/src/main/groovy/whelk/history/Ownership.java
@@ -21,7 +21,7 @@ public class Ownership {
             m_manualEditTime = ZonedDateTime.parse(version.doc.getModified()).toInstant();
         }
         // A handmade (or atleast REST-API entered) version
-        else if (version.changedIn.equals("xl") && version.changedBy != null && !version.changedBy.endsWith(".groovy")) {
+        else if (version.changedIn.equals("xl") && version.changedBy != null && !History.wasScriptEdit(version)) {
             m_manualEditor = version.changedBy;
             m_manualEditTime = ZonedDateTime.parse(version.doc.getModified()).toInstant();
         }


### PR DESCRIPTION
This compiles a summary of a records history, and makes it
availble under the pattern:
[baseuri]/katalogisering/[xlid]/changesets

Example of output:
```
$ curl "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/changesets" | jq
{
  "@id": "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/changesets",
  "changeSets": [
    {
      "date": "2021-06-23T09:30:56.617+02:00",
      "agent": "WhelkCopier",
      "@type": "ChangeSet",
      "manualEdit": true,
      "version": {
        "@id": "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/data?version=0"
      }
    },
    {
      "date": "2021-12-02T10:49:19.468+01:00",
      "agent": "SEK",
      "added": [
        [
          "@graph",
          0,
          "descriptionLastModifier"
        ],
        [
          "@graph",
          1,
          "birthPlace"
        ],
        [
          "@graph",
          1,
          "hasNote"
        ]
      ],
      "@type": "ChangeSet",
      "manualEdit": true,
      "modified": [
        [
          "@graph",
          0,
          "modified"
        ]
      ],
      "version": {
        "@id": "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/data?version=1"
      }
    },
    {
      "date": "2021-12-02T10:50:51.517+01:00",
      "agent": "SEK",
      "added": [
        [
          "@graph",
          1,
          "birthDate"
        ]
      ],
      "@type": "ChangeSet",
      "manualEdit": true,
      "modified": [
        [
          "@graph",
          0,
          "modified"
        ]
      ],
      "version": {
        "@id": "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/data?version=2"
      }
    },
    {
      "date": "2021-12-02T11:12:19.41+01:00",
      "note": "Scripted (XL administrative)",
      "agent": "SEK",
      "removed": [
        [
          "@graph",
          0,
          "descriptionLastModifier"
        ],
        [
          "@graph",
          1,
          "birthPlace"
        ],
        [
          "@graph",
          1,
          "hasNote"
        ],
        [
          "@graph",
          1,
          "birthDate"
        ]
      ],
      "@type": "ChangeSet",
      "manualEdit": false,
      "modified": [
        [
          "@graph",
          0,
          "generationDate"
        ],
        [
          "@graph",
          0,
          "generationProcess",
          "@id"
        ]
      ],
      "version": {
        "@id": "http://kblocalhost.kb.se:5000/dbqt2g7x2p1fl3g/data?version=3"
      }
    }
  ],
  "@context": "/context.jsonld"
}
```