### PR TITLE
ES index: Fix missing _str when using alternateProperties in lens

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -925,7 +925,7 @@ class JsonLd {
         }
         if (lens) {
             List propertiesToKeep = (List) lens.get("showProperties")
-                    .collect { prop -> isAlternateProperties(prop) ? prop['alternateProperties'] : prop}
+                    .collect { prop -> isAlternateProperties(prop) ? prop['alternateProperties'] : prop }
                     .flatten()
             
             for (prop in propertiesToKeep) {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -925,6 +925,11 @@ class JsonLd {
         }
         if (lens) {
             List propertiesToKeep = (List) lens.get("showProperties")
+            propertiesToKeep = propertiesToKeep.collect { prop ->
+                isAlternateProperties(prop)
+                        ? prop['alternateProperties']
+                        : prop
+            }.flatten()
             for (prop in propertiesToKeep) {
                 def values = object[prop]
                 if (isLangContainer(context[prop]) && values instanceof Map) {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -925,11 +925,9 @@ class JsonLd {
         }
         if (lens) {
             List propertiesToKeep = (List) lens.get("showProperties")
-            propertiesToKeep = propertiesToKeep.collect { prop ->
-                isAlternateProperties(prop)
-                        ? prop['alternateProperties']
-                        : prop
-            }.flatten()
+                    .collect { prop -> isAlternateProperties(prop) ? prop['alternateProperties'] : prop}
+                    .flatten()
+            
             for (prop in propertiesToKeep) {
                 def values = object[prop]
                 if (isLangContainer(context[prop]) && values instanceof Map) {


### PR DESCRIPTION
Picking all existing properties gives similar result to before `alternateProperties` was introduced. 
(note "Svenska swe" vs "Svenska" below)
We should maybe re-evaluate this depending on our future usage of `alternateProperties`


Before fix
```
olov@olov-XPS-13-9370:~$ curl -s localhost:9200/whelk_dev/_doc/97mpsvst0mss2fd | gron | grep _str
json._source.meta._str = "244795";
json._source.meta.descriptionCreator._str = "Nationalbibliografin NB";
```

After fix
```
olov@olov-XPS-13-9370:~$ curl -s localhost:9200/whelk_dev/_doc/97mpsvst0mss2fd | gron | grep _str
json._source._str = "Hundar";
json._source.broader[0]._str = "Däggdjur";
json._source.broader[0].inScheme._str = "Barnämnesord barn";
json._source.inScheme._str = "Barnämnesord barn";
json._source.meta._str = "244795";
json._source.meta.descriptionCreator._str = "Nationalbibliografin NB";
json._source.meta.descriptionLanguage._str = "Svenska swe";
```

pre 1.24
```
olov@olov-XPS-13-9370:~$ curl -s "branch-dev2.libris.kb.se:9200/libris_dev2/_doc/97mpsvst0mss2fd" | gron | grep _str
json._source._str = "Hundar";
json._source.broader[0]._str = "Däggdjur";
json._source.broader[0].inScheme._str = "Barnämnesord barn";
json._source.inScheme._str = "Barnämnesord barn";
json._source.meta._str = "244795";
json._source.meta.descriptionCreator._str = "Nationalbibliografin NB";
json._source.meta.descriptionLanguage._str = "Svenska";
```