### PR TITLE
Fix ETag quotes

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -690,7 +690,7 @@ class Crud extends HttpServlet {
         savedDoc = saveDocument(newDoc, request, response, isUpdate, "POST")
         if (savedDoc != null) {
             sendCreateResponse(response, savedDoc.getURI().toString(),
-                               savedDoc.getChecksum(jsonld))
+                    ETag.plain(savedDoc.getChecksum(jsonld)))
         } else if (!response.isCommitted()) {
             sendNotFound(response, request.getContextPath())
         }
@@ -828,7 +828,7 @@ class Crud extends HttpServlet {
         Document savedDoc = saveDocument(updatedDoc, request, response, isUpdate, "PUT")
         if (savedDoc != null) {
             sendUpdateResponse(response, savedDoc.getURI().toString(),
-                               savedDoc.getChecksum(jsonld))
+                    ETag.plain(savedDoc.getChecksum(jsonld)))
         }
 
     }
@@ -927,22 +927,22 @@ class Crud extends HttpServlet {
     }
 
     static void sendCreateResponse(HttpServletResponse response, String locationRef,
-                                   String etag) {
-        sendDocumentSavedResponse(response, locationRef, etag, true)
+                                   ETag eTag) {
+        sendDocumentSavedResponse(response, locationRef, eTag, true)
     }
 
     static void sendUpdateResponse(HttpServletResponse response, String locationRef,
-                                   String etag) {
-        sendDocumentSavedResponse(response, locationRef, etag, false)
+                                   ETag eTag) {
+        sendDocumentSavedResponse(response, locationRef, eTag, false)
     }
 
     static void sendDocumentSavedResponse(HttpServletResponse response,
-                                          String locationRef, String etag,
+                                          String locationRef, ETag eTag,
                                           boolean newDocument) {
         log.debug("Setting header Location: $locationRef")
 
         response.setHeader("Location", locationRef)
-        response.setHeader("ETag", "\"${etag as String}\"")
+        response.setHeader("ETag", eTag.toString())
         response.setHeader('Cache-Control', 'no-cache')
 
         if (newDocument) {

--- a/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
@@ -249,9 +249,9 @@ class CrudUtils {
         }
 
         String toString() {
-            embellished ? "$plain$SEPARATOR$embellished" : plain
+            "\"${ embellished ? "$plain$SEPARATOR$embellished" : plain }\""
         }
-        
+
         boolean isNotModified(ETag ifNoneMatch) {
             if (plain != ifNoneMatch.plain) {
                 return false


### PR DESCRIPTION
ETag header should always be a string within quotes: "<etag_value>"
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag

And also use ETag class in `sendDocumentSavedResponse()`