### PR TITLE
Make it possible to write merge rules targeting list members.

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -18,7 +18,7 @@ public class Merge {
         "rules": [
             {
                 "operation": "replace",
-                "path": ["@graph", 1, "hasTitle"],
+                "path": ["@graph", 1, "hasTitle", "@type=Title", "subtitle"],
                 "priority":  {
                     "Utb1": 10,
                     "Utb2": 11
@@ -30,8 +30,19 @@ public class Merge {
             }
         ]
     }
-
+    The "paths" in use here work the same way PostgresSQL paths do, but with
+    some exceptions.
+    1. Other than the surrounding @graph list (@graph,X), it is not possible
+       to specify list indexes. So for example:
+       ["@graph", 1, "hasTitle", 0, "subtitle"] is not allowed (the "0" being the problem).
+    2. It is however allowed to target elements in lists using type specifiers. So for example
+       ["@graph", 1, "hasTitle", "@type=Title", "subtitle"] is ok, BUT WILL ONLY WORK if there
+       is exactly one title with @type=Title in both existing and incoming records. If either
+       record has more than one (or none) of these, there is no way to identify which one is
+       being targeted.
      */
+
+    // TODO: GENERATE A LOG OF _CHANGES MADE_ AND PERHAPS CHANGES NOT MADE!
 
     // Contains paths where we're allowed to add things that don't already exist
     private Set<List<Object>> m_pathAddRules = null;
@@ -178,7 +189,93 @@ public class Merge {
                             baseHistory);
                 }
             }
+        } else if (base instanceof List && correspondingIncoming instanceof List) {
+            // The idea here, is that if a list contains only a single element (per type)
+            // In both existing and incoming records, then we can allow ourselves to assume
+            // that those elements represent the same entity. If however there are more than
+            // one, then no such assumptions can be made.
+            //
+            // So for example given existing @graph,1,hasTitle :
+            // [ { "@type":"Title", mainTitle:"A" }, { "@type":"SpineTitle", mainTitle:"B" } ]
+            // and an incoming @graph,1,hasTitle :
+            // [ { "@type":"Title", mainTitle:"C" }, { "@type":"SpineTitle", mainTitle:"D" } ]
+            // We will allow the "path" @graph,1,hasTitle,@type=Title,mainTitle (with a type
+            // specification instead of list index) to specify the one and only title entity with
+            // that type.
+            //
+            // Only exact type matches are considered, inheritance is meaningless in this context!
+
+            List baseList = (List) base;
+            List incomingList = (List) correspondingIncoming;
+
+            Set<String> singleInstanceTypes = findSingleInstanceTypesInBoth(baseList, incomingList);
+
+            // For each type of which there is exactly one instance in each list
+            for (String type : singleInstanceTypes) {
+
+                // Find the one instance of that type in each list
+                Map baseChild = null;
+                Map incomingChild = null;
+                for (Object o : baseList) {
+                    if (o instanceof Map) {
+                        Map m = (Map) o;
+                        if (m.containsKey("@type") && m.get("@type").equals(type))
+                            baseChild = m;
+                    }
+                }
+                for (Object o : incomingList) {
+                    if (o instanceof Map) {
+                        Map m = (Map) o;
+                        if (m.containsKey("@type") && m.get("@type").equals(type))
+                            incomingChild = m;
+                    }
+                }
+
+                // Keep scanning
+                List<Object> childPath = new ArrayList(path);
+                childPath.add("@type="+type);
+                mergeInternal( baseChild, incomingList,
+                        incomingChild,
+                        childPath,
+                        incomingAgent,
+                        baseHistory);
+            }
         }
+    }
+
+    /**
+     * Find the types of which there are exactly one instance in each list
+     */
+    private Set<String> findSingleInstanceTypesInBoth(List a, List b) {
+        HashMap<String, Integer> typeCountsA = countTypes(a);
+        HashMap<String, Integer> typeCountsB = countTypes(b);
+        Set<String> singleInstanceTypes = new HashSet<>();
+        for (String type : typeCountsA.keySet()) {
+            if (typeCountsB.containsKey(type) &&
+                    typeCountsA.get(type) == 1 &&
+                    typeCountsB.get(type) == 1) {
+                singleInstanceTypes.add(type);
+            }
+        }
+        return singleInstanceTypes;
+    }
+
+    private HashMap<String, Integer> countTypes(List list) {
+        HashMap<String, Integer> typeCounts = new HashMap<>();
+        for (Object o : list) {
+            if (o instanceof Map) {
+                Map map = (Map) o;
+                if (map.get("@type") != null) {
+                    String type = (String) map.get("@type");
+                    if (!typeCounts.containsKey(type)) {
+                        typeCounts.put(type, 1);
+                    } else {
+                        typeCounts.put(type, typeCounts.get(type) + 1);
+                    }
+                }
+            }
+        }
+        return typeCounts;
     }
 
     private boolean subtreeContainsLinks(Object object) {


### PR DESCRIPTION
When an incoming record is to be merged with an existing record,
and the rules in play say to target a member of a list, say for
example you want to replace:
["@graph", 1, "instanceOf", "contribution", 0, "agent"].

This doesn't work, because there is no way to know that item 0
in the incoming "contribution" list is really the same entity
as item 0 in the existing list. After all there could be any
number of items in either list, and in any order.

What this does, is to allow the rules to make certain assumptions
in cases where there is only a single item in both of the lists of a
certain type.

For example, the above (not working) path could now instead be
written as:
["@graph", 1, "instanceOf", "contribution", "@type=PrimaryContribution", "agent"].

which will now work _IF AND ONLY IF_ both records have only a
single PrimaryContribution. If this is not the case, there's
nothing we can do, and the rule has no effect for that record.