### PR TITLE
Fix clean up after deleted documents

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -376,7 +376,7 @@ class Whelk {
         storage.remove(id, changedIn, changedBy)
         if (elastic && !skipIndex) {
             elastic.remove(id)
-            reindexAffected(doc, doc.getExternalRefs(), new TreeSet<>())
+            reindexAffected(doc, doc.getExternalRefs(), Collections.emptySet())
             log.debug "Object ${id} was removed from Whelk"
         }
         else {

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -71,8 +71,10 @@ class DependencyCache {
         thingIris.addAll(preUpdateDoc.getThingIdentifiers())
         thingIris.addAll(postUpdateDoc.getThingIdentifiers())
 
-        Set<Link> added = (postUpdateDoc.getExternalRefs() - preUpdateDoc.getExternalRefs())
-        Set<Link> removed = (preUpdateDoc.getExternalRefs() - postUpdateDoc.getExternalRefs())
+        Set<Link> before = preUpdateDoc.getExternalRefs()
+        Set<Link> after = postUpdateDoc.deleted ? Collections.emptySet() : postUpdateDoc.getExternalRefs()
+        Set<Link> added = (after - before)
+        Set<Link> removed = (before - after)
 
         (added + removed).each { Link link ->
             thingIris.each { fromIri ->

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1249,11 +1249,10 @@ class PostgreSQLComponent {
     }
 
     protected void deleteCard(Document doc, Connection connection) {
-        String systemId = getSystemIdByIri(doc.getThingIdentifiers().first())
         PreparedStatement preparedStatement = null
         try {
             preparedStatement = connection.prepareStatement(DELETE_CARD)
-            preparedStatement.setString(1,systemId)
+            preparedStatement.setString(1, doc.getShortId())
 
             preparedStatement.executeUpdate()
         }


### PR DESCRIPTION
Fix the following two issues related to document deletion when the deleted document has "`@reverse` relations" to other documents.

If e.g. "<sao/Digitala möten>" which has `broader` "<sao/Möten>" is deleted
* "<sao/Möten>" is not reindexed
* A (broken) link to "<sao/Digitala möten>" is still included under `@reverse/broader` in embellished "<sao/Möten>"