### PR TITLE
Workaround for marc_export.jar output garbled by log4j warning

### DIFF
--- a/marc_export/build.gradle
+++ b/marc_export/build.gradle
@@ -54,8 +54,14 @@ gretty {
 
 jar {
     dependsOn ':whelk-core:jar'
+
+    // 'Multi-Release': 'true' is needed because log4j2-api is a 'Multi-Release' jar and selects "StackLocator"
+    // implementation based on JDK version. If we build our fat jar without 'Multi-Release' it will not find the 
+    // JDK9+ version and log a warning to STDOUT (not STDERR...) messing up the output of this program.
+    // "WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance."
     manifest {
-        attributes "Main-Class": "whelk.export.marc.MarcCliExport"
+        attributes "Main-Class": "whelk.export.marc.MarcCliExport", 
+                'Multi-Release': 'true' 
     }
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE


### PR DESCRIPTION
We should fix this everywhere but let's start with marc_export.jar.
Maybe it's time to get rid of log4j completely...