### PR TITLE
Change resourceTypes to Material in 340 and add specs

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -11702,6 +11702,28 @@
           }
         },
         {
+          "Name": "Huvudsaklig resurs och medföljande",
+          "source": [
+            {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "250 sidor"},{"e": "1 CD-ROM"}]}}
+          ],
+          "result": {
+            "mainEntity": 
+            {
+              "extent": [
+                {
+                  "@type": "Extent",
+                  "label": "250 sidor"
+                }
+              ],
+              "accompaniedBy":
+                {
+                  "@type": "Resource",
+                  "label": "1 CD-ROM"
+                }
+            }
+          }
+        },
+        {
           "Name": "Import med interpunktion i flera fält",
           "source": [
             {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "11 volumes :"},{"b": "illustrations ;"},{"c": "24 cm"}]}}
@@ -12503,7 +12525,7 @@
       "$a": {
         "TODO": "Add the separate lists used for cataloging, as enumerations",
         "addLink": "baseMaterial",
-        "resourceType": "BaseMaterial",
+        "resourceType": "Material",
         "property": "label"
       },
       "$b": {
@@ -12517,7 +12539,7 @@
       "$c": {
         "TODO": "Add the separate lists used for cataloging, as enumerations",
         "addLink": "appliedMaterial",
-        "resourceType": "AppliedMaterial",
+        "resourceType": "Material",
         "property": "label"
       },
       "$d": {
@@ -12583,24 +12605,40 @@
       },
       "_spec": [
         {
+          "name": "baseMaterial",
+          "source":  [
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"a": "papper"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "baseMaterial": [
+                {
+                  "@type": "Material",
+                  "label": "papper"
+                }
+              ]
+            }
+          }
+        },
+        {
           "name": "Property clash between 300c from 340b producing doubled fields in MARC. (340 ignored on revert)",
           "source":  [
-            {"300": {"ind1": " ", "ind2": " ", "subfields": [{"c": "film 300"}]}},
-            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"b": "film 340"}]}}
+            {"300": {"ind1": " ", "ind2": " ", "subfields": [{"c": "film 300c"}]}},
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"b": "film 340b"}]}}
           ],
           "normalized":  [
-            {"300": {"ind1": " ", "ind2": " ", "subfields": [{"c": "film 300"},{"c": "film 340"}]}}
+            {"300": {"ind1": " ", "ind2": " ", "subfields": [{"c": "film 300c"},{"c": "film 340b"}]}}
           ],
           "result": {
             "mainEntity": {
               "hasDimensions": [
                 {
                   "@type": "Dimensions",
-                  "label": "film 300"
+                  "label": "film 300c"
                 },
                 {
                   "@type": "Dimensions",
-                  "label": "film 340"
+                  "label": "film 340b"
                 }
               ]
             }
@@ -12622,7 +12660,7 @@
             "mainEntity": {
               "baseMaterial": [
                 {
-                  "@type": "BaseMaterial",
+                  "@type": "Material",
                   "label": "film"
                 }
               ],
@@ -12644,6 +12682,38 @@
                       "label": "original"
                     }
                   ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "appliedMaterial",
+          "source":  [
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"c": "akvarell"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "appliedMaterial": [
+                {
+                  "@type": "Material",
+                  "label": "akvarell"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "productionMethod",
+          "source":  [
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"d": "gravyr"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "productionMethod": [
+                {
+                  "@type": "ProductionMethod",
+                  "label": "gravyr"
                 }
               ]
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -12526,7 +12526,7 @@
         "TODO": "Add the separate lists used for cataloging, as enumerations",
         "addLink": "baseMaterial",
         "resourceType": "Material",
-        "property": "label"
+        "property": "label", "infer": true
       },
       "$b": {
         "NOTE:LC": "bf2marcSpec-3XX-v1.0: nac - Cannot be differeneted from 300 $c",
@@ -12540,7 +12540,7 @@
         "TODO": "Add the separate lists used for cataloging, as enumerations",
         "addLink": "appliedMaterial",
         "resourceType": "Material",
-        "property": "label"
+        "property": "label", "infer": true
       },
       "$d": {
         "TODO": "Add the separate lists used for cataloging, as enumerations. Ensure this doesn't clash with 007 13:14 Sound",
@@ -12615,6 +12615,23 @@
                 {
                   "@type": "Material",
                   "label": "papper"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "baseMaterial linked",
+          "normalized":  [
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"a": "papper"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "baseMaterial": [
+                {
+                  "@id": "https://id.kb.se/material/Paper",
+                  "@type": "Material",
+                  "prefLabel": "papper"
                 }
               ]
             }
@@ -12698,6 +12715,23 @@
                 {
                   "@type": "Material",
                   "label": "akvarell"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "appliedMaterial linked",
+          "normalized":  [
+            {"340": {"ind1": " ", "ind2": " ", "subfields": [{"c": "akvarell"}]}}
+          ],
+          "result": {
+            "mainEntity": {
+              "appliedMaterial": [
+                {
+                  "@id": "https://id.kb.se/material/Watercolour",
+                  "@type": "Material",
+                  "prefLabel": "akvarell"
                 }
               ]
             }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -12523,7 +12523,7 @@
       },
       "aboutEntity": "?thing",
       "$a": {
-        "TODO": "Add the separate lists used for cataloging, as enumerations",
+        "NOTE": "Linked enumerations only at revert from https://id.kb.se/material/",
         "addLink": "baseMaterial",
         "resourceType": "Material",
         "property": "label", "infer": true
@@ -12537,7 +12537,7 @@
         "punctuationChars": ":;+"
       },
       "$c": {
-        "TODO": "Add the separate lists used for cataloging, as enumerations",
+        "NOTE": "Linked enumerations only at revert from https://id.kb.se/material/",
         "addLink": "appliedMaterial",
         "resourceType": "Material",
         "property": "label", "infer": true


### PR DESCRIPTION
- Change Type `AppliedMaterial` and `BaseMaterial` to only `Material` in conversion bib 340.
- Add inference for linked objects with prefLabel
- Add specs