### PR TITLE
Feature/merge ignore some links

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -147,9 +147,22 @@ public class Merge {
                 }
             }
 
+            // Determine if the subtree that is to potentially be replaced contains links.
+            // If it does, it should generally speaking not be replaced. But there is a list
+            // of exceptions to this rule:
+            boolean containsSanctifiedLinks = subtreeContainsLinks(base);
+            // instanceOf,language may be overwritten
+            if (path.size() > 1 && path.get(path.size()-1).equals("language") && path.get(path.size()-2).equals("instanceOf")) {
+                containsSanctifiedLinks = false;
+            }
+            // publication,*,country may be overwritten
+            if (path.size() > 2 && path.get(path.size()-1).equals("country") && path.get(path.size()-3).equals("publication")) {
+                containsSanctifiedLinks = false;
+            }
+
             // Execute replacement if appropriate
             if (!baseContainsHandEdits && incomingPriorityHere >= basePriorityHere &&
-                    !subtreeContainsLinks(base)) {
+                    !containsSanctifiedLinks) {
                 if (baseParent instanceof Map) {
                     Map parentMap = (Map) baseParent;
                     parentMap.put(path.get(path.size()-1), correspondingIncoming);

--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -151,13 +151,15 @@ public class Merge {
             // If it does, it should generally speaking not be replaced. But there is a list
             // of exceptions to this rule:
             boolean containsSanctifiedLinks = subtreeContainsLinks(base);
-            // instanceOf,language may be overwritten
-            if (path.size() > 1 && path.get(path.size()-1).equals("language") && path.get(path.size()-2).equals("instanceOf")) {
-                containsSanctifiedLinks = false;
-            }
-            // publication,*,country may be overwritten
-            if (path.size() > 2 && path.get(path.size()-1).equals("country") && path.get(path.size()-3).equals("publication")) {
-                containsSanctifiedLinks = false;
+            for (int i = path.size(); i > 1; --i) {
+                // instanceOf,language links may be overwritten
+                if (i > 1 && path.get(i-1).equals("language") && path.get(i-2).equals("instanceOf")) {
+                    containsSanctifiedLinks = false;
+                }
+                // publication,*,country links may be overwritten
+                if (path.size() > 2 && path.get(i-1).equals("country") && path.get(i-3).equals("publication")) {
+                    containsSanctifiedLinks = false;
+                }
             }
 
             // Execute replacement if appropriate


### PR DESCRIPTION
Create exceptions to the rule that "objects containing links may never be replaced in the merge process".

With this change, a few select sorts of objects may be replaced even if they contain links.