### PR TITLE
CRUD: Enable all JSON-LD validation for POST

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -649,9 +649,8 @@ class Crud extends HttpServlet {
         newDoc.normalizeUnicode()
         newDoc.deepReplaceId(Document.BASE_URI.toString() + IdGenerator.generate())
         newDoc.setControlNumber(newDoc.getShortId())
-
-        String collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, jsonld)
-        List<JsonLdValidator.Error> errors = validator.validate(newDoc.data, collection)
+        
+        List<JsonLdValidator.Error> errors = validator.validateAll(newDoc.data)
         if (errors) {
             failedRequests.labels("POST", request.getRequestURI(),
                     HttpServletResponse.SC_BAD_REQUEST.toString()).inc()


### PR DESCRIPTION
New documents should always be valid even though we haven't cleaned up all existing data yet.

Might break "create new from file" with old documents.