### PR TITLE
Remove imageBitDepth in hold-data

### DIFF
--- a/whelktool/scripts/cleanups/2022/03/lxl-3828-remove-hold-imageBitDepth.groovy
+++ b/whelktool/scripts/cleanups/2022/03/lxl-3828-remove-hold-imageBitDepth.groovy
@@ -1,0 +1,16 @@
+/**
+ * Removes imageBitDepth from hold records. (All have only '---' as values).
+ *
+ * See LXL-3828 for more info.
+ */
+
+String where = """
+  collection = 'hold' AND
+  deleted = false AND
+  data#>>'{@graph,1,imageBitDepth}' IS NOT NULL
+  """
+
+selectBySqlWhere(where) { data ->
+  if(data.graph[1].remove('imageBitDepth'))
+    data.scheduleSave()
+}


### PR DESCRIPTION
Remove validation errors `Unknown term. Missing definition.`: Old datatype form and only `---` values in 94 hold-records.