### PR TITLE
Search: Use dfs_query_then_fetch 

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -22,6 +22,7 @@ import static whelk.util.Jackson.mapper
 @Log
 class ElasticSearch {
     static final String BULK_CONTENT_TYPE = "application/x-ndjson"
+    static final String SEARCH_TYPE = "dfs_query_then_fetch"
 
     static final Set<String> LANGUAGES_TO_INDEX = ['sv', 'en'] as Set
     static final List<String> REMOVABLE_BASE_URIS = [
@@ -422,7 +423,7 @@ class ElasticSearch {
     Map queryIds(Map jsonDsl) {
         return performQuery(
                 jsonDsl,
-                getQueryUrl() + '?filter_path=took,hits.total,hits.hits._id',
+                getQueryUrl(['took','hits.total','hits.hits._id']),
                 { it."_id" }
         )
     }
@@ -493,8 +494,12 @@ class ElasticSearch {
         }
     }
 
-    private String getQueryUrl() {
-        return "/${indexName}/_search"
+    private String getQueryUrl(filterPath = []) {
+        def url = "/${indexName}/_search?search_type=$SEARCH_TYPE"
+        if (filterPath) {
+            url += "&filter_path=${filterPath.join(',')}"
+        }
+        return url.toString()
     }
 
     static String toElasticId(String id) {
@@ -600,7 +605,7 @@ class ElasticSearch {
 
         @Override
         String queryPath() {
-            "/${indexName}/_search?filter_path=$filterPath"
+            "/${indexName}/_search?search_type=$SEARCH_TYPE&filter_path=$filterPath"
         }
 
         @Override
@@ -657,7 +662,7 @@ class ElasticSearch {
 
         @Override
         String queryPath() {
-            "/_search?filter_path=$filterPath"
+            "/_search?search_type=$SEARCH_TYPE&filter_path=$filterPath"
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -662,7 +662,9 @@ class ElasticSearch {
 
         @Override
         String queryPath() {
-            "/_search?search_type=$SEARCH_TYPE&filter_path=$filterPath"
+            isPitApiAvailable // point in time is created on index and then index cannot be specified here 
+                    ? "/_search?search_type=$SEARCH_TYPE&filter_path=$filterPath" 
+                    : "/${indexName}/_search?search_type=$SEARCH_TYPE&filter_path=$filterPath"
         }
 
         @Override


### PR DESCRIPTION
Two things
* Use dfs_query_then_fetch 
* Fix a bug where search_after would query all indices instead of a specific one



Use normalized index statistics: dfs_query_then_fetch [1]

Fix search relevancy issue. prefLabel is boosted alot for concepts.
Since each term in preflabel is pretty rare across all indexed
documents the idf value for the term might vary alot across shards.

Specifically, "n, number of documents containing term", seems to get
skewed for a while after a document has been updated alot?
For instance when reverseLinks.totalItems is updated.

Example
prefLabel:sverige

sao/Sverige--Östergötland
idf: n=74, N=12116
```
{
  "value": 5.0915656,
  "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
  "details": [
    {
      "value": 74,
      "description": "n, number of documents containing term",
      "details": []
    },
    {
      "value": 12116,
      "description": "N, total number of documents with field",
      "details": []
    }
  ]
}
```

sao/Sverige
idf: n=315, N=12019
```
{
  "value": 3.6401684,
  "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
  "details": [
    {
      "value": 315,
      "description": "n, number of documents containing term",
      "details": []
    },
    {
      "value": 12019,
      "description": "N, total number of documents with field",
      "details": []
    }
  ]
},

```

See LXL-3837.