### PR TITLE
Refactor Crud::getFormattedResponseBody

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -72,8 +72,8 @@ class CrudGetRequest {
         return lens
     }
 
-    String getProfile() {
-        return profile
+    Optional<String> getProfile() {
+        return Optional.ofNullable(profile)
     }
 
     /**


### PR DESCRIPTION
Minor restructuring. Don't modify response inside `getFormattedResponseBody`.
Fix 400 Bad Request on missing profile.