### PR TITLE
DELETE instead of TRUNCATE embellish cache.

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -134,7 +134,7 @@ class PostgreSQLComponent {
     private static final String GET_TABLE_SIZE_BYTES =
             "SELECT pg_total_relation_size(?)"
 
-    private static final String CLEAR_EMBELLISHED = "TRUNCATE TABLE lddb__embellished"
+    private static final String CLEAR_EMBELLISHED = "DELETE FROM lddb__embellished"
 
     private static final String GET_DOCUMENT_VERSION_BY_MAIN_ID = """
             SELECT id, data 


### PR DESCRIPTION
Truncating a table, while faster, is beleived to be problematic
because an exclusive lock on the table is necesseray. Obtaining
this lock while other transations are active may be the reason for
DB lock ups while trying to copy data to another environment
(this is however unproven).