### PR TITLE
CRUD API: Refactor error handling

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/BadRequestException.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/BadRequestException.groovy
@@ -1,9 +1,13 @@
 package whelk.rest.api
 
-class BadRequestException extends RuntimeException {
-    Object extraInfo // TODO: use
-    BadRequestException(String msg, Object extraInfo = null) {
+class BadRequestException extends Crud.NoStackTraceException {
+    Map extraInfo
+    BadRequestException(String msg, Map extraInfo = null) {
         super(msg)
         this.extraInfo = extraInfo
+    }
+    
+    Map getExtraInfo() {
+        return extraInfo ?: Collections.EMPTY_MAP
     }
 }

--- a/rest/src/main/groovy/whelk/rest/api/BadRequestException.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/BadRequestException.groovy
@@ -1,7 +1,9 @@
 package whelk.rest.api
 
 class BadRequestException extends RuntimeException {
-    BadRequestException(String msg) {
+    Object extraInfo // TODO: use
+    BadRequestException(String msg, Object extraInfo = null) {
         super(msg)
+        this.extraInfo = extraInfo
     }
 }

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -675,7 +675,6 @@ class Crud extends HttpServlet {
         String collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, jsonld)
         List<JsonLdValidator.Error> errors = validator.validate(newDoc.data, collection)
         if (errors) {
-            // TODO: make sure extraInfo is passed along
             throw new BadRequestException("Invalid JSON-LD", ['errors': errors.collect{ it.toMap() }])
         }
         

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -1066,6 +1066,11 @@ class Crud extends HttpServlet {
         }
     }
 
+    /** "Don't use exceptions for flow control" in part comes from that exceptions in Java are
+     * expensive to create because building the stack trace is expensive. But in the context of 
+     * sending error responses in this API exceptions are pretty useful for flow control. 
+     * This is a base class for stack trace-less exceptions for common error flows.
+     */
     static class NoStackTraceException extends RuntimeException {
         protected NoStackTraceException(String msg) {
             super(msg, null, true, false)

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -1044,7 +1044,7 @@ class Crud extends HttpServlet {
                 return HttpServletResponse.SC_CONFLICT
           
             case OtherStatusException:
-                return e.code
+                return ((OtherStatusException) e).code
 
             default: 
                 return HttpServletResponse.SC_INTERNAL_SERVER_ERROR

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -45,9 +45,8 @@ class HttpTools {
         }
     }
     
-    static void sendError(HttpServletResponse response, int statusCode, String msg, Object extraInfo = null) {
-        Exception e = extraInfo instanceof Exception ? extraInfo : null
-        Map extra = extraInfo instanceof Map ? extraInfo : [:]
+    static void sendError(HttpServletResponse response, int statusCode, String msg, Exception e = null) {
+        Map extra = e instanceof BadRequestException ? e.getExtraInfo() : Collections.EMPTY_MAP
         
         Map json = [
                 "message"    : msg,

--- a/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/HttpTools.groovy
@@ -44,7 +44,7 @@ class HttpTools {
             out.close()
         }
     }
-
+    
     static void sendError(HttpServletResponse response, int statusCode, String msg, Object extraInfo = null) {
         Exception e = extraInfo instanceof Exception ? extraInfo : null
         Map extra = extraInfo instanceof Map ? extraInfo : [:]


### PR DESCRIPTION
Found this old branch on my machine and rebased it on `develop`.

It removes all the tedious `sendError` code from the happy path.
It is less noisy in my eyes but let me know what you think

