### PR TITLE
Invalidate dependency cache of all whelk instances on write

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit
 import java.util.function.BiFunction
 import java.util.function.Supplier
 
+import static whelk.component.PostgreSQLComponent.NotificationType.dependency_cache_invalidate
+
 @Log
 class DependencyCache {
     private static final int CACHE_SIZE = 50_000
@@ -59,11 +61,13 @@ class DependencyCache {
     }
 
     void invalidate(Document createdDoc) {
+        def i = []
         createdDoc.getThingIdentifiers().each { fromIri ->
             createdDoc.getExternalRefs().each { link ->
-                invalidate(fromIri, link)
+                i << new Tuple2(fromIri, link)
             }
         }
+        _invalidate(i)
     }
 
     void invalidate(Document preUpdateDoc, Document postUpdateDoc) {
@@ -76,13 +80,36 @@ class DependencyCache {
         Set<Link> added = (after - before)
         Set<Link> removed = (before - after)
 
+        def i = []
         (added + removed).each { Link link ->
             thingIris.each { fromIri ->
-                invalidate(fromIri, link)
+                i << new Tuple2(fromIri, link)
             }
         }
+        _invalidate(i)
     }
 
+    private void _invalidate(Collection<Tuple2<String, Link>> fromTo) {
+        fromTo.each { String fromIri, Link link ->
+            invalidate(fromIri, link)
+        }
+        
+        def notification = fromTo.collect{ String fromIri, Link link ->
+            "$fromIri ${link.relation} ${link.iri}"
+        }
+        log.debug("Sending {}", notification)
+        storage.sendNotification(dependency_cache_invalidate, notification)
+    }
+    
+    void handleInvalidateNotification(List<String> payload) {
+        payload.each {
+            def s = it.split(' ')
+            def (fromIri, relation, toIri) = [s[0], s[1], s[2]]
+            log.debug("Invalidate {} {} {}", fromIri, relation, toIri)
+            invalidate(fromIri, new Link(relation: relation, iri: toIri))
+        }
+    }
+    
     void invalidate(String fromIri, Link link) {
         dependersCache.invalidate(link)
         dependenciesCache.invalidate(new Link(iri: fromIri, relation: link.relation))

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -87,6 +87,11 @@ class DependencyCache {
         dependersCache.invalidate(link)
         dependenciesCache.invalidate(new Link(iri: fromIri, relation: link.relation))
     }
+    
+    void invalidateAll() {
+        dependenciesCache.invalidateAll()
+        dependersCache.invalidateAll()
+    }
 
     void logStats() {
         log.info("dependersCache: ${dependersCache.stats()}")

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2663,11 +2663,11 @@ class PostgreSQLComponent {
 
                 def (oldVersion, newVersion) = [docs[0], docs[1]]
                 if (oldVersion && newVersion) {
-                    log.info("New doc version {}, invalidating dependencyCache.", newVersion.shortId)
+                    log.info("Document {} updated, invalidating dependencyCache.", newVersion.shortId)
                     dependencyCache.invalidate(oldVersion, newVersion)
                 }
                 else if (newVersion) {
-                    log.info("New doc version {}, invalidating dependencyCache.", newVersion.shortId)
+                    log.info("Document {} created, invalidating dependencyCache.", newVersion.shortId)
                     dependencyCache.invalidate(newVersion)
                 }
                 else {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -86,7 +86,7 @@ class PostgreSQLComponent {
 
     private Random random = new Random(System.currentTimeMillis())
 
-    private String whelkId = "${ProcessHandle.current().pid()}@${InetAddress.getLocalHost().getHostName()}"
+    private String whelkInstanceId = "${ProcessHandle.current().pid()}@${InetAddress.getLocalHost().getHostName()}"
 
     // SQL statements
     private static final String UPDATE_DOCUMENT = """
@@ -2574,14 +2574,14 @@ class PostgreSQLComponent {
     }
     
     void sendNotification(NotificationType type, List<String> payload) {
-        int MAX_BYTES_PER_CHAR_UNICODE_BMP = 3
+        int MAX_BYTES_PER_CHAR_UNICODE_BMP = 3 // overly cautious
         def messages = []
-        StringBuilder s = new StringBuilder().append(whelkId)
+        StringBuilder s = new StringBuilder().append(whelkInstanceId)
         
         for (String p : payload) {
             if (s.size() + p.size() + 1 > MAX_PG_NOTIFY_PAYLOAD_BYTES / MAX_BYTES_PER_CHAR_UNICODE_BMP) {
                 messages << s.toString()
-                s = new StringBuilder().append(whelkId)
+                s = new StringBuilder().append(whelkInstanceId)
             }
             s.append(NOTIFICATION_DELIMITER).append(p)
         }
@@ -2643,7 +2643,7 @@ class PostgreSQLComponent {
                 for (PGNotification notification : notifications) {
                     try {
                         String msg = notification.getParameter()
-                        if (!msg.startsWith(whelkId)) {
+                        if (!msg.startsWith(whelkInstanceId)) {
                             handleNotification(notification.getName(), msg.split(NOTIFICATION_DELIMITER).drop(1) as List)
                         }
                     }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -85,7 +85,7 @@ class PostgreSQLComponent {
 
     private Random random = new Random(System.currentTimeMillis())
     
-    private String whelkInstanceId = UUID.randomUUID().toString()
+    private String whelkInstanceId = "${ProcessHandle.current().pid()}@${InetAddress.getLocalHost().getHostName()}"
 
     // SQL statements
     private static final String UPDATE_DOCUMENT = """
@@ -452,6 +452,7 @@ class PostgreSQLComponent {
             config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory())
 
             log.info("Connecting to sql database at ${config.getJdbcUrl()}, using driver $driverClass. Pool size: $maxPoolSize")
+            log.info("ID: ${whelkInstanceId}")
             URI connURI = new URI(sqlUrl.substring(5))
             if (connURI.getUserInfo() != null) {
                 String username = connURI.getUserInfo().split(":")[0]

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -164,13 +164,7 @@ class PostgreSQLComponent {
             ORDER BY GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) ASC
             """.stripIndent()
     
-    private static final String GET_PREVIOUS_VERSION_PK_BY_ID_AND_PK = """
-            SELECT GREATEST(-1, MAX(pk)) AS pk 
-            FROM lddb__versions 
-            WHERE id = ? AND pk < ?;
-            """.stripIndent()
-
-    private static final String GET_DOCUMENT_VERSION_BY_PK = """
+    private static final String GET_DOCUMENT_VERSION_BY_ID_AND_PK = """
             SELECT id, data, deleted, created, modified, changedBy, changedIn 
             FROM lddb__versions 
             WHERE id = ? AND pk = ?
@@ -2670,7 +2664,7 @@ class PostgreSQLComponent {
                 def (shortId, pks) = [s[0], s[1]]
                 List docs = pks.split(' ')
                         .collect { Long.parseLong(it) }
-                        .collect { pk -> pk < 0 ? null : loadFromSql(GET_DOCUMENT_VERSION_BY_PK, [1: shortId, 2: pk]) }
+                        .collect { pk -> pk < 0 ? null : loadFromSql(GET_DOCUMENT_VERSION_BY_ID_AND_PK, [1: shortId, 2: pk]) }
 
                 def (oldVersion, newVersion) = [docs[0], docs[1]]
                 if (oldVersion && newVersion) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2643,7 +2643,8 @@ class PostgreSQLComponent {
                     try {
                         String msg = notification.getParameter()
                         if (!msg.startsWith(whelkInstanceId)) {
-                            handleNotification(notification.getName(), msg.split(NOTIFICATION_DELIMITER).drop(1) as List)
+                            def payload = msg.split(NOTIFICATION_DELIMITER).drop(1) as List
+                            handleNotification(notification.getName(), payload)
                         }
                     }
                     catch (Exception e) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2595,7 +2595,6 @@ class PostgreSQLComponent {
                     statement.execute()
                 }
             }
-            
         }
     }
     

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2575,9 +2575,9 @@ class PostgreSQLComponent {
     
     void sendNotification(NotificationType type, List<String> payload) {
         int MAX_BYTES_PER_CHAR_UNICODE_BMP = 3 // overly cautious
+        
         def messages = []
         StringBuilder s = new StringBuilder().append(whelkInstanceId)
-        
         for (String p : payload) {
             if (s.size() + p.size() + 1 > MAX_PG_NOTIFY_PAYLOAD_BYTES / MAX_BYTES_PER_CHAR_UNICODE_BMP) {
                 messages << s.toString()

--- a/whelktool/scripts/examples/touch-all-bib.groovy
+++ b/whelktool/scripts/examples/touch-all-bib.groovy
@@ -1,0 +1,9 @@
+selectByCollection('bib') { bib ->
+    try {
+        bib.scheduleSave()
+    }
+    catch(Exception e) {
+        println(e)
+        e.printStackTrace()
+    }
+}


### PR DESCRIPTION
Send a notification to all other whelk instances to invalidate affected parts of DependencyCache when a document is saved. PostgreSQLs LISTEN/NOTIFY is used as a simple IPC mechanism.

This uses one more physical database connection per whelk instance.

Here is a previous iteration that instead sends the ids of the previous and current document versions and lets each listener calculate which links have been added and removed https://github.com/libris/librisxl/compare/feature/clear-deps-cache