### PR TITLE
Actually bulk load documents in one query in bulkLoad

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -511,6 +511,10 @@ class JsonLd {
         return (o instanceof List) ? (List) o : o != null ? [o] : []
     }
 
+    static boolean looksLikeIri(String s) {
+        s && (s.startsWith('https://') || s.startsWith('http://'))
+    }
+
     static List<List<String>> findPaths(Map obj, String key, String value) {
         return findPaths(obj, key, [value].toSet())
     }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -7,6 +7,7 @@ import com.zaxxer.hikari.metrics.prometheus.PrometheusHistogramMetricsTrackerFac
 import groovy.json.StringEscapeUtils
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
+import org.apache.jena.atlas.iterator.Iter
 import org.postgresql.PGStatement
 import org.postgresql.util.PGobject
 import org.postgresql.util.PSQLException
@@ -118,6 +119,12 @@ class PostgreSQLComponent {
     private static final String GET_DOCUMENT_VERSION =
             "SELECT id, data FROM lddb__versions WHERE id = ? AND checksum = ?"
 
+    private static final String BULK_LOAD_DOCUMENTS = """
+            SELECT id, data, created, modified, deleted
+            FROM unnest(?) AS in_id, lddb l 
+            WHERE in_id = l.id
+            """.stripIndent()
+    
     private static final String GET_EMBELLISHED_DOCUMENT =
             "SELECT data from lddb__embellished where id = ?"
 
@@ -1826,6 +1833,27 @@ class PostgreSQLComponent {
             doc = loadFromSql(GET_DOCUMENT, [1: id])
         }
         return doc
+    }
+    
+    Map<String, Document> bulkLoad(Iterable<String> systemIds) {
+        return withDbConnection {
+            Connection connection = getMyConnection()
+            PreparedStatement preparedStatement = null
+            ResultSet rs = null
+            try {
+                preparedStatement = connection.prepareStatement(BULK_LOAD_DOCUMENTS)
+                preparedStatement.setArray(1,  connection.createArrayOf("TEXT", systemIds as String[]))
+
+                rs = preparedStatement.executeQuery()
+                SortedMap<String, Document> result = new TreeMap<>()
+                while(rs.next()) {
+                    result[rs.getString("id")] = assembleDocument(rs)
+                }
+                return result
+            } finally {
+                close(rs, preparedStatement)
+            }
+        }
     }
 
     String getSystemIdByIri(String iri) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -7,7 +7,6 @@ import com.zaxxer.hikari.metrics.prometheus.PrometheusHistogramMetricsTrackerFac
 import groovy.json.StringEscapeUtils
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
-import org.apache.jena.atlas.iterator.Iter
 import org.postgresql.PGStatement
 import org.postgresql.util.PGobject
 import org.postgresql.util.PSQLException

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -1,5 +1,6 @@
 package whelk.filter
 
+import com.google.common.collect.Iterables
 import whelk.Whelk
 import whelk.search.ESQuery
 import whelk.search.ElasticFind
@@ -63,9 +64,8 @@ class BlankNodeLinker implements DocumentUtil.Linker {
                     '_sort'   : [ID_KEY]
             ]
 
-            finder.findIds(q).each { id ->
-                def doc = whelk.getDocument(id)
-                if (doc) {
+            Iterables.partition(finder.findIds(q), 100).each { List<String> i ->
+                whelk.bulkLoad(i).each { id, doc ->
                     addDefinition(doc.data[GRAPH_KEY][1])
                 }
             }


### PR DESCRIPTION
* Use `whelk.bulkLoad` when loading data for `Normalizers`
* Actually bulk load documents in one query in `bulkLoad`

This cuts the normalizer initialization part of of Whelk startup from ~20 to ~2 seconds when connecting to e.g. QA database from my laptop over VPN.

