### PR TITLE
Limit depth of frame/embed

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1179,23 +1179,23 @@ class JsonLd {
         }
     }
 
-    private static Map embed(String mainId, Map mainItem, Map idMap, Set embedChain) {
+    private static Map embed(String mainId, Map mainItem, Map idMap, Set embedChain, int depth = 0) {
         embedChain.add(mainId)
         Map newItem = [:]
         mainItem.each { key, value ->
             if (key != JSONLD_ALT_ID_KEY)
-                newItem.put(key, toEmbedded(value, idMap, embedChain))
+                newItem.put(key, toEmbedded(value, idMap, embedChain, depth))
             else
                 newItem.put(key, value)
         }
         return newItem
     }
 
-    private static Object toEmbedded(Object o, Map idMap, Set embedChain) {
+    private static Object toEmbedded(Object o, Map idMap, Set embedChain, int depth) {
         if (o instanceof List) {
             def newList = []
             o.each {
-                newList.add(toEmbedded(it, idMap, embedChain))
+                newList.add(toEmbedded(it, idMap, embedChain, depth))
             }
             return newList
         }
@@ -1209,7 +1209,9 @@ class JsonLd {
                 obj = fullObj ? [:] + fullObj : null
             }
             if (obj) {
-                return embed(oId, obj, idMap, new HashSet<String>(embedChain))
+                return depth < 2
+                        ? embed(oId, obj, idMap, new HashSet<String>(embedChain), depth + 1)
+                        : obj
             }
         }
         return o


### PR DESCRIPTION
For very connected datasets like Queerlit where many Concepts are `related` to many other Concepts in the same embellish graph there is a combinatorial explosion leading to huge framed documents (which are later thrown away).

We still want e.g. the queerlit concept scheme definition to be embedded in all places in the result so just add a limit on the number of levels where we start with a new "embedChain".

