### PR TITLE
Add force option to PostgreSQLComponent.remove

### DIFF
--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -29,12 +29,15 @@ class DatasetImporter {
     // verify that id:s are served by the system; else use:
     static REPLACE_MAIN_IDS = 'replace-main-ids' // replace id with XL-id (move current to sameAs)
 
+    static FORCE_DELETE = 'force-delete'
+
     Whelk whelk
     String datasetUri
     DatasetInfo dsInfo
     private Document dsRecord
 
     boolean replaceMainIds = false
+    boolean forceDelete = false
     String collection = NO_MARC_COLLECTION
 
     TargetVocabMapper tvm = null
@@ -53,6 +56,7 @@ class DatasetImporter {
         }
 
         replaceMainIds = flags.get(REPLACE_MAIN_IDS) == true
+        forceDelete = flags.get(FORCE_DELETE) == true
 
         if (Runtime.getRuntime().maxMemory() < 2l * 1024l * 1024l * 1024l) {
             log.warn("This application may require substantial amounts of memory, " +
@@ -326,7 +330,7 @@ class DatasetImporter {
 
     private boolean remove(String id) {
         try {
-            whelk.remove(id, "xl", null)
+            whelk.remove(id, "xl", null, forceDelete)
             return true
         } catch ( RuntimeException re ) {
             // The expected exception here is: java.lang.RuntimeException: Deleting depended upon records is not allowed.

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -39,7 +39,7 @@ class ImporterMain {
     }
 
     @Command(args='SOURCE_URL DATASET_URI [DATASET_DESCRIPTION_FILE]',
-             flags='--skip-index --replace-main-ids')
+             flags='--skip-index --replace-main-ids --force-delete')
     void dataset(String sourceUrl, String datasetUri, String datasetDescPath=null, Map flags) {
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)
         if (flags['skip-index']) {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -382,10 +382,10 @@ class Whelk {
         return storage.quickCreateDocument(document, changedIn, changedBy, collection)
     }
   
-    void remove(String id, String changedIn, String changedBy) {
+    void remove(String id, String changedIn, String changedBy, boolean force=false) {
         log.debug "Deleting ${id} from Whelk"
         Document doc = storage.load(id)
-        storage.remove(id, changedIn, changedBy)
+        storage.remove(id, changedIn, changedBy, force)
         if (elastic && !skipIndex) {
             elastic.remove(id)
             reindexAffected(doc, doc.getExternalRefs(), Collections.emptySet())

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2487,9 +2487,9 @@ class PostgreSQLComponent {
         }
     }
 
-    void remove(String identifier, String changedIn, String changedBy) {
+    void remove(String identifier, String changedIn, String changedBy, boolean force=false) {
         if (versioning) {
-            if(!followDependers(identifier).isEmpty())
+            if(!force && !followDependers(identifier).isEmpty())
                 throw new RuntimeException("Deleting depended upon records is not allowed.")
 
             log.debug("Marking document with ID ${identifier} as deleted.")


### PR DESCRIPTION
This is used via the `--force-delete` flag to DatasetImporter to delete records in a dataset even if there are links to them. This is sometimes necessary to break (cyclic) cross-references within a dataset.

(Currently only needed to refresh qlit in QA. We may want to cherry-pick this into a hotfix if we require dataset-imports to run from the master branch.)