### PR TITLE
Search: Embellish with cards instead of chips in ES index

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1183,23 +1183,23 @@ class JsonLd {
         }
     }
 
-    private static Map embed(String mainId, Map mainItem, Map idMap, Set embedChain, int depth = 0) {
+    private static Map embed(String mainId, Map mainItem, Map idMap, Set embedChain, int linkDepth = 1) {
         embedChain.add(mainId)
         Map newItem = [:]
         mainItem.each { key, value ->
             if (key != JSONLD_ALT_ID_KEY)
-                newItem.put(key, toEmbedded(value, idMap, embedChain, depth))
+                newItem.put(key, toEmbedded(value, idMap, embedChain, linkDepth))
             else
                 newItem.put(key, value)
         }
         return newItem
     }
 
-    private static Object toEmbedded(Object o, Map idMap, Set embedChain, int depth) {
+    private static Object toEmbedded(Object o, Map idMap, Set embedChain, int linkDepth) {
         if (o instanceof List) {
             def newList = []
             o.each {
-                newList.add(toEmbedded(it, idMap, embedChain, depth))
+                newList.add(toEmbedded(it, idMap, embedChain, linkDepth))
             }
             return newList
         }
@@ -1213,9 +1213,9 @@ class JsonLd {
                 obj = fullObj ? [:] + fullObj : null
             }
             if (obj) {
-                int i = oId ? 1 : 0
-                return depth < 2
-                        ? embed(oId, obj, idMap, new HashSet<String>(embedChain), depth + i)
+                boolean isLinked = oId
+                return linkDepth < 3
+                        ? embed(oId, obj, idMap, new HashSet<String>(embedChain), linkDepth + (isLinked ? 1 : 0))
                         : obj
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -281,8 +281,13 @@ class ElasticSearch {
     String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
 
-        whelk.embellish(copy, ['chips'])
-
+        if (document.getThingType() == 'Item') {
+            whelk.embellish(copy, ['chips'])
+        }
+        else {
+            whelk.embellish(copy, ['cards'])
+        }
+        
         if (log.isDebugEnabled()) {
             log.debug("Framing ${document.getShortId()}")
         }


### PR DESCRIPTION
Fixes e.g. that instances can be found on contributor variant name
(LXL-3811).

This was previously changed from cards to chip because of problems with
the size of the ES index.

The switch on entity class (Item) should become vocab driven at some
point if we want to have different shapes like that.

---

We've changed this back and forth a couple of times now. 
I think we should merge this and test it again on QA with the full Libris dataset.