### PR TITLE
Pull request for NatLibFi changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,12 @@ Session.vim
 /*/build
 /*/catalina.base_IS_UNDEFINED
 /*/logs
+
+# Eclipse meta files
 /eclipse-classes/
+.classpath
+.project
+.settings
+
+# Local overrides to Log4J configuration etc.
 /local-overrides/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Session.vim
 /*/build
 /*/catalina.base_IS_UNDEFINED
 /*/logs
+/eclipse-classes/
+/local-overrides/

--- a/batchimport/src/main/java/whelk/importer/ThreadPool.java
+++ b/batchimport/src/main/java/whelk/importer/ThreadPool.java
@@ -2,71 +2,8 @@ package whelk.importer;
 
 public class ThreadPool
 {
-    private final int THREAD_COUNT;
-    private final Thread[] s_threadPool;
-
-    public ThreadPool(int threadCount)
-    {
-        THREAD_COUNT = threadCount;
-        s_threadPool = new Thread[THREAD_COUNT];
-    }
-
     public interface Worker<T>
     {
         void doWork(T t);
     }
-
-    /**
-     * Will block until a thread becomes available to perform this work.
-     */
-    public <T> void executeOnThread(T workLoad, Worker<T> worker)
-    {
-        // Find a suitable thread from the pool to do the work
-
-        int i = 0;
-        while(true)
-        {
-            i++;
-            if (i == THREAD_COUNT)
-            {
-                i = 0;
-                Thread.yield();
-            }
-
-            if (s_threadPool[i] == null || s_threadPool[i].getState() == Thread.State.TERMINATED)
-            {
-                s_threadPool[i] = new Thread(new Runnable()
-                {
-                    public void run()
-                    {
-                        worker.doWork(workLoad);
-                    }
-                });
-                s_threadPool[i].start();
-                return;
-            }
-        }
-    }
-
-    public int getActiveThreadCount()
-    {
-        int activeThreadCount = 0;
-        for (int i = 0; i < THREAD_COUNT; ++i)
-        {
-            if (s_threadPool[i] != null && s_threadPool[i].getState() != Thread.State.TERMINATED)
-                ++activeThreadCount;
-        }
-        return activeThreadCount;
-    }
-
-    public void joinAll()
-            throws InterruptedException
-    {
-        for (int i = 0; i < THREAD_COUNT; ++i)
-        {
-            if (s_threadPool[i] != null)
-                s_threadPool[i].join();
-        }
-    }
-
 }

--- a/natlibfi/batchimport/log4j2.xml
+++ b/natlibfi/batchimport/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Properties>
+        <Property name="catalina.base">.</Property>
+    </Properties>
+
+	<Appenders>
+		<Console name="STDERR" target="SYSTEM_ERR">
+			<PatternLayout pattern="%msg%n" />
+		</Console>
+
+		<File name="File" fileName="logs/batchimport.log">
+			<PatternLayout>
+				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+			</PatternLayout>
+		</File>
+	</Appenders>
+
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="STDERR"/>
+            <AppenderRef ref="File" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -895,4 +895,7 @@ class Document {
         jsonLd && key && jsonLd.isSetContainer(key)
     }
 
+    public String toVerboseString() {
+        return "{completeId=" + getCompleteId() + ", baseUri=" + baseUri.toString() + ", base identifiers:" + getRecordIdentifiers().join(',');
+    }
 }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -161,7 +161,11 @@ class ElasticSearch {
                     String action = createActionRow(doc)
                     return "${action}\n${shapedData}\n"
                 } catch (Exception e) {
-                    log.error("Failed to index ${doc.getShortId()} in elastic: $e", e)
+                    if (doc.getShortId() == null) {
+                        log.error("Document has null shortId, something is wrong. Some details: " + doc.toVerboseString(), e);
+                    } else {
+                        log.error("Failed to index ${doc.getShortId()} in elastic: $e", e)
+                    }
                     return null
                 }
             }.join('')

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2718,6 +2718,18 @@ class PostgreSQLComponent {
         return s.startsWith('http://') || s.startsWith('https://')
     }
 
+    private static void close(AutoCloseable... resources) {
+        for (AutoCloseable resource : resources) {
+            try {
+                if (resource != null) {
+                    resource.close()
+                }
+            } catch (Exception e) {
+                log.debug("Error closing $resource : $e")
+            }
+        }
+    }
+
     private static void close(Object... resources = null) {
         if (resources != null) {
             for (def resource : resources) {

--- a/whelk-core/src/main/groovy/whelk/util/ThreadPool.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/ThreadPool.groovy
@@ -1,15 +1,28 @@
 package whelk.util
 
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RunnableFuture
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.regex.Matcher
+
 import groovy.transform.CompileStatic
 
 @CompileStatic
 class ThreadPool {
+    private BlockingQueue<Runnable> blockingQueue
     private final int THREAD_COUNT
-    private final Thread[] s_threadPool
+    private int nextThreadNo = 0;
+    private final ThreadPoolExecutor s_threadPool
 
     ThreadPool(int threadCount) {
         THREAD_COUNT = threadCount
-        s_threadPool = new Thread[THREAD_COUNT]
+        blockingQueue = new LinkedBlockingQueue<Runnable>()
+//        s_threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(threadCount);
+        s_threadPool = new ThreadPoolExecutor(threadCount, threadCount, 0, TimeUnit.MILLISECONDS, blockingQueue);
     }
 
     interface Worker<T> {
@@ -18,45 +31,62 @@ class ThreadPool {
 
     /**
      * Will block until a thread becomes available to perform this work.
+     * 
+     * This version uses Java standard Executors, but implements the blocking wait
+     * for execution to retain full interface compatibility.
      */
     def <T> void executeOnThread(T workLoad, Worker<T> worker) {
-        // Find a suitable thread from the pool to do the work
+        Object MONITOR = new Object();
+        boolean executionStarted = false;
+        
+        int threadNo;
+        
+        synchronized (this) {
+            threadNo = nextThreadNo++;
+        }
 
-        int i = 0
-        while(true) {
-            i++
-            if (i == THREAD_COUNT) {
-                i = 0
-                Thread.yield()
+        Runnable runnable = new Runnable() {
+            void run() {
+                synchronized (MONITOR) {
+                    executionStarted = true;
+                    MONITOR.notifyAll();
+                }
+                String threadName = Thread.currentThread().getName();
+//                    def Matcher threadNameMatcher = threadName =~ /pool-(\d+)-thread-(\d+)/
+//                    int i = Integer.valueOf(threadNameMatcher.group(1));
+                
+                String noString;
+                if (threadName.lastIndexOf('-') > 0) {
+                    noString = threadName.substring(threadName.lastIndexOf('-'), threadName.length());
+                } else {
+                    noString = Integer.toString(threadNo);
+                }
+                
+                worker.doWork(workLoad, Integer.parseInt(noString));
             }
+        }
+        
 
-            if (s_threadPool[i] == null || s_threadPool[i].getState() == Thread.State.TERMINATED) {
-                s_threadPool[i] = new Thread(new Runnable() {
-                    void run() {
-                        worker.doWork(workLoad, i)
-                    }
-                })
-                s_threadPool[i].start()
-                return
+//        s_threadPool.queue.put(runnable);
+//        blockingQueue.put(runnable);
+        s_threadPool.execute(runnable)
+
+        synchronized (MONITOR) {
+            while (!executionStarted) {
+                MONITOR.wait(100);
             }
         }
     }
 
     int getActiveThreadCount() {
-        int activeThreadCount = 0
-        for (int i = 0; i < THREAD_COUNT; ++i) {
-            if (s_threadPool[i] != null && s_threadPool[i].getState() != Thread.State.TERMINATED)
-                ++activeThreadCount
-        }
-        return activeThreadCount
+        return s_threadPool.activeCount;
     }
 
-    void joinAll()
-            throws InterruptedException {
-        for (int i = 0; i < THREAD_COUNT; ++i) {
-            if (s_threadPool[i] != null)
-                s_threadPool[i].join()
+    void joinAll() {
+        s_threadPool.shutdown();
+        
+        for (int i=0; i < 20; i++) {
+            if (s_threadPool.awaitTermination(5, TimeUnit.SECONDS)) return;
         }
     }
-
 }

--- a/whelktool/.gitignore
+++ b/whelktool/.gitignore
@@ -1,1 +1,2 @@
 /reports
+/eclipse-build/


### PR DESCRIPTION
I profiled the batchimport to figure out why it is slow with our data, and found out it almost busy-loops on Thread.yield() which causes a lot of system calls. It also created a new OS-level thread for each task, which again causes system calls and is somewhat expensive.

I changed the import to utilize the thread pool implementation that comes with Java standard libraries and it reduced amount of time spent in system calls by factor of seven. Total execution time didn't drop much as this test was run on otherwise idle developer laptop, but on busy system system calls can become a bottleneck and slow the whole system down.

Here are timings run without profiler:

Original:
real	3m57.395s
user	5m17.832s
sys	2m27.186s

ExecutorService:
real	5m6.852s
user	4m44.039s
sys	0m21.946s

The other changes are more minor, ignoring Eclipse files, fixing half-broken Log4J file logger setup and making it easier to see from the logs where a NPE coming from wrong config originates from.

![Screenshot at 2022-06-17 15-26-52_crop](https://user-images.githubusercontent.com/98903749/175517887-de440990-4ba0-4c75-96b0-18bdd5a11ec2.png)

