### PR TITLE
Validate @id in JsonLdValidator

### DIFF
--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     api 'commons-io:commons-io:2.11.0'
     implementation "org.apache.httpcomponents:httpclient:${httpComponentsClientVersion}"
     implementation "org.apache.httpcomponents:httpcore:${httpComponentsCoreVersion}"
-    implementation 'org.apache.jena:apache-jena-libs:3.0.1'
+    api 'org.apache.jena:apache-jena-libs:3.0.1'
     api "org.codehaus.groovy:groovy-json:${groovyVersion}"
     api "org.codehaus.groovy:groovy-xml:${groovyVersion}"
     api "org.codehaus.groovy:groovy:${groovyVersion}"

--- a/whelk-core/src/test/groovy/whelk/JsonLdValidatorSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/JsonLdValidatorSpec.groovy
@@ -100,4 +100,36 @@ class JsonLdValidatorSpec extends Specification {
         then:
         assert errors.any {it.type == JsonLdValidator.Error.Type.MISSING_DEFINITION}
     }
+
+    def "@id with valid IRI should pass validation"() {
+        given:
+        def validator = setupValidator()
+        def errors = validator.validate(["@graph": [["@id": id]]])
+
+        expect:
+        assert errors.isEmpty()
+
+        where:
+        id << [
+                "https://id.kb.se/term/sao/Marsvin%20som%20s%C3%A4llskapsdjur",
+                "https://ja.wikipedia.org/wiki/モルモット",
+                "//foo"
+        ]
+    }
+
+    def "@id with invalid IRI should not pass validation"() {
+        given:
+        def validator = setupValidator()
+        def errors = validator.validate(["@graph": [["@id": id]]])
+
+        expect:
+        assert errors.any {it.type == JsonLdValidator.Error.Type.INVALID_IRI}
+
+        where:
+        id << [
+                "\"https://libris.kb.se/library/DIGI\"",
+                "https://example.com/ bar",
+                "[sfsdfsdf]",
+        ]
+    }
 }


### PR DESCRIPTION
Ensures @id is a valid IRI. Uses Apache Jena's IRI validation (which we're already using in JsonLdToTrigSerializer).