### PR TITLE
Search: Improve queries on nested documents

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -576,7 +576,7 @@ class ESQuery {
     private Map getNestedParams(Map groups) {
         Map nested = groups.findAll { g ->
             g.key in nestedFields &&
-            g.value.size() == 2
+            g.value.size() > 1
         }
         return nested
     }


### PR DESCRIPTION
* Get which fields are "nested" from ES mappings instead of hardcoding them
* Make some queries work
  * Repeated parameters [(LXL-265)](https://jira.kb.se/browse/LXL-265)
    * `?identifiedBy.@type=ISBN&identifiedBy.value=1234&identifiedBy.@type=LCCN&identifiedBy.value=5678`
    * `?identifiedBy.@type=ISBN&identifiedBy.@type=LCCN&identifiedBy.@type=NBN`
  * More than two properties inside nested document
    *  `?hasTitle.@type=Title&hasTitle.mainTitle=städer&hasTitle.subtitle=storstadspolitik`