### PR TITLE
Return 409 Conflict (instead of 400) on ConflictingHoldException

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -985,9 +985,11 @@ class Crud extends HttpServlet {
             case BadRequestException:
             case ModelValidationException:
             case LinkValidationException:
-            case PostgreSQLComponent.ConflictingHoldException:    
                 return HttpServletResponse.SC_BAD_REQUEST
-            
+
+            case PostgreSQLComponent.ConflictingHoldException:
+                return HttpServletResponse.SC_CONFLICT
+
             case NotFoundException:
                 return HttpServletResponse.SC_NOT_FOUND
             

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -987,9 +987,6 @@ class Crud extends HttpServlet {
             case LinkValidationException:
                 return HttpServletResponse.SC_BAD_REQUEST
 
-            case PostgreSQLComponent.ConflictingHoldException:
-                return HttpServletResponse.SC_CONFLICT
-
             case NotFoundException:
                 return HttpServletResponse.SC_NOT_FOUND
             
@@ -999,6 +996,7 @@ class Crud extends HttpServlet {
             case WhelkRuntimeException:
                 return HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 
+            case PostgreSQLComponent.ConflictingHoldException:
             case StorageCreateFailedException:
                 return HttpServletResponse.SC_CONFLICT
           


### PR DESCRIPTION
Makes it possible for lxlviewer to show a nicer error message.