### PR TITLE
Feature/handle linked works

### DIFF
--- a/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/Normalizers.groovy
@@ -14,6 +14,7 @@ import whelk.util.DocumentUtil.Remove
 import static whelk.JsonLd.GRAPH_KEY
 import static whelk.JsonLd.ID_KEY
 import static whelk.JsonLd.TYPE_KEY
+import static whelk.JsonLd.WORK_KEY
 import static whelk.JsonLd.asList
 import static whelk.util.DocumentUtil.traverse
 
@@ -195,13 +196,19 @@ class Normalizers {
         }
     }
 
-    static Map getWork(JsonLd jsonLd, Document doc) {
-        def (_record, thing) = doc.data['@graph']
-        if (thing && isInstanceOf(jsonLd, thing, 'Work')) {
+    static Map getWork(Whelk whelk, Document doc) {
+        def (_record, thing) = doc.data[GRAPH_KEY]
+        if (thing && isInstanceOf(whelk.jsonld, thing, 'Work')) {
             return thing
         }
-        else if(thing && thing['instanceOf'] && isInstanceOf(jsonLd, thing['instanceOf'], 'Work')) {
-            return thing['instanceOf']
+        else if (thing && thing[WORK_KEY]) {
+            def linked = thing[WORK_KEY][ID_KEY]
+            if (linked) {
+                return getWork(whelk, whelk.storage.getDocumentByIri(linked))
+            }
+            if (isInstanceOf(whelk.jsonld, thing[WORK_KEY], 'Work')) {
+                return thing[WORK_KEY]
+            }
         }
         return null
     }

--- a/whelktool/scripts/analysis/find-work-clusters.groovy
+++ b/whelktool/scripts/analysis/find-work-clusters.groovy
@@ -32,8 +32,6 @@ selectByCollection('bib') { bib ->
     }
 }
 
-exit()
-
 Map<String, List<String>> buildQuery(bib) {
     def title = title(bib)
 
@@ -63,10 +61,6 @@ Map<String, List<String>> buildQuery(bib) {
         return query
     }
     return null
-}
-
-synchronized void exit() {
-    System.exit(0)
 }
 
 private void insertLinkedAgents(bib) {

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/DisplayDoc.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/DisplayDoc.groovy
@@ -61,7 +61,7 @@ class DisplayDoc {
 
     private String reproductionOfLink() {
         def shortId = Util.getPathSafe(getMainEntity(), ['reproductionOf', '@id'])
-                ?.tokenize("/#")
+                ?.split('[#/]')
                 ?.dropRight(1)
                 ?.last() ?: ''
 

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/DisplayDoc.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/DisplayDoc.groovy
@@ -56,7 +56,7 @@ class DisplayDoc {
     }
 
     protected String chipString(def thing) {
-        Util.chipString(thing, whelk)
+        Util.chipString(thing, doc.whelk)
     }
 
     private String reproductionOfLink() {
@@ -154,7 +154,7 @@ class DisplayDoc {
             if (isInstance()) {
                 framed = JsonLd.frame(doc.doc.getThingIdentifiers().first(), doc.whelk.loadEmbellished(doc.doc.shortId).data)
             } else {
-                Document copy = doc.clone()
+                Document copy = doc.doc.clone()
                 doc.whelk.embellish(copy)
                 framed = JsonLd.frame(doc.doc.getThingIdentifiers().first(), copy.data)
             }

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/Doc.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/Doc.groovy
@@ -62,7 +62,7 @@ class Doc {
     }
 
     static Map getWork(Whelk whelk, Document d) {
-        Map work = Normalizers.getWork(whelk.jsonld, d)
+        Map work = Normalizers.getWork(whelk, d)
         if (!work) {
             throw new NoWorkException(d.shortId)
         }
@@ -70,12 +70,16 @@ class Doc {
 
         //TODO 'marc:fieldref'
 
-        work.remove('@id')
+//        work.remove('@id')
         return work
     }
 
     Map workCopy() {
         return getWork(whelk, doc.clone())
+    }
+
+    String workIri() {
+        getWork()['@id']
     }
 
     Map getMainEntity() {

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/MergedWork.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/MergedWork.groovy
@@ -1,0 +1,9 @@
+package datatool.scripts.mergeworks
+
+import whelk.Document
+
+interface MergedWork {
+    Document doc
+    Collection<Doc> derivedFrom
+    File reportDir
+}

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/NewWork.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/NewWork.groovy
@@ -1,0 +1,44 @@
+package datatool.scripts.mergeworks
+
+import whelk.Document
+import whelk.IdGenerator
+
+class NewWork implements MergedWork {
+    Document doc
+    Collection<Doc> derivedFrom
+    File reportDir
+
+    NewWork(Map data, Collection<Doc> derivedFrom, File reportDir) {
+        this.derivedFrom = derivedFrom
+        this.reportDir = new File(reportDir, 'new')
+        this.doc = buildWorkDocument(data)
+    }
+
+    private Document buildWorkDocument(Map workData) {
+        String workId = IdGenerator.generate()
+        def reportUri = "http://xlbuild.libris.kb.se/works/${reportDir.getPath().replace('report/', '')}/${workId}.html"
+
+        workData['@id'] = "TEMPID#it"
+        Document d = new Document([
+                "@graph": [
+                        [
+                                "@id"          : "TEMPID",
+                                "@type"        : "Record",
+                                "mainEntity"   : ["@id": "TEMPID#it"],
+                                "technicalNote": [[
+                                                          "@type"  : "TechnicalNote",
+                                                          "hasNote": [[
+                                                                              "@type": "Note",
+                                                                              "label": ["Maskinellt utbrutet verk... TODO"]
+                                                                      ]],
+                                                          "uri"    : [reportUri]
+                                                  ]
+                                ]],
+                        workData
+                ]
+        ])
+
+        d.deepReplaceId(Document.BASE_URI.toString() + workId)
+        return d
+    }
+}

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/UpdatedWork.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/UpdatedWork.groovy
@@ -1,0 +1,17 @@
+package datatool.scripts.mergeworks
+
+import whelk.Document
+
+class UpdatedWork implements MergedWork {
+    Document doc
+    Collection<Doc> derivedFrom
+    File reportDir
+    String checksum
+
+    UpdatedWork(Document doc, Collection<Doc> derivedFrom, File reportDir, String checksum) {
+        this.doc = doc
+        this.derivedFrom = derivedFrom
+        this.reportDir = new File(reportDir, 'updated')
+        this.checksum = checksum
+    }
+}

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/Util.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/Util.groovy
@@ -188,6 +188,14 @@ class Util {
 
     // Return the most common title for the best encodingLevel
     static Object bestTitle(Collection<Doc> docs) {
+        def linkedWorkTitle = docs.findResult {
+            def w = it.getWork()
+            w['@id'] ? w['hasTitle'] : null
+        }
+        if (linkedWorkTitle) {
+            return linkedWorkTitle
+        }
+
         def isTitle = { it.'@type' == 'Title' }
         def addSource = { t, d -> t.plus(['source': [d.getMainEntity().subMap('@id')]]) }
 

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/Util.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/Util.groovy
@@ -109,7 +109,7 @@ class Util {
     static List flatTitles(List hasTitle) {
         dropSubTitles(hasTitle).collect {
             def title = new TreeMap<>()
-            title['flatTitle'] = normalize(Doc.flatten(it, titleComponents))
+            title['flatTitle'] = normalize(DisplayDoc.flatten(it, titleComponents))
             if (it['@type']) {
                 title['@type'] = it['@type']
             }

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/WorkComparator.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/WorkComparator.groovy
@@ -1,6 +1,7 @@
 package datatool.scripts.mergeworks
 
 import datatool.scripts.mergeworks.compare.Classification
+import datatool.scripts.mergeworks.compare.Id
 import datatool.scripts.mergeworks.compare.SameOrEmpty
 import datatool.scripts.mergeworks.compare.Default
 import datatool.scripts.mergeworks.compare.Extent
@@ -29,6 +30,7 @@ class WorkComparator {
             'subject'         : new Subject(),
             'summary'         : new StuffSet(),
             'translationOf'   : new TranslationOf(),
+            '@id'             : new Id()
     ]
 
     static FieldHandler DEFAULT = new Default()
@@ -113,7 +115,7 @@ class WorkComparator {
     static Set<String> allFields(Collection<Doc> cluster) {
         Set<String> fields = new HashSet<>()
         cluster.each { fields.addAll(it.getWork().keySet()) }
-        return fields - 'summary' // - 'summary' only temporary, remove when summaries have been moved to instance (LXL-3303)
+        return fields
     }
 
     Map<String, FieldStatus> fieldStatuses(Collection<Doc> cluster) {

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/WorkToolJob.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/WorkToolJob.groovy
@@ -133,7 +133,7 @@ class WorkToolJob {
                 def titles = titleClusters(cluster)
                 def works = mergedWorks(titles)
 
-                def needsStore = { it instanceof UpdatedWork || it.derivedFrom > 1 }
+                def needsStore = { it instanceof UpdatedWork || it.derivedFrom.size() > 1 }
                 def storedWorks = works.findAll(needsStore).each { store(it) }
 
                 String report = htmlReport(titles, storedWorks)

--- a/whelktool/src/main/groovy/datatool/scripts/mergeworks/compare/Id.groovy
+++ b/whelktool/src/main/groovy/datatool/scripts/mergeworks/compare/Id.groovy
@@ -1,0 +1,22 @@
+package datatool.scripts.mergeworks.compare
+
+import datatool.scripts.mergeworks.Doc
+import org.apache.commons.lang3.NotImplementedException
+
+class Id implements ValuePicker {
+
+    @Override
+    boolean isCompatible(Object a, Object b) {
+        return !a || !b
+    }
+
+    @Override
+    Object merge(Object a, Object b) {
+        throw new NotImplementedException('')
+    }
+
+    @Override
+    Object pick(Collection<Doc> values) {
+        return values.findResult { it.workIri() }
+    }
+}


### PR DESCRIPTION
This makes it possible to run "verkskörningen" repeatedly and create new works as well as link instances to already existing works.

[The very first step](https://github.com/libris/librisxl/blob/feature/merge-works/whelktool/scripts/analysis/find-work-clusters.groovy) is still the same, however after the first run we should only use newly created/modified docs as a starting point to find clusters.

The "title cluster" step is also pretty much the same, the only difference is that duplicate linked works are filtered out from the cluster before doing the partitioning, i.e. only one instance/doc per linked work is saved.

Then we partition title clusters into "work clusters" (cluster = same work). This is also done the same way as before, but since we now have linked works in the mix we get three different possibilities for each cluster:
-  It contains only local works -> Create new linked work (merge local works) and link the instances to this.
-  It contains one linked work -> Merge the local works with the linked one and link the instances to the updated work. We could also skip the merging and just link the instances to the existing work, that is if we don't want to "enrich" existing works with data from new/updated local works.
-  It contains more than one linked work -> Log and handle manually? Should be very unusual that two linked works are considered to be the same but it _can_ happen if either is modified by e.g. a cataloguer.