### PR TITLE
Fix and improvement to the ExecutorService parallelization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Session.vim
 
 # Local overrides to Log4J configuration etc.
 /local-overrides/
+
+# Logs
+/logs/

--- a/apix_server/.gitignore
+++ b/apix_server/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-classes/

--- a/batchimport/.gitignore
+++ b/batchimport/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-classes/

--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -9,6 +9,7 @@ import se.kb.libris.util.marc.io.MarcXmlRecordReader;
 import se.kb.libris.util.marc.io.MarcXmlRecordWriter;
 import whelk.component.PostgreSQLComponent;
 import whelk.importer.ThreadPool.Worker;
+import whelk.meta.WhelkConstants;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.Collections;
@@ -163,6 +165,13 @@ public class Main
         if (parameters.getRunParallel())
             threadCount = 2 * Runtime.getRuntime().availableProcessors();
         ThreadPoolExecutor threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(threadCount);
+        threadPool.setThreadFactory(new ThreadFactory() {
+            ThreadGroup group = new ThreadGroup(WhelkConstants.WHELKTOOL_THREAD_GROUP);
+
+            public Thread newThread(Runnable runnable) {
+                return new Thread(group, runnable);
+            }
+        });
 
         MarcXmlRecordReader reader = null;
         try

--- a/gui-whelktool/.gitignore
+++ b/gui-whelktool/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-classes/

--- a/importers/.gitignore
+++ b/importers/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-classes/

--- a/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
+++ b/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
@@ -64,12 +64,12 @@ class ElasticReindexer {
         }
     }
 
-    void reindex(String suppliedCollection) {
+    void reindex(String suppliedCollection, int numberOfThreads) {
         try {
             int counter = 0
             startTime = System.currentTimeMillis()
             List<String> collections = suppliedCollection ? [suppliedCollection] : whelk.storage.loadCollections()
-            ThreadPool threadPool = new ThreadPool(Runtime.getRuntime().availableProcessors() * 2)
+            ThreadPool threadPool = new ThreadPool(numberOfThreads)
             collections.each { collection ->
                 List<Document> documents = []
                 for (document in whelk.storage.loadAll(collection)) {

--- a/marc_export/.gitignore
+++ b/marc_export/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-classes/

--- a/oaipmh/.gitignore
+++ b/oaipmh/.gitignore
@@ -1,0 +1,1 @@
+/eclipse-build/

--- a/whelk-core/.gitignore
+++ b/whelk-core/.gitignore
@@ -1,0 +1,3 @@
+/eclipse-build/
+/eclipse-classes/
+/test/

--- a/whelk-core/src/main/java/whelk/meta/WhelkConstants.java
+++ b/whelk-core/src/main/java/whelk/meta/WhelkConstants.java
@@ -1,0 +1,12 @@
+package whelk.meta;
+
+/**
+ * This class is meant for constants that need to be visible to several modules
+ * that are not seeing each others code.
+ * 
+ * @author Jari Juslin <jari.juslin@helsinki.fi>
+ */
+
+public class WhelkConstants {
+    public static final String WHELKTOOL_THREAD_GROUP = "whelktool";
+}

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -11,6 +11,7 @@ import whelk.search.ESQuery
 import whelk.search.ElasticFind
 import whelk.util.LegacyIntegrationTools
 import whelk.util.Statistics
+import whelk.meta.WhelkConstants
 
 import javax.script.Bindings
 import javax.script.Compilable
@@ -33,10 +34,8 @@ import static java.util.concurrent.TimeUnit.SECONDS
 import static whelk.util.Jackson.mapper
 
 class WhelkTool {
-
     static final int DEFAULT_BATCH_SIZE = 500
     static final int DEFAULT_FETCH_SIZE = 100
-    private static final String WHELKTOOL_THREAD_GROUP = "whelktool"
 
     Whelk whelk
 
@@ -363,7 +362,7 @@ class WhelkTool {
     }
 
     private boolean isWorkerThread() {
-        return Thread.currentThread().getThreadGroup().getName().contains(WHELKTOOL_THREAD_GROUP)
+        return Thread.currentThread().getThreadGroup().getName().contains(WhelkConstants.WHELKTOOL_THREAD_GROUP)
     }
 
     private ScheduledFuture<?> setupTimedLogger(Counter counter) {


### PR DESCRIPTION
I recently changed Whelk ThreadPool to utilize Java standard ExecutorService.

However, Whelk uses some unconventional messaging paths for code flow control, and I missed one such item.

Whelk.batchJobThread() checks for thread group name and the exact name affects the path of execution. However, as string literal is used and not constant, unless you accidentally run into this one line method you can easily miss it.

I now changed the literals to a constant and changed the ExecutorService implementation to set the name.

I also added a command line switch -t for the reindex operation to set the level of parallelizatrion.

Then I tested on a beefy server on various values for -t to see that my fix improves the perfornamce, and indeed it does.