### PR TITLE
Add `asList()` and `getAtPath()` to whelktool API

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -85,6 +85,37 @@ class DocumentUtil {
     static boolean isBlank(Map node) {
         return !node.containsKey('@id')
     }
+    
+    /**
+     * 
+     * @param item
+     * @param path
+     * @param defaultTo
+     * @return
+     */
+    static def getAtPath(item, Iterable path, defaultTo = null) {
+        if(!item) {
+            return defaultTo
+        }
+
+        for (int i = 0 ; i < path.size(); i++) {
+            def p = path[i]
+            if (p == '*') {
+                if (item instanceof Collection) {
+                    return item.collect { getAtPath(it, path.drop(i + 1), []) }.flatten()
+                }
+                else {
+                    return []
+                }
+            }
+            else if (((item instanceof Collection && p instanceof Integer) || item instanceof Map) && item[p] != null) {
+                item = item[p]
+            } else {
+                return defaultTo
+            }
+        }
+        return item
+    }
 
     private static Operation linkBlankNode(List<Map> nodes, Linker linker) {
         if (!nodes.any(DocumentUtil.&isBlank)) {

--- a/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
@@ -5,6 +5,7 @@ import whelk.util.DocumentUtil.Remove
 import whelk.util.DocumentUtil.Replace
 
 import static whelk.util.DocumentUtil.NOP
+import static whelk.util.DocumentUtil.getAtPath
 
 class DocumentUtilSpec extends Specification {
 
@@ -197,5 +198,61 @@ class DocumentUtilSpec extends Specification {
                 [key: ['@id': 's']],
                 [key: [['@id': 8], ['@id': 9]]]
         ]
+    }
+    
+    def "get at path"() {
+        given:
+        def data = [
+                a:  [ 
+                        [b: [
+                                [x: 1],
+                                [x: 2],
+                                [x: 3],
+                                [x: 4],
+                                [x: 5],
+                        ]],
+                        [b: [x: 88]],
+                        [b: 'str'],
+                        [b: [x: 99]],
+                        [b: [
+                                [x: 6],
+                                [x: 7],
+                                [x: 8],
+                        ]],
+                        999
+                    ]
+                ]
+
+        expect:
+        getAtPath(data, path, defaultTo) == expected
+
+        where:
+        path                      | defaultTo || expected
+        ['b']                     | 'default' || 'default'
+        [1]                       | 'default' || 'default'
+        ['*']                     | 'default' || []
+        ['a', 4, 'b', 1, 'x']     | 'default' || 7
+        ['a', '*', 'b', 1, 'x']   | 'default' || [2, 7]
+        ['a', '*', 'b', 3, 'x']   | 'default' || [4]
+        ['a', '*', 'b', '*', 'x'] | 'default' || [1, 2, 3, 4, 5, 6, 7, 8]
+        ['a', '*', 'b', 'x']      | 'default' || [88, 99]
+        // maybe a bit counter-intuitive but using '*' flattens all lists
+        ['a', '*', 'b']           | 'default' || [[x: 1], [x: 2], [x: 3], [x: 4], [x: 5], [x: 88], 'str', [x: 99], [x: 6], [x: 7], [x: 8]]
+    }
+
+    def "get at empty path"() {
+        given:
+        def data = [a: [b: 1]]
+
+        expect:
+        getAtPath(data, []) == data
+    }
+
+    def "get at path default defaultTo"() {
+        given:
+        def data = [a: [b: 1]]
+
+        expect:
+        getAtPath(data, ['c']) == null
     }
 }

--- a/whelktool/README.md
+++ b/whelktool/README.md
@@ -306,13 +306,6 @@ selectByIds(queryIds(q).collect()) { languageLabels.add(it.graph[1]['prefLabelBy
 ```
 
 ### Tips
-It is often helpful to define an `asList` helper to deal with properties being objects or lists or non-existing.
-```groovy
-List asList(o) {
-    (o instanceof List) ? (List) o : (o ? [o] : [])
-}
-```
-
 Any exception thrown inside `selectBy...` will halt script execution. Sometimes this is what you want, sometimes
 it is easier to catch exceptions from edge cases and write them to an error report (with doc id). For example
 during development of a script that takes a long time to run.
@@ -380,3 +373,44 @@ DocumentUtil.traverse(d.graph, { value, path ->
 })
 ```
 See also [DocumentUtilSpec.groovy](../whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy)
+
+----
+
+You can use `asList` to deal with properties being objects or lists or non-existing.
+```groovy
+> asList([a:1])
+Result: [[a:1]]
+
+> asList('str')
+Result: [str]
+
+> asList([1, 2])
+Result: [1, 2]
+
+> asList(null)
+Result: []
+
+> asList(['is', 'a', 'list'])
+Result: [is, a, list]
+
+> asList(null)
+Result: []
+```
+
+----
+You can use `getAtPath(data, path, defaultTo=null)` for safe access to nested properties.
+If the path is not valid the specified default value is returned.
+```groovy
+selectByIds(ids) { d ->
+    def subjects = getAtPath(d.doc.data, ['@graph', 1, 'instanceOf', 'subject'], [])
+}
+```
+
+Use `'*'` as a wildcard for getting all values in a list (set).
+When using wildcards, `defaultTo` will always be an empty list.
+```groovy
+selectByIds(ids) { d ->
+    def agentIds = getAtPath(d.graph[1], ['instanceOf', 'contribution', '*', 'agent', '@id'])
+    def partTitles = getAtPath(d.graph[1], ['instanceOf', 'hasPart', '*', 'hasTitle', '*', 'mainTitle'])
+}
+```

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -4,11 +4,13 @@ import com.google.common.util.concurrent.MoreExecutors
 import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl
 import whelk.Document
 import whelk.IdGenerator
+import whelk.JsonLd
 import whelk.Whelk
 import whelk.exception.StaleUpdateException
 import whelk.exception.WhelkException
 import whelk.search.ESQuery
 import whelk.search.ElasticFind
+import whelk.util.DocumentUtil
 import whelk.util.LegacyIntegrationTools
 import whelk.util.Statistics
 
@@ -619,6 +621,8 @@ class WhelkTool {
         bindings.put("queryIds", this.&queryIds)
         bindings.put("queryDocs", this.&queryDocs)
         bindings.put("incrementStats", statistics.&increment)
+        bindings.put("asList", JsonLd::asList)
+        bindings.put("getAtPath", DocumentUtil::getAtPath)
         return bindings
     }
 


### PR DESCRIPTION
They are used (copy-pasted) in a lot of scripts.

Existing scripts continue to work as before since "bindings" are shadowed by methods defined in script.