### PR TITLE
Check for identical versions _after_ final adjustments of records hav…

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
+++ b/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
@@ -208,7 +208,7 @@ public class ApixCatServlet extends HttpServlet
                 id = Utils.s_whelk.getStorage().getSystemIdByIri("http://libris.kb.se/" + collection + "/" + id);
 
             incomingDocument.deepReplaceId( Document.getBASE_URI().resolve(id).toString() );
-            Utils.s_whelk.storeAtomicUpdate(id, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+            Utils.s_whelk.storeAtomicUpdate(id, false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                     (Document doc) ->
                     {
                         doc.data = incomingDocument.data;

--- a/apix_server/src/main/java/whelk/apixserver/Digidaily.java
+++ b/apix_server/src/main/java/whelk/apixserver/Digidaily.java
@@ -240,7 +240,7 @@ public class Digidaily {
                     out.write(bibToBeSaved.getShortId() + "\tDIGI CREATED\n");
                 } else {
                     bibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                             (Document doc) -> {
                                 doc.data = bibToBeSaved.data;
                             });
@@ -304,7 +304,7 @@ public class Digidaily {
                     MarcXmlRecordWriter marcXmlRecordWriter = new MarcXmlRecordWriter(baos);
                     marcXmlRecordWriter.writeRecord(eRecord);
                     Document printBibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                             (Document doc) -> {
                                 doc.data = printBibToBeSaved.data;
                             });

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -139,13 +139,8 @@ class XL
                             + existing.getDataAsString());
                 }
                 else {
-                    m_whelk.storeAtomicUpdate(idToMerge, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
-                        String existingChecksum = existing.getChecksum(m_whelk.getJsonld());
+                    m_whelk.storeAtomicUpdate(idToMerge, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
                         m_merge.merge(existing, incoming, m_parameters.getChangedBy(), m_whelk);
-                        String modifiedChecksum = existing.getChecksum(m_whelk.getJsonld());
-                        // Avoid writing an identical version
-                        if (modifiedChecksum.equals(existingChecksum))
-                            throw new CancelUpdateException();
                     });
                 }
 
@@ -228,10 +223,9 @@ class XL
             {
                 try
                 {
-                    m_whelk.storeAtomicUpdate(replaceSystemId, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
+                    m_whelk.storeAtomicUpdate(replaceSystemId, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
                             (Document doc) ->
                     {
-                        String existingChecksum = doc.getChecksum(m_whelk.getJsonld());
                         String existingEncodingLevel = doc.getEncodingLevel();
                         String newEncodingLevel = rdfDoc.getEncodingLevel();
 
@@ -261,11 +255,6 @@ class XL
                             doc.addTypedRecordIdentifier("SystemNumber", systemNumber);
                         if (controlNumber != null)
                             doc.setControlNumber(controlNumber);
-
-                        // Avoid writing an identical version
-                        String modifiedChecksum = doc.getChecksum(m_whelk.getJsonld());
-                        if (modifiedChecksum.equals(existingChecksum))
-                            throw new CancelUpdateException();
                     });
                 }
                 catch (TooHighEncodingLevelException e)

--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -277,10 +277,7 @@ class DatasetImporter {
     }
 
     private Document updateIfModified(Document incomingDoc, Closure callback=null) {
-        whelk.storeAtomicUpdate(incomingDoc.getShortId(), true, "xl", null, { doc ->
-            if (doc.getChecksum(whelk.jsonld) == incomingDoc.getChecksum(whelk.jsonld)) {
-                throw new CancelUpdateException() // Not an error, merely cancels the update
-            }
+        whelk.storeAtomicUpdate(incomingDoc.getShortId(), true, false, "xl", null, { doc ->
             doc.data = incomingDoc.data
             if (callback) {
                 callback()

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -827,7 +827,7 @@ class Crud extends HttpServlet {
                             .orElseThrow({ -> new BadRequestException("Missing If-Match header in update") })
                     
                     log.info("If-Match: ${ifMatch}")
-                    whelk.storeAtomicUpdate(doc, false, "xl", activeSigel, ifMatch.documentCheckSum())
+                    whelk.storeAtomicUpdate(doc, false, true, "xl", activeSigel, ifMatch.documentCheckSum())
                 }
                 else {
                     log.debug("Saving NEW document ("+ doc.getId() +")")

--- a/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
@@ -100,7 +100,7 @@ class RefreshAPI extends HttpServlet
 
     void refreshLoudly(Document doc) {
         boolean minorUpdate = false
-        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, "xl", "Libris admin", {
+        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, true, "xl", "Libris admin", {
             Document _doc ->
                 _doc.data = doc.data
         })

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -344,9 +344,9 @@ class Whelk {
      * The UpdateAgent SHOULD be a pure function since the update will be retried in case the document
      * was modified in another transaction.
      */
-    void storeAtomicUpdate(String id, boolean minorUpdate, String changedIn, String changedBy, PostgreSQLComponent.UpdateAgent updateAgent) {
+    void storeAtomicUpdate(String id, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, PostgreSQLComponent.UpdateAgent updateAgent) {
         Document preUpdateDoc = null
-        Document updated = storage.storeUpdate(id, minorUpdate, changedIn, changedBy, { Document doc ->
+        Document updated = storage.storeUpdate(id, minorUpdate, writeIdenticalVersions, changedIn, changedBy, { Document doc ->
             preUpdateDoc = doc.clone()
             updateAgent.update(doc)
             normalize(doc)
@@ -360,10 +360,10 @@ class Whelk {
         sparqlUpdater?.pollNow()
     }
 
-    void storeAtomicUpdate(Document doc, boolean minorUpdate, String changedIn, String changedBy, String oldChecksum) {
+    void storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, String oldChecksum) {
         normalize(doc)
         Document preUpdateDoc = storage.load(doc.shortId)
-        Document updated = storage.storeAtomicUpdate(doc, minorUpdate, changedIn, changedBy, oldChecksum)
+        Document updated = storage.storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, changedIn, changedBy, oldChecksum)
 
         if (updated == null) {
             return

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -519,7 +519,7 @@ class WhelkTool {
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
-            whelk.storeAtomicUpdate(doc, !item.loud, changedIn, scriptJobUri, item.preUpdateChecksum)
+            whelk.storeAtomicUpdate(doc, !item.loud, true, changedIn, scriptJobUri, item.preUpdateChecksum)
         }
         modifiedLog.println(doc.shortId)
     }


### PR DESCRIPTION
…e been done.

This fixes a bug where an incoming record would be considered not-identical to the existing record (being updated) because the comparisons were done _before_ the final fixup, specifically before the normalizeDocumentForStorage() call. This meant that for example incoming records with local entities about to be linked (during the normalize) call would be overwritten with a new identical version.

This moves the comparison to _after_ the normalizeDocumentForStorage() call, and makes the behaviour controllable through the "writeIdenticalVersions" boolean. As a side effect, the  behaviour (not overwriting) now becomes an availale option to other code trying to save records and in one place (APIX) that option will now be exercised, as that is more appropriate behaviour even though overwriting was tolerated before.