### PR TITLE
Make batchimport integTest work without bundled secret.properties

### DIFF
--- a/batchimport/integtest/test.sh
+++ b/batchimport/integtest/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eux
+
 # NEVER RUN THIS TEST CASE ON AN ENVIRONMENT WHERE THE DATA MATTERS!
 # This test case assumes you have built the batch_import jar file.
 # It also assumes that 'jq' is installed on the system.


### PR DESCRIPTION
And on environments where psql requires a username.
