### PR TITLE
MX-11 

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -229,7 +229,7 @@ public class Main {
         int recordNo = 0;
         for (MarcRecord marcRecord : batch) {
             try {
-                ThreadContext.push("-" + recordNo++);
+                ThreadContext.push(Integer.toString(recordNo++));
                 if (verbose) {
                     dumpDigIds(marcRecord);
                 }

--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -15,6 +15,10 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -59,8 +63,8 @@ public class Main {
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread thread, Throwable throwable) {
-                System.err.println("fatal: PANIC ABORT, unhandled exception:\n");
-                throwable.printStackTrace();
+                org.apache.logging.log4j.Logger log = LogManager.getLogger(XL.class.getName() + ".unhandled");
+                log.fatal("PANIC ABORT, unhandled exception:\n", throwable);
                 System.exit(-1);
             }
         });

--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -17,7 +17,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,6 +35,8 @@ import java.util.List;
 
 public class Main {
     private static XL s_librisXl = null;
+    
+    static Logger LOG = LogManager.getLogger(Main.class);
 
     private static boolean verbose = false;
 
@@ -63,7 +65,7 @@ public class Main {
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread thread, Throwable throwable) {
-                org.apache.logging.log4j.Logger log = LogManager.getLogger(XL.class.getName() + ".unhandled");
+                Logger log = LogManager.getLogger(XL.class.getName() + ".unhandled");
                 log.fatal("PANIC ABORT, unhandled exception:\n", throwable);
                 System.exit(-1);
             }
@@ -120,10 +122,10 @@ public class Main {
             PushGateway pg = new PushGateway(METRICS_PUSHGATEWAY);
             pg.pushAdd(registry, "batch_import");
         } catch (Throwable e) {
-            System.err.println("Metrics server connection failed. No metrics will be generated.");
+            LOG.warn("Metrics server connection failed. No metrics will be generated.");
         }
         if (verbose) {
-            System.err.println("info: All done.");
+            LOG.info("All done.");
         }
         threadPool.awaitAllAndShutdown();
     }
@@ -188,7 +190,7 @@ public class Main {
                     if (secondDiff > 0) {
                         long recordsPerSec = recordsBatched / secondDiff;
                         if (verbose) {
-                            System.err.println("info: Currently importing " + recordsPerSec + " records / sec.");
+                            LOG.info("Currently importing " + recordsPerSec + " records / sec.");
                         }
                     }
                 }
@@ -257,7 +259,7 @@ public class Main {
                         lastKnownBibDocId = resultingId;
                 }
             } catch (Exception e) {
-                System.err.println("Failed to convert or write the following MARC record:\n" + marcRecord.toString());
+                LOG.error("Failed to convert or write the following MARC record:\n" + marcRecord.toString());
                 throw new RuntimeException(e);
             }
         }

--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -135,7 +135,7 @@ public class Main {
      */
     private static void importFile(Path path, Parameters parameters)
             throws Exception {
-        System.err.println("info: Importing file: " + path.toString());
+        LOG.info("Importing file: " + path.toString());
         try (ExclusiveFile file = new ExclusiveFile(path);
              InputStream fileInStream = file.getInputStream()) {
             importStream(fileInStream, parameters);

--- a/natlibfi/batchimport/log4j2.xml
+++ b/natlibfi/batchimport/log4j2.xml
@@ -9,11 +9,18 @@
 			<PatternLayout pattern="%msg%n" />
 		</Console>
 
-		<File name="File" fileName="logs/batchimport.log">
+		<RollingFile name="File"
+			fileName="logs/batchimport.log"
+			filePattern="logs/batchimport.%d{dd-MMM}.log.gz"
+			ignoreExceptions="false">
 			<PatternLayout>
-				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1.} [%t]%x %m%n</Pattern>
 			</PatternLayout>
-		</File>
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" />
+			</Policies>
+			<DefaultRolloverStrategy max="5" />
+		</RollingFile>
 	</Appenders>
 
     <Loggers>


### PR DESCRIPTION
Currently only Groovy side logs via the logging framework and Java does not. This means informal DEBUG level messages are persisted whereas fatal errors are epheremal. Here I'm changing Main.java log uncaught fatal problems via the same framework as Groovy already does.