### PR TITLE
Mx 11 enhance batchimport logging

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Main.java
+++ b/batchimport/src/main/java/whelk/importer/Main.java
@@ -18,6 +18,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -225,8 +226,10 @@ public class Main {
 
     private static void importBatch(List<MarcRecord> batch) {
         String lastKnownBibDocId = null;
+        int recordNo = 0;
         for (MarcRecord marcRecord : batch) {
             try {
+                ThreadContext.push(Integer.toString(recordNo++));
                 if (verbose) {
                     dumpDigIds(marcRecord);
                 }
@@ -248,7 +251,7 @@ public class Main {
                     // - batch A creates holding
                     // - batch B creates holding  <-- ConflictingHoldException
                     // As a workaround we retry the holding record (batch B) which will now be found and updated instead
-                    System.err.println("Duplicate bib+hold in file? retrying:\n" + marcRecord.toString());
+                    LOG.warn("Duplicate bib+hold in file? retrying:\n" + marcRecord.toString());
                     String resultingId = s_librisXl.importISO2709(
                             marcRecord,
                             lastKnownBibDocId,
@@ -261,6 +264,8 @@ public class Main {
             } catch (Exception e) {
                 LOG.error("Failed to convert or write the following MARC record:\n" + marcRecord.toString());
                 throw new RuntimeException(e);
+            } finally {
+                ThreadContext.pop();
             }
         }
     }
@@ -272,7 +277,7 @@ public class Main {
                 if (r != null) {
                     for (String c : r) {
                         if (c != null) {
-                            System.out.printf("%s ", c);
+                            LOG.debug("%s ", c);
                         }
                     }
                 }

--- a/natlibfi/batchimport/log4j2.xml
+++ b/natlibfi/batchimport/log4j2.xml
@@ -9,11 +9,18 @@
 			<PatternLayout pattern="%msg%n" />
 		</Console>
 
-		<File name="File" fileName="logs/batchimport.log">
+		<RollingFile name="File"
+			fileName="logs/batchimport.log"
+			filePattern="logs/batchimport.%d{dd-MMM}.log.gz"
+			ignoreExceptions="false">
 			<PatternLayout>
-				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1.} [%t]%x %m%n</Pattern>
 			</PatternLayout>
-		</File>
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" />
+			</Policies>
+			<DefaultRolloverStrategy max="5" />
+		</RollingFile>
 	</Appenders>
 
     <Loggers>


### PR DESCRIPTION
I further enhance batchimport logging. Now all places in Main.java that logged to stdout and stderr write to the Log4J2 (that implements injected Groovy @Log) instead.

I also added generation of sequential ID for each MARC record which is then set to Log4J2 ThreadContext. The Log4J2 config under natlibfi/batchimport/ was also changed to print this information as well as name of the thread and logger. I have found these very useful in multi-threaded programs, because the ThreadContext (superset of earlier Nested Diagnostic Context) allows you see what log lines belong to same operation, or a different one.