### PR TITLE
Make it possible to sync datasets without refreshing dependers on upd…

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
+++ b/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
@@ -208,7 +208,7 @@ public class ApixCatServlet extends HttpServlet
                 id = Utils.s_whelk.getStorage().getSystemIdByIri("http://libris.kb.se/" + collection + "/" + id);
 
             incomingDocument.deepReplaceId( Document.getBASE_URI().resolve(id).toString() );
-            Utils.s_whelk.storeAtomicUpdate(id, false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+            Utils.s_whelk.storeAtomicUpdate(id, false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                     (Document doc) ->
                     {
                         doc.data = incomingDocument.data;

--- a/apix_server/src/main/java/whelk/apixserver/Digidaily.java
+++ b/apix_server/src/main/java/whelk/apixserver/Digidaily.java
@@ -240,7 +240,7 @@ public class Digidaily {
                     out.write(bibToBeSaved.getShortId() + "\tDIGI CREATED\n");
                 } else {
                     bibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                             (Document doc) -> {
                                 doc.data = bibToBeSaved.data;
                             });
@@ -304,7 +304,7 @@ public class Digidaily {
                     MarcXmlRecordWriter marcXmlRecordWriter = new MarcXmlRecordWriter(baos);
                     marcXmlRecordWriter.writeRecord(eRecord);
                     Document printBibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, false, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
+                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
                             (Document doc) -> {
                                 doc.data = printBibToBeSaved.data;
                             });

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -139,7 +139,7 @@ class XL
                             + existing.getDataAsString());
                 }
                 else {
-                    m_whelk.storeAtomicUpdate(idToMerge, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
+                    m_whelk.storeAtomicUpdate(idToMerge, false, false, true, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
                         String existingChecksum = existing.getChecksum(m_whelk.getJsonld());
 
                         List<String> recordIDs = existing.getRecordIdentifiers();
@@ -251,7 +251,7 @@ class XL
             {
                 try
                 {
-                    m_whelk.storeAtomicUpdate(replaceSystemId, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
+                    m_whelk.storeAtomicUpdate(replaceSystemId, false, false, true, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
                             (Document doc) ->
                     {
                         String existingEncodingLevel = doc.getEncodingLevel();

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -40,7 +40,7 @@ class ImporterMain {
     }
 
     @Command(args='SOURCE_URL DATASET_URI [DATASET_DESCRIPTION_FILE]',
-             flags='--skip-index --replace-main-ids --force-delete')
+             flags='--skip-index --replace-main-ids --force-delete --skip-dependers')
     void dataset(String sourceUrl, String datasetUri, String datasetDescPath=null, Map flags) {
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)
         if (flags['skip-index']) {

--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -409,7 +409,7 @@ public class ProfileExport
     private PreparedStatement getAllChangedIDsStatement(Timestamp from, Timestamp until, Connection connection)
             throws SQLException
     {
-        String sql = "SELECT id, collection, created, deleted, data#>>'{@graph,1,@type}' AS mainEntityType FROM lddb__versions WHERE modified >= ? AND modified <= ?";
+        String sql = "SELECT id, collection, created, deleted, data#>>'{@graph,1,@type}' AS mainEntityType FROM lddb__versions WHERE modified >= ? AND modified <= ? AND collection in ('bib', 'auth', 'hold')";
         PreparedStatement preparedStatement = connection.prepareStatement(sql);
         preparedStatement.setTimestamp(1, from);
         preparedStatement.setTimestamp(2, until);

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -827,7 +827,7 @@ class Crud extends HttpServlet {
                             .orElseThrow({ -> new BadRequestException("Missing If-Match header in update") })
                     
                     log.info("If-Match: ${ifMatch}")
-                    whelk.storeAtomicUpdate(doc, false, true, "xl", activeSigel, ifMatch.documentCheckSum())
+                    whelk.storeAtomicUpdate(doc, false, true, true, "xl", activeSigel, ifMatch.documentCheckSum())
                 }
                 else {
                     log.debug("Saving NEW document ("+ doc.getId() +")")

--- a/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
@@ -100,14 +100,14 @@ class RefreshAPI extends HttpServlet
 
     void refreshLoudly(Document doc) {
         boolean minorUpdate = false
-        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, true, "xl", "Libris admin", {
+        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, true, true, "xl", "Libris admin", {
             Document _doc ->
                 _doc.data = doc.data
         })
     }
 
     void refreshQuietly(Document doc) {
-        whelk.storage.refreshDerivativeTables(doc)
+        whelk.storage.refreshDerivativeTables(doc, true)
         whelk.elastic.index(doc, whelk)
     }
 }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -195,14 +195,16 @@ class Whelk {
                 .collectEntries { id, doc -> [(idMap.getOrDefault(id, id)) : doc]}
     }
 
-    private void reindex(Document updated, Document preUpdateDoc) {
+    private void reindex(Document updated, boolean refreshDependers, Document preUpdateDoc) {
         if (elastic && !skipIndex) {
             elastic.index(updated, this)
 
-            if (hasChangedMainEntityId(updated, preUpdateDoc)) {
-                reindexAllLinks(updated.shortId)
-            } else {
-                reindexAffected(updated, preUpdateDoc.getExternalRefs(), updated.getExternalRefs())
+            if (refreshDependers) {
+                if (hasChangedMainEntityId(updated, preUpdateDoc)) {
+                    reindexAllLinks(updated.shortId)
+                } else {
+                    reindexAffected(updated, preUpdateDoc.getExternalRefs(), updated.getExternalRefs())
+                }
             }
         }
     }
@@ -345,33 +347,45 @@ class Whelk {
     /**
      * The UpdateAgent SHOULD be a pure function since the update will be retried in case the document
      * was modified in another transaction.
+     *
+     * Parameter explanation:
+     * minorUpdate - When set to true, the 'modified' timestamp will not be updated. This results in no exports being triggered.
+     * writeIdenticalVersions - When set to true, a new entry will be written to the versions table even if the data did not change.
+     * refreshDependers - When set to true (you almost always want this!) records referencing the updated record will have their
+     *                    various denormalized things refreshed as well. If you set this to false, the onus is on you to make sure
+     *                    your changes to the data do not affect the dependencies table, and to reindex all the dependeing records
+     *                    if/when necessary.
+     *
+     * Returns true if anything was written.
      */
-    void storeAtomicUpdate(String id, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, PostgreSQLComponent.UpdateAgent updateAgent) {
+    boolean storeAtomicUpdate(String id, boolean minorUpdate, boolean writeIdenticalVersions, boolean refreshDependers, String changedIn, String changedBy, PostgreSQLComponent.UpdateAgent updateAgent) {
         Document preUpdateDoc = null
-        Document updated = storage.storeUpdate(id, minorUpdate, writeIdenticalVersions, changedIn, changedBy, { Document doc ->
+        Document updated = storage.storeUpdate(id, minorUpdate, writeIdenticalVersions, refreshDependers, changedIn, changedBy, { Document doc ->
             preUpdateDoc = doc.clone()
             updateAgent.update(doc)
             normalize(doc)
         })
 
         if (updated == null || preUpdateDoc == null) {
-            return
+            return false
         }
 
-        reindex(updated, preUpdateDoc)
+        reindex(updated, refreshDependers, preUpdateDoc)
         sparqlUpdater?.pollNow()
+
+        return true
     }
 
-    void storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, String oldChecksum) {
+    void storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, boolean refreshDependers, String changedIn, String changedBy, String oldChecksum) {
         normalize(doc)
         Document preUpdateDoc = storage.load(doc.shortId)
-        Document updated = storage.storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, changedIn, changedBy, oldChecksum)
+        Document updated = storage.storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, refreshDependers, changedIn, changedBy, oldChecksum)
 
         if (updated == null) {
             return
         }
         
-        reindex(updated, preUpdateDoc)
+        reindex(updated, refreshDependers, preUpdateDoc)
         sparqlUpdater?.pollNow()
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -150,8 +150,6 @@ class PostgreSQLComponent {
 
     private static final String CLEAR_EMBELLISHED = "DELETE FROM lddb__embellished"
 
-    private static final String CLEAR_CARDS = "DELETE FROM lddb__cards"
-
     private static final String GET_DOCUMENT_VERSION_BY_MAIN_ID = """
             SELECT id, data
             FROM lddb__versions 
@@ -541,21 +539,10 @@ class PostgreSQLComponent {
     }
 
     void clearEmbellishedCache(Connection connection) {
-        log.info("Clearing embellish cache")
+        log.debug("Clearing embellish cache")
         PreparedStatement preparedStatement = null
         try {
             preparedStatement = connection.prepareStatement(CLEAR_EMBELLISHED)
-            preparedStatement.execute()
-        } finally {
-            close(preparedStatement)
-        }
-    }
-
-    void clearCards(Connection connection) {
-        log.info("Clearing card cache")
-        PreparedStatement preparedStatement = null
-        try {
-            preparedStatement = connection.prepareStatement(CLEAR_CARDS)
             preparedStatement.execute()
         } finally {
             close(preparedStatement)
@@ -977,7 +964,6 @@ class PostgreSQLComponent {
             refreshDerivativeTables(doc, connection, refreshDependers, deleted)
             if (!refreshDependers) {
                 clearEmbellishedCache(connection)
-                clearCards(connection)
             }
 
             postCommitActions << { dependencyCache.invalidate(preUpdateDoc, doc) }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -150,6 +150,8 @@ class PostgreSQLComponent {
 
     private static final String CLEAR_EMBELLISHED = "DELETE FROM lddb__embellished"
 
+    private static final String CLEAR_CARDS = "DELETE FROM lddb__cards"
+
     private static final String GET_DOCUMENT_VERSION_BY_MAIN_ID = """
             SELECT id, data
             FROM lddb__versions 
@@ -549,6 +551,17 @@ class PostgreSQLComponent {
         }
     }
 
+    void clearCards(Connection connection) {
+        log.info("Clearing card cache")
+        PreparedStatement preparedStatement = null
+        try {
+            preparedStatement = connection.prepareStatement(CLEAR_CARDS)
+            preparedStatement.execute()
+        } finally {
+            close(preparedStatement)
+        }
+    }
+
     void evictDependersFromEmbellishedCache(String id, Connection connection) {
         if (random.nextInt(1000) == 0) { // check every 1000 calls on average
             boolean isFull = totalTableSizeBytes('lddb__embellished', connection) > embellishCacheMaxSize
@@ -702,7 +715,7 @@ class PostgreSQLComponent {
                 insert.executeUpdate()
 
                 saveVersion(doc, connection, now, now, changedIn, changedBy, collection, deleted)
-                refreshDerivativeTables(doc, connection, deleted)
+                refreshDerivativeTables(doc, connection, true, deleted)
 
                 connection.commit()
                 connection.setAutoCommit(true)
@@ -749,7 +762,7 @@ class PostgreSQLComponent {
 
             long count = 0
             for (Document doc : loadAll(null, false, null, null)) {
-                refreshDerivativeTables(doc, connection, doc.getDeleted(), leaveCacheAlone)
+                refreshDerivativeTables(doc, connection, true, doc.getDeleted(), leaveCacheAlone)
 
                 ++count
                 if (count % 500 == 0)
@@ -782,7 +795,7 @@ class PostgreSQLComponent {
                 insert.executeUpdate()
 
                 saveVersion(doc, connection, now, now, changedIn, changedBy, collection, false)
-                refreshDerivativeTables(doc, connection, false)
+                refreshDerivativeTables(doc, connection, true, false)
 
                 connection.commit()
                 return true
@@ -826,12 +839,12 @@ class PostgreSQLComponent {
         }
     }
 
-    Document storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, String oldChecksum) {
+    Document storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, boolean refreshDependers, String changedIn, String changedBy, String oldChecksum) {
         return withDbConnection {
             Connection connection = getMyConnection()
             connection.setAutoCommit(false)
             List<Runnable> postCommitActions = []
-            Document result = storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, changedIn, changedBy, oldChecksum, connection, postCommitActions)
+            Document result = storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, refreshDependers, changedIn, changedBy, oldChecksum, connection, postCommitActions)
             connection.commit()
             connection.setAutoCommit(true)
             postCommitActions.each { it.run() }
@@ -839,14 +852,14 @@ class PostgreSQLComponent {
         }
     }
 
-    Document storeUpdate(String id, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy, UpdateAgent updateAgent) {
+    Document storeUpdate(String id, boolean minorUpdate, boolean writeIdenticalVersions, boolean refreshDependers, String changedIn, String changedBy, UpdateAgent updateAgent) {
         int retriesLeft = STALE_UPDATE_RETRIES
         while (true) {
             try {
                 Document doc = load(id)
                 String checksum = doc.getChecksum(jsonld)
                 updateAgent.update(doc)
-                Document updated = storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, changedIn, changedBy, checksum)
+                Document updated = storeAtomicUpdate(doc, minorUpdate, writeIdenticalVersions, refreshDependers, changedIn, changedBy, checksum)
                 return updated
             }
             catch (StaleUpdateException e) {
@@ -861,7 +874,7 @@ class PostgreSQLComponent {
         }
     }
 
-    Document storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, String changedIn, String changedBy,
+    Document storeAtomicUpdate(Document doc, boolean minorUpdate, boolean writeIdenticalVersions, boolean refreshDependers, String changedIn, String changedBy,
                                        String oldChecksum, Connection connection, List<Runnable> postCommitActions) {
         String id = doc.shortId
         log.debug("Saving (atomic update) ${id}")
@@ -957,11 +970,15 @@ class PostgreSQLComponent {
                 SortedSet<String> idsLinkingToOldId = getDependencyData(id, GET_DEPENDERS, connection)
                 for (String dependerId : idsLinkingToOldId) {
                     Document depender = load(dependerId)
-                    storeAtomicUpdate(depender, true, false, changedIn, changedBy, depender.getChecksum(jsonld), connection, postCommitActions)
+                    storeAtomicUpdate(depender, true, false, refreshDependers, changedIn, changedBy, depender.getChecksum(jsonld), connection, postCommitActions)
                 }
             }
 
-            refreshDerivativeTables(doc, connection, deleted)
+            refreshDerivativeTables(doc, connection, refreshDependers, deleted)
+            if (!refreshDependers) {
+                clearEmbellishedCache(connection)
+                clearCards(connection)
+            }
 
             postCommitActions << { dependencyCache.invalidate(preUpdateDoc, doc) }
 
@@ -974,7 +991,7 @@ class PostgreSQLComponent {
             } else {
                 throw psqle
             }
-        } catch (TooHighEncodingLevelException | StaleUpdateException e) {
+        } catch (TooHighEncodingLevelException | StaleUpdateException | CancelUpdateException e) {
             connection.rollback()
             throw e
         } catch (Exception e) {
@@ -1047,16 +1064,17 @@ class PostgreSQLComponent {
         // We're ok.
     }
 
-    void refreshDerivativeTables(Document doc) {
+    void refreshDerivativeTables(Document doc, boolean refreshDependers) {
         withDbConnection {
             Connection connection = getMyConnection()
-            refreshDerivativeTables(doc, connection, doc.deleted)
+            refreshDerivativeTables(doc, connection, refreshDependers, doc.deleted)
         }
     }
 
-    void refreshDerivativeTables(Document doc, Connection connection, boolean deleted, boolean leaveCacheAlone = false) {
+    void refreshDerivativeTables(Document doc, Connection connection, boolean refreshDependers, boolean deleted, boolean leaveCacheAlone = false) {
         saveIdentifiers(doc, connection, deleted)
-        saveDependencies(doc, connection)
+        if (refreshDependers)
+            saveDependencies(doc, connection)
         if (!leaveCacheAlone)
             evictDependersFromEmbellishedCache(doc.getShortId(), connection)
 
@@ -1551,7 +1569,7 @@ class PostgreSQLComponent {
                 ver_batch.executeBatch()
                 docs.each { doc ->
                     boolean leaveCacheAlone = true
-                    refreshDerivativeTables(doc, connection, false, leaveCacheAlone)
+                    refreshDerivativeTables(doc, connection, true, false, leaveCacheAlone)
                 }
                 clearEmbellishedCache(connection)
                 connection.commit()
@@ -2512,7 +2530,7 @@ class PostgreSQLComponent {
 
             log.debug("Marking document with ID ${identifier} as deleted.")
             try {
-                storeUpdate(identifier, false, true, changedIn, changedBy,
+                storeUpdate(identifier, false, true, true, changedIn, changedBy,
                     { Document doc ->
                         doc.setDeleted(true)
                         // Add a tombstone marker (without removing anything) perhaps?

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -518,7 +518,7 @@ class WhelkTool {
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
-            whelk.storeAtomicUpdate(doc, !item.loud, true, changedIn, scriptJobUri, item.preUpdateChecksum)
+            whelk.storeAtomicUpdate(doc, !item.loud, true, true, changedIn, scriptJobUri, item.preUpdateChecksum)
         }
         modifiedLog.println(doc.shortId)
     }


### PR DESCRIPTION
…ated records.

This is necessary in order to sync some datasets that see extremely heavy use, like "languages".

Doing this has drawbacks however. If you sync a dataset this way, it's up to you to make sure the changed data should not have affected the dependency table, and also to reindex the dataset (and all it's dependers!) if and when that is necessary.

All of this was equally true for the old definitions importer as well.

Additionally: Fix the counters in the dataset importer (updated/created/deleted). These had rotted with other changes to the core system.

Additionally: Make it an explicit rule that changes brought by syncing of "definitions" (meaning any datasets!) do not ever trigger MARC21 or OAIPMH exports under any circumstances.

Finally this STILL does not make it possible to completely replace the old definitions importer, because the dataset loader relies on the normal write-record code paths, which in turn _need_ some definitions data (vocab?) to function. This puts us in a chicken-and-egg type situation.

The dataset importer could now however be used to _update_ all definitions data.