### PR TITLE
Do all elastic indexing asynchronously

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -195,10 +195,9 @@ class Whelk {
                 .collectEntries { id, doc -> [(idMap.getOrDefault(id, id)) : doc]}
     }
 
-    private void reindex(Document updated, Document preUpdateDoc) {
-        if (elastic && !skipIndex) {
+    private void reindexUpdated(Document updated, Document preUpdateDoc) {
+        indexAsyncOrSync {
             elastic.index(updated, this)
-
             if (hasChangedMainEntityId(updated, preUpdateDoc)) {
                 reindexAllLinks(updated.shortId)
             } else {
@@ -206,12 +205,21 @@ class Whelk {
             }
         }
     }
-
-    private void reindexAffected(Document document, Set<Link> preUpdateLinks, Set<Link> postUpdateLinks) {
+    
+    private void indexAsyncOrSync(Runnable runnable) {
+        if (skipIndex) {
+            return
+        }
+        
+        if(!elastic) {
+            log.warn("Elasticsearch not configured when trying to reindex")
+            return
+        }
+        
         Runnable reindex = {
             try {
-                reindexAffectedSync(document, preUpdateLinks, postUpdateLinks)
-            } 
+                runnable.run()
+            }
             catch (Exception e) {
                 log.error("Error reindexing: $e", e)
             }
@@ -232,7 +240,7 @@ class Whelk {
         bulkIndex(links)
     }
 
-    private void reindexAffectedSync(Document document, Set<Link> preUpdateLinks, Set<Link> postUpdateLinks) {
+    private void reindexAffected(Document document, Set<Link> preUpdateLinks, Set<Link> postUpdateLinks) {
         Set<Link> addedLinks = (postUpdateLinks - preUpdateLinks)
         Set<Link> removedLinks = (preUpdateLinks - postUpdateLinks)
 
@@ -333,7 +341,7 @@ class Whelk {
 
         boolean success = storage.createDocument(document, changedIn, changedBy, collection, deleted)
         if (success) {
-            if (elastic && !skipIndex) {
+            indexAsyncOrSync {
                 elastic.index(document, this)
                 reindexAffected(document, new TreeSet<>(), document.getExternalRefs())
             }
@@ -358,7 +366,7 @@ class Whelk {
             return
         }
 
-        reindex(updated, preUpdateDoc)
+        reindexUpdated(updated, preUpdateDoc)
         sparqlUpdater?.pollNow()
     }
 
@@ -370,8 +378,8 @@ class Whelk {
         if (updated == null) {
             return
         }
-        
-        reindex(updated, preUpdateDoc)
+
+        reindexUpdated(updated, preUpdateDoc)
         sparqlUpdater?.pollNow()
     }
 
@@ -388,13 +396,9 @@ class Whelk {
         log.debug "Deleting ${id} from Whelk"
         Document doc = storage.load(id)
         storage.remove(id, changedIn, changedBy, force)
-        if (elastic && !skipIndex) {
+        indexAsyncOrSync {
             elastic.remove(id)
             reindexAffected(doc, doc.getExternalRefs(), Collections.emptySet())
-            log.debug "Object ${id} was removed from Whelk"
-        }
-        else {
-            log.warn "No Elastic present when deleting. Skipping call to elastic.remove(${id})"
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -38,7 +38,9 @@ class ElasticClient {
     static final int CONNECTION_POOL_SIZE = 30
 
     static final int CONNECT_TIMEOUT_MS = 5 * 1000
-    static final int READ_TIMEOUT_MS = 60 * 1000
+    static final int READ_TIMEOUT_MS = 15 * 1000
+    static final int BATCH_CONNECT_TIMEOUT_MS = 0 // infinite
+    static final int BATCH_READ_TIMEOUT_MS = READ_TIMEOUT_MS * 80
     static final int MAX_BACKOFF_S = 1024
 
     static final CircuitBreakerConfig CB_CONFIG = CircuitBreakerConfig.custom()
@@ -85,8 +87,8 @@ class ElasticClient {
         cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_HOST)
 
         RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(0)
-                .setSocketTimeout(READ_TIMEOUT_MS * 20)
+                .setConnectTimeout(BATCH_CONNECT_TIMEOUT_MS)
+                .setSocketTimeout(BATCH_READ_TIMEOUT_MS)
                 .build()
 
         CloseableHttpClient httpClient = HttpClients.custom()

--- a/whelk-core/src/main/java/whelk/exception/UnexpectedHttpStatusException.java
+++ b/whelk-core/src/main/java/whelk/exception/UnexpectedHttpStatusException.java
@@ -16,4 +16,16 @@ public class UnexpectedHttpStatusException extends WhelkRuntimeException {
     public String getMessage() {
         return statusCode + ": " + super.getMessage();
     }
+
+    public static boolean isBadRequest(Exception e) {
+        return isStatus(e, 400);
+    }
+
+    public static boolean isNotFound(Exception e) {
+        return isStatus(e, 404);
+    }
+
+    private static boolean isStatus(Exception e, int code) {
+        return e instanceof UnexpectedHttpStatusException && ((UnexpectedHttpStatusException) e).getStatusCode() == code;
+    }
 }


### PR DESCRIPTION
(except for batch jobs, like before)

HTTP requests to elastic sometimes hang. These hanging requests would
cause POST or PUT to our CRUD API to block for 60s (SO_TIMEOUT/READ_TIMEOUT
in ElasticClient). These would timeout in API clients or the proxy even if
everything was finally successful. Leading some clients to retry and creating
duplicates in case of POST.

Before this change the document being created/updated/removed was
indexed synchronously and other affected documents asynchonously.
Do all elastic indexing in the background instead.

This also fixes a similar problem when the main URI of a resource is
changed.

Also reduce SO_TIMEOUT for indexing of single docs to 15s so that we retry
hanged requests sooner.

---- 
Also:
Fix an old problem where trying to update the reverse link counter on a deleted document would be retried indefinitely.