### PR TITLE
Detect simple contexts and just compact

### DIFF
--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -19,6 +19,9 @@ import static whelk.util.Jackson.mapper
 @CompileStatic
 class DatasetImporter {
 
+    static String CONTEXT = JsonLd.CONTEXT_KEY
+    static String VOCAB = JsonLd.VOCAB_KEY
+    static String BASE = '@base'
     static String GRAPH = JsonLd.GRAPH_KEY
     static String ID = JsonLd.ID_KEY
     static String TYPE = JsonLd.TYPE_KEY
@@ -269,7 +272,13 @@ class DatasetImporter {
 
     private Map loadTurtleAsSystemShaped(InputStream ins) {
         Map data = TrigToJsonLdParser.parse(ins)
-        data = (Map) getTvm().applyTargetVocabularyMap(whelk.defaultTvmProfile, contextDocData, data)
+        if (data[CONTEXT] instanceof Map) {
+            Map ctx = (Map) data[CONTEXT]
+            if (ctx[VOCAB] == whelk.jsonld.vocabId && (ctx.size() == 1 || (ctx.size() == 2 && ctx.containsKey(BASE)))) {
+                return (Map) TrigToJsonLdParser.compact(data, contextDocData)
+            }
+        }
+        return (Map) getTvm().applyTargetVocabularyMap(whelk.defaultTvmProfile, contextDocData, data)
     }
 
     private Document getDocByMainEntityId(String id) {

--- a/whelk-core/src/main/groovy/whelk/converter/TrigToJsonLdParser.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/TrigToJsonLdParser.groovy
@@ -2,6 +2,8 @@ package whelk.converter
 
 import groovy.transform.CompileStatic
 
+import trld.jsonld.Compaction
+import trld.jsonld.Expansion
 import trld.Output
 import trld.Input
 import trld.trig.Parser
@@ -10,5 +12,13 @@ import trld.trig.Parser
 class TrigToJsonLdParser {
     static Map parse(InputStream ins) {
         return (Map) Parser.parse(new Input(ins))
+    }
+
+    static Object expand(Object data, String baseIri=null) {
+        Expansion.expand(data, baseIri)
+    }
+
+    static Object compact(Object data, Map context, String baseIri=null) {
+        return Compaction.compact(context, expand(data, baseIri))
     }
 }


### PR DESCRIPTION
If the input data is simply using the system vocab `@context` (KBV in our case), we can simply compact that using the system context (to expand links and compact terms using datatype coercion or containers).