### PR TITLE
Feature/detailed history again

### DIFF
--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -284,8 +284,7 @@ public class History {
             List tempNew = new LinkedList((List) examining);
             List tempOld = new LinkedList((List) correspondingPrevious);
             for (int i = 0; i < tempNew.size(); ++i) {
-                int j;
-                for (j = 0; j < tempOld.size(); ++j) {
+                for (int j = 0; j < tempOld.size(); ++j) {
                     if (tempNew.get(i).equals(tempOld.get(j))) { // Equals will recursively check the entire subtree!
                         tempNew.remove(i);
                         tempOld.remove(j);


### PR DESCRIPTION
This PR clears up what was previously a confusion around the double meaning of "path" in the context of change sets.

From now on, it is unambigiously the case that removedPaths strictly refer to the path of the removed object *in the previous version*, while addedPaths strictly refer to the path of the added object *in the new/current version*.

These were previously confused, which did not matter for 99% of cases, but made difficult cases where different things were being removed and added within the same list impossible.

This WILL require frontend changes to compensate for, but hopefully they will be minor @lrosenstrom 