### PR TITLE
Feature/extend language linker

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -11,6 +11,7 @@ import whelk.component.PostgreSQLComponent
 import whelk.component.SparqlUpdater
 import whelk.converter.marc.MarcFrameConverter
 import whelk.exception.StorageCreateFailedException
+import whelk.filter.LanguageLinker
 import whelk.filter.LinkFinder
 import whelk.filter.NormalizerChain
 import whelk.meta.WhelkConstants
@@ -132,16 +133,18 @@ class Whelk {
     }
     
     private void initDocumentNormalizers() {
+        LanguageLinker languageLinker = new LanguageLinker()
+        Normalizers.loadDefinitions(languageLinker, this)
         normalizer = new NormalizerChain(
                 [
                         Normalizers.nullRemover(),
                         //FIXME: This is KBV specific stuff
                         Normalizers.workPosition(jsonld),
                         Normalizers.typeSingularity(jsonld),
-                        Normalizers.language(this),
+                        Normalizers.language(languageLinker),
                         Normalizers.identifiedBy(),
                         Normalizers.romanizer(this),
-                ] + Normalizers.heuristicLinkers(this)
+                ] + Normalizers.heuristicLinkers(this, languageLinker.getTypes())
         )
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/BlankNodeLinker.groovy
@@ -39,7 +39,7 @@ class BlankNodeLinker implements DocumentUtil.Linker {
     boolean linkAll(data, Collection<String> keys) {
         return findKey(data, keys, link(this)) && removeDeleted(data)
     }
-    
+
     boolean linkAll(data, String key) {
         return findKey(data, key, link(this)) && removeDeleted(data)
     }
@@ -81,15 +81,14 @@ class BlankNodeLinker implements DocumentUtil.Linker {
                 labels.values().each(maybeCollection({ String label ->
                     identifiers.add(label.toLowerCase())
                 }))
-            }
-            else {
-                (definition[field] ?: []).with(maybeCollection( { String identifier ->
+            } else {
+                (definition[field] ?: []).with(maybeCollection({ String identifier ->
                     identifiers.add(identifier.toLowerCase())
                 }))
             }
         }
 
-        String id = definition.isReplacedBy? definition.isReplacedBy[ID_KEY] : definition[ID_KEY]
+        String id = definition.isReplacedBy ? definition.isReplacedBy[ID_KEY] : definition[ID_KEY]
         identifiers.each { addMapping(it, id) }
     }
 
@@ -125,7 +124,7 @@ class BlankNodeLinker implements DocumentUtil.Linker {
             return
         }
 
-        if (!fields.any {blank.containsKey(it)}) {
+        if (!fields.any { blank.containsKey(it) }) {
             incrementCounter('unhandled shape', blank.keySet())
             throw new RuntimeException('unhandled shape: ' + blank.keySet())
         }
@@ -156,15 +155,14 @@ class BlankNodeLinker implements DocumentUtil.Linker {
         return null
     }
 
-    List<Map> link(String blank) {
+    List<Map> link(String blank, List existingLinks = []) {
         incrementCounter('single value encountered', blank)
 
-        List<String> links = findLinks(blank, [])
+        List<String> links = findLinks(blank, existingLinks)
         if (links) {
             incrementCounter('mapped', blank)
             return links.collect { [(ID_KEY): it] }
-        }
-        else {
+        } else {
             incrementCounter('not mapped (canonized values)', canonize(blank))
         }
     }

--- a/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
@@ -7,12 +7,12 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
     List ignoreCodes = []
 
     LanguageLinker(List ignoreCodes = [], Statistics stats = null) {
-        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm'], stats)
+        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm', 'hiddenLabel'], stats)
         this.ignoreCodes = ignoreCodes
     }
 
-    boolean linkLanguages(data, String key = 'language') {
-        return DocumentUtil.findKey(data, key, DocumentUtil.link(this))
+    boolean linkLanguages(data, List<Map> helpNodes = [], String key = 'language') {
+        return DocumentUtil.findKey(data, key, DocumentUtil.link(this, helpNodes))
     }
 
     @Override
@@ -44,6 +44,11 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
                 matches << m.group(1)
             }
             return matches
+        }
+
+        // concatenated language labels, e.g. "Svenska & engelska"
+        if (labelOrCode ==~ /^(.*,)*.*( & | och | and ).*/) {
+            return labelOrCode.split(/,| & | och | and /) as List
         }
 
         return []

--- a/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
@@ -7,7 +7,7 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
     List ignoreCodes = []
 
     LanguageLinker(List ignoreCodes = [], Statistics stats = null) {
-        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabelByLang', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm'], stats)
+        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabelByLang', 'hiddenLabel', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm'], stats)
         this.ignoreCodes = ignoreCodes
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
@@ -11,8 +11,8 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
         this.ignoreCodes = ignoreCodes
     }
 
-    boolean linkLanguages(data, List<Map> helpNodes = [], String key = 'language') {
-        return DocumentUtil.findKey(data, key, DocumentUtil.link(this, helpNodes))
+    boolean linkLanguages(data, List<Map> disambiguationNodes = [], String key = 'language') {
+        return DocumentUtil.findKey(data, key, DocumentUtil.link(this, disambiguationNodes))
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
@@ -7,7 +7,7 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
     List ignoreCodes = []
 
     LanguageLinker(List ignoreCodes = [], Statistics stats = null) {
-        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm', 'hiddenLabel'], stats)
+        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabelByLang', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm'], stats)
         this.ignoreCodes = ignoreCodes
     }
 
@@ -36,6 +36,11 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
             return labelOrCode
         }
 
+        // concatenated language labels, e.g. "Svenska & engelska"
+        if (labelOrCode ==~ /^(.*,)*.*( & | och | and ).*/) {
+            return labelOrCode.split(/,| & | och | and /) as List
+        }
+
         // concatenated language codes, e.g "sweruseng", "swe ; rus ; eng"
         if (labelOrCode ==~ /^(\w{3}\W*){2,}/) {
             def m = labelOrCode =~ /(\w{3})\W*/
@@ -44,11 +49,6 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
                 matches << m.group(1)
             }
             return matches
-        }
-
-        // concatenated language labels, e.g. "Svenska & engelska"
-        if (labelOrCode ==~ /^(.*,)*.*( & | och | and ).*/) {
-            return labelOrCode.split(/,| & | och | and /) as List
         }
 
         return []

--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -86,6 +86,35 @@ class DocumentUtil {
         return !node.containsKey('@id')
     }
 
+    /**
+     *
+     * @param item
+     * @param path
+     * @param defaultTo
+     * @return
+     */
+    static def getAtPath(item, Iterable path, defaultTo = null) {
+        if (!item) {
+            return defaultTo
+        }
+
+        for (int i = 0; i < path.size(); i++) {
+            def p = path[i]
+            if (p == '*') {
+                if (item instanceof Collection) {
+                    return item.collect { getAtPath(it, path.drop(i + 1), []) }.flatten()
+                } else {
+                    return []
+                }
+            } else if (((item instanceof Collection && p instanceof Integer) || item instanceof Map) && item[p] != null) {
+                item = item[p]
+            } else {
+                return defaultTo
+            }
+        }
+        return item
+    }
+
     private static Operation linkBlankNode(List<Map> nodes, Linker linker, List<Map> helpNodes = []) {
         if (!nodes.any(DocumentUtil.&isBlank)) {
             return NOP

--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -23,7 +23,7 @@ class DocumentUtil {
          * This is called when the blank node search encounters
          * a single string value where there would normally be a node
          */
-        List<Map> link(String blank)
+        List<Map> link(String blank, List existingLinks)
     }
 
     /**
@@ -58,7 +58,7 @@ class DocumentUtil {
      * @return true if obj was changed
      */
     static boolean findKey(data, Collection<String> keys, Visitor visitor) {
-        Set<String> k = keys instanceof Set ? keys : new HashSet<>(keys) 
+        Set<String> k = keys instanceof Set ? keys : new HashSet<>(keys)
         return traverse(data, { value, path ->
             if (path && path.last() instanceof String && k.contains(path.last())) {
                 return visitor.visitElement(value, path)
@@ -66,9 +66,9 @@ class DocumentUtil {
         })
     }
 
-    static Visitor link(Linker linker) {
+    static Visitor link(Linker linker, List<Map> helpNodes = []) {
         return { value, path ->
-            return DocumentUtil.&linkBlankNodes(value, linker)
+            return DocumentUtil.&linkBlankNodes(value, linker, helpNodes)
         }
     }
 
@@ -78,51 +78,21 @@ class DocumentUtil {
      * @param linker
      * @return
      */
-    static Operation linkBlankNodes(def objectOrArray, Linker linker) {
-        return linkBlankNode(objectOrArray, linker)
+    static Operation linkBlankNodes(def objectOrArray, Linker linker, List<Map> helpNodes = []) {
+        return linkBlankNode(objectOrArray, linker, helpNodes)
     }
 
     static boolean isBlank(Map node) {
         return !node.containsKey('@id')
     }
-    
-    /**
-     * 
-     * @param item
-     * @param path
-     * @param defaultTo
-     * @return
-     */
-    static def getAtPath(item, Iterable path, defaultTo = null) {
-        if(!item) {
-            return defaultTo
-        }
 
-        for (int i = 0 ; i < path.size(); i++) {
-            def p = path[i]
-            if (p == '*') {
-                if (item instanceof Collection) {
-                    return item.collect { getAtPath(it, path.drop(i + 1), []) }.flatten()
-                }
-                else {
-                    return []
-                }
-            }
-            else if (((item instanceof Collection && p instanceof Integer) || item instanceof Map) && item[p] != null) {
-                item = item[p]
-            } else {
-                return defaultTo
-            }
-        }
-        return item
-    }
-
-    private static Operation linkBlankNode(List<Map> nodes, Linker linker) {
+    private static Operation linkBlankNode(List<Map> nodes, Linker linker, List<Map> helpNodes = []) {
         if (!nodes.any(DocumentUtil.&isBlank)) {
             return NOP
         }
 
-        List<Map> existingLinks = nodes.findAll { !DocumentUtil.&isBlank(it) }.collect { it['@id'] }
+        List<Map> existingLinks = collectIris(nodes)
+        List<Map> helpLinks = collectIris(helpNodes)
         List<Map> result = []
 
         List<Map> newLinked
@@ -130,7 +100,7 @@ class DocumentUtil {
             if (isDefective(node)) {
                 continue // remove node
             }
-            if (isBlank(node) && (newLinked = linker.link(node, existingLinks))) {
+            if (isBlank(node) && (newLinked = linker.link(node, existingLinks) ?: linker.link(node, helpLinks))) {
                 result.addAll(newLinked.findAll { l ->
                     !existingLinks.contains(l['@id']) && !result.contains { it['@id'] == l['@id'] }
                 })
@@ -146,7 +116,7 @@ class DocumentUtil {
         }
     }
 
-    private static Operation linkBlankNode(Map node, Linker linker) {
+    private static Operation linkBlankNode(Map node, Linker linker, List<Map> helpNodes = []) {
         if (isDefective(node)) {
             return new Remove()
         }
@@ -154,11 +124,11 @@ class DocumentUtil {
             return NOP
         }
 
-        toOperation(linker.link(node, []))
+        toOperation(linker.link(node, collectIris(helpNodes)))
     }
 
-    private static Operation linkBlankNode(String singleValue, Linker linker) {
-        toOperation(linker.link(singleValue))
+    private static Operation linkBlankNode(String singleValue, Linker linker, List<Map> helpNodes = []) {
+        toOperation(linker.link(singleValue, collectIris(helpNodes)))
     }
 
     private static Operation toOperation(List<Map> replacement) {
@@ -169,6 +139,10 @@ class DocumentUtil {
 
     private static boolean isDefective(Map node) {
         node.size() == 0 || (node.size() == 1 && node.containsKey(TYPE_KEY))
+    }
+
+    private static List<Map> collectIris(List<Map> nodes) {
+        nodes.findAll { !isBlank(it) }.collect { it['@id'] }
     }
 
     private static class DFS {
@@ -182,7 +156,7 @@ class DocumentUtil {
             operations = []
 
             node(obj)
-            operations = operations.reverse().each { it.perform(obj )}
+            operations = operations.reverse().each { it.perform(obj) }
             return !operations.isEmpty()
         }
 
@@ -236,6 +210,7 @@ class DocumentUtil {
     static class Nop extends Operation {
         @Override
         protected void perform(Object obj) {}
+
         protected Operation setPath(List path) { this }
     }
 
@@ -243,7 +218,7 @@ class DocumentUtil {
         @Override
         protected void perform(Object obj) {
             def (parent, key) = parentAndKey(obj)
-            if(!parent) {
+            if (!parent) {
                 return
             }
 

--- a/whelk-core/src/test/groovy/whelk/filter/LanguageLinkerSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/filter/LanguageLinkerSpec.groovy
@@ -254,6 +254,9 @@ class LanguageLinkerSpec extends Specification {
                         code           : 'gre',
                         prefLabelByLang: [
                                 'sv': 'Nygrekiska'
+                        ],
+                        hiddenLabelByLang: [
+                                'sv': 'grekiska'
                         ]
                 ],
                 [
@@ -261,6 +264,9 @@ class LanguageLinkerSpec extends Specification {
                         code           : 'grc',
                         prefLabelByLang: [
                                 'sv': 'Grekiska, klassisk'
+                        ],
+                        hiddenLabelByLang: [
+                                'sv': 'grekiska'
                         ]
                 ],
                 [
@@ -272,8 +278,6 @@ class LanguageLinkerSpec extends Specification {
                         ]
                 ]
         ].each(linker.&addDefinition)
-        linker.addMapping('grekiska', 'http://id/gre')
-        linker.addMapping('grekiska', 'http://id/grc')
 
         expect:
         linker.linkLanguages(data) == change
@@ -319,6 +323,9 @@ class LanguageLinkerSpec extends Specification {
                         code           : 'gre',
                         prefLabelByLang: [
                                 'sv': 'Nygrekiska'
+                        ],
+                        hiddenLabelByLang: [
+                                'sv': 'grekiska'
                         ]
                 ],
                 [
@@ -326,6 +333,9 @@ class LanguageLinkerSpec extends Specification {
                         code           : 'grc',
                         prefLabelByLang: [
                                 'sv': 'Grekiska, klassisk'
+                        ],
+                        hiddenLabelByLang: [
+                                'sv': 'grekiska'
                         ]
                 ],
                 [
@@ -337,8 +347,6 @@ class LanguageLinkerSpec extends Specification {
                         ]
                 ]
         ].each(linker.&addDefinition)
-        linker.addMapping('grekiska', 'http://id/gre')
-        linker.addMapping('grekiska', 'http://id/grc')
 
         expect:
         linker.linkLanguages(data, [['@id': 'http://id/ton'], ['@id': 'http://id/gre']]) == change

--- a/whelk-core/src/test/groovy/whelk/filter/LanguageLinkerSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/filter/LanguageLinkerSpec.groovy
@@ -197,6 +197,22 @@ class LanguageLinkerSpec extends Specification {
         [language: [code: 'swe qqq eng']]     | false  | [language: [code: 'swe qqq eng']]
     }
 
+    def "handles concatenated language labels"() {
+        expect:
+        linker.linkLanguages(data) == change
+        data == expected
+
+        where:
+        data                                                   | change | expected
+        [language: [label: 'svenska & engelska']]              | true   | [language: [['@id': 'http://id/swe'], ['@id': 'http://id/eng']]]
+        [language: [label: 'english and hebrew']]              | true   | [language: [['@id': 'http://id/eng'], ['@id': 'http://id/heb']]]
+        [language: [label: 'svenska, engelska och hebreiska']] | true   | [language: [['@id': 'http://id/swe'], ['@id': 'http://id/eng'], ['@id': 'http://id/heb']]]
+
+        // do nothing if not all codes can be mapped
+        [language: [label: 'svenska och hittepåiska']]         | false  | [language: [label: 'svenska och hittepåiska']]
+        [language: [label: 'engelska & hittepåiska']]          | false  | [language: [label: 'engelska & hittepåiska']]
+    }
+
     def "handles weird language label lists"() {
         expect:
         linker.linkLanguages(data) == change
@@ -264,16 +280,80 @@ class LanguageLinkerSpec extends Specification {
         data == expected
 
         where:
-        data                                                                | change | expected
-        [language: [[label: 'tonga']]]                                      | false  | [language: [[label: 'tonga']]]
-        [language: [[label: 'tonga'], ['@id': 'http://id/ton']]]            | true   | [language: [['@id': 'http://id/ton']]]
-        [language: [[label: 'tonga'], ['@id': 'http://id/tog']]]            | true   | [language: [['@id': 'http://id/tog']]]
+        data                                                        | change | expected
+        [language: [[label: 'tonga']]]                              | false  | [language: [[label: 'tonga']]]
+        [language: [[label: 'tonga'], ['@id': 'http://id/ton']]]    | true   | [language: [['@id': 'http://id/ton']]]
+        [language: [[label: 'tonga'], ['@id': 'http://id/tog']]]    | true   | [language: [['@id': 'http://id/tog']]]
 
-        [language: [[label: 'grekiska']]]                                   | false  | [language: [[label: 'grekiska']]]
-        [language: [[label: 'grekiska'], ['@id': 'http://id/gre']]]         | true   | [language: [['@id': 'http://id/gre']]]
-        [language: [[label: 'grekiska'], ['@id': 'http://id/grc']]]         | true   | [language: [['@id': 'http://id/grc']]]
+        [language: [[label: 'grekiska']]]                           | false  | [language: [[label: 'grekiska']]]
+        [language: [[label: 'grekiska'], ['@id': 'http://id/gre']]] | true   | [language: [['@id': 'http://id/gre']]]
+        [language: [[label: 'grekiska'], ['@id': 'http://id/grc']]] | true   | [language: [['@id': 'http://id/grc']]]
     }
 
+    def "handles ambiguous labels using given input to disambiguate"() {
+        given:
+        LanguageLinker linker = new LanguageLinker()
+        [
+                [
+                        '@id'          : 'http://id/tog',
+                        code           : 'tog',
+                        prefLabelByLang: [
+                                'sv': 'Tonga'
+                        ],
+                        commentByLang  : [
+                                sv: 'Nyasa'
+                        ]
+                ],
+                [
+                        '@id'          : 'http://id/ton',
+                        code           : 'ton',
+                        prefLabelByLang: [
+                                sv: 'Tonga'
+                        ],
+                        commentByLang  : [
+                                sv: 'Tongaöarna'
+                        ]
+                ],
+                [
+                        '@id'          : 'http://id/gre',
+                        code           : 'gre',
+                        prefLabelByLang: [
+                                'sv': 'Nygrekiska'
+                        ]
+                ],
+                [
+                        '@id'          : 'http://id/grc',
+                        code           : 'grc',
+                        prefLabelByLang: [
+                                'sv': 'Grekiska, klassisk'
+                        ]
+                ],
+                [
+                        '@id'          : 'http://id/lat',
+                        code           : 'lat',
+                        prefLabelByLang: [
+                                'sv': 'Latin',
+                                'en': 'Latin'
+                        ]
+                ]
+        ].each(linker.&addDefinition)
+        linker.addMapping('grekiska', 'http://id/gre')
+        linker.addMapping('grekiska', 'http://id/grc')
+
+        expect:
+        linker.linkLanguages(data, [['@id': 'http://id/ton'], ['@id': 'http://id/gre']]) == change
+        data == expected
+
+        where:
+        data                                                        | change | expected
+        [language: [[label: 'tonga']]]                              | true   | [language: [['@id': 'http://id/ton']]]
+        [language: [[label: 'tonga'], ['@id': 'http://id/ton']]]    | true   | [language: [['@id': 'http://id/ton']]]
+        [language: [[label: 'tonga'], ['@id': 'http://id/tog']]]    | true   | [language: [['@id': 'http://id/tog']]]
+
+        [language: [[label: 'grekiska']]]                           | true   | [language: [['@id': 'http://id/gre']]]
+        [language: [[label: 'grekiska'], ['@id': 'http://id/gre']]] | true   | [language: [['@id': 'http://id/gre']]]
+        [language: [[label: 'grekiska'], ['@id': 'http://id/grc']]] | true   | [language: [['@id': 'http://id/grc']]]
+    }
 
     def "removes non-existing sameAs links"() {
         expect:

--- a/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
@@ -5,7 +5,6 @@ import whelk.util.DocumentUtil.Remove
 import whelk.util.DocumentUtil.Replace
 
 import static whelk.util.DocumentUtil.NOP
-import static whelk.util.DocumentUtil.getAtPath
 
 class DocumentUtilSpec extends Specification {
 
@@ -178,7 +177,7 @@ class DocumentUtilSpec extends Specification {
                     }
 
                     @Override
-                    List<Map> link(String blank) {
+                    List<Map> link(String blank, List existingLinks) {
                         return [['@id': 's']]
                     }
                 }
@@ -198,61 +197,5 @@ class DocumentUtilSpec extends Specification {
                 [key: ['@id': 's']],
                 [key: [['@id': 8], ['@id': 9]]]
         ]
-    }
-    
-    def "get at path"() {
-        given:
-        def data = [
-                a:  [ 
-                        [b: [
-                                [x: 1],
-                                [x: 2],
-                                [x: 3],
-                                [x: 4],
-                                [x: 5],
-                        ]],
-                        [b: [x: 88]],
-                        [b: 'str'],
-                        [b: [x: 99]],
-                        [b: [
-                                [x: 6],
-                                [x: 7],
-                                [x: 8],
-                        ]],
-                        999
-                    ]
-                ]
-
-        expect:
-        getAtPath(data, path, defaultTo) == expected
-
-        where:
-        path                      | defaultTo || expected
-        ['b']                     | 'default' || 'default'
-        [1]                       | 'default' || 'default'
-        ['*']                     | 'default' || []
-        ['a', 4, 'b', 1, 'x']     | 'default' || 7
-        ['a', '*', 'b', 1, 'x']   | 'default' || [2, 7]
-        ['a', '*', 'b', 3, 'x']   | 'default' || [4]
-        ['a', '*', 'b', '*', 'x'] | 'default' || [1, 2, 3, 4, 5, 6, 7, 8]
-        ['a', '*', 'b', 'x']      | 'default' || [88, 99]
-        // maybe a bit counter-intuitive but using '*' flattens all lists
-        ['a', '*', 'b']           | 'default' || [[x: 1], [x: 2], [x: 3], [x: 4], [x: 5], [x: 88], 'str', [x: 99], [x: 6], [x: 7], [x: 8]]
-    }
-
-    def "get at empty path"() {
-        given:
-        def data = [a: [b: 1]]
-
-        expect:
-        getAtPath(data, []) == data
-    }
-
-    def "get at path default defaultTo"() {
-        given:
-        def data = [a: [b: 1]]
-
-        expect:
-        getAtPath(data, ['c']) == null
     }
 }

--- a/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/DocumentUtilSpec.groovy
@@ -5,6 +5,7 @@ import whelk.util.DocumentUtil.Remove
 import whelk.util.DocumentUtil.Replace
 
 import static whelk.util.DocumentUtil.NOP
+import static whelk.util.DocumentUtil.getAtPath
 
 class DocumentUtilSpec extends Specification {
 
@@ -197,5 +198,61 @@ class DocumentUtilSpec extends Specification {
                 [key: ['@id': 's']],
                 [key: [['@id': 8], ['@id': 9]]]
         ]
+    }
+    
+    def "get at path"() {
+        given:
+        def data = [
+                a:  [ 
+                        [b: [
+                                [x: 1],
+                                [x: 2],
+                                [x: 3],
+                                [x: 4],
+                                [x: 5],
+                        ]],
+                        [b: [x: 88]],
+                        [b: 'str'],
+                        [b: [x: 99]],
+                        [b: [
+                                [x: 6],
+                                [x: 7],
+                                [x: 8],
+                        ]],
+                        999
+                    ]
+                ]
+
+        expect:
+        getAtPath(data, path, defaultTo) == expected
+
+        where:
+        path                      | defaultTo || expected
+        ['b']                     | 'default' || 'default'
+        [1]                       | 'default' || 'default'
+        ['*']                     | 'default' || []
+        ['a', 4, 'b', 1, 'x']     | 'default' || 7
+        ['a', '*', 'b', 1, 'x']   | 'default' || [2, 7]
+        ['a', '*', 'b', 3, 'x']   | 'default' || [4]
+        ['a', '*', 'b', '*', 'x'] | 'default' || [1, 2, 3, 4, 5, 6, 7, 8]
+        ['a', '*', 'b', 'x']      | 'default' || [88, 99]
+        // maybe a bit counter-intuitive but using '*' flattens all lists
+        ['a', '*', 'b']           | 'default' || [[x: 1], [x: 2], [x: 3], [x: 4], [x: 5], [x: 88], 'str', [x: 99], [x: 6], [x: 7], [x: 8]]
+    }
+
+    def "get at empty path"() {
+        given:
+        def data = [a: [b: 1]]
+
+        expect:
+        getAtPath(data, []) == data
+    }
+
+    def "get at path default defaultTo"() {
+        given:
+        def data = [a: [b: 1]]
+
+        expect:
+        getAtPath(data, ['c']) == null
     }
 }


### PR DESCRIPTION
New features:

- Concatenated language labels, e.g. "Svenska & engelska" will now be linked.
- Option to arbitrarily specify links to be used for disambiguation. When ambiguous, the linker will check for a linked sibling as before but if none can be found it will now go on and check the specified links.
- More label mappings through `hiddenLabelByLang`/`hiddenLabel`.
- Linker objects accessible from whelk instance, e.g. `whelk.normalizer.normalizers.find { it.getLinker() instanceof LanguageLinker }`. This can easily be generalized to any normalizer object, not just linkers, if needed in the future.
- Keep track of which normalizers have already been loaded to avoid multiple instances of identical normalizers (so far only to avoid Language normalizer being loaded by `heuristicLinkers` method).