### PR TITLE
Romanization API

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
@@ -21,36 +21,30 @@ class TransliterationAPI extends HttpServlet {
     @Override
     void doPost(HttpServletRequest request, HttpServletResponse response) {
         log.debug("Handling POST request for ${request.pathInfo}")
-        log.info("${request}")
-        log.info("Request body")
 
         Map body = getRequestBody(request)
 
         if (!(body.containsKey("langTag") && body.containsKey("source"))) {
             log.warn("Transliteration parameter missing")
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Parameter missing; needs langTag and source")
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Parameter missing; needs langTag and source")
             return
         }
 
         def languageTag = body["langTag"]
         def source = body["source"]
-        log.info(languageTag)
-        log.info(source)
 
         if (supportedLangTags.contains(languageTag)) {
             def romanized = Romanizer.romanize(source.toString(), languageTag.toString())
             HttpTools.sendResponse(response,  romanized, "application/json")
         } else {
             log.warn("Language tag ${languageTag} not found")
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Invalid language code")
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid language code")
         }
     }
 
     @Override
     void doGet(HttpServletRequest request, HttpServletResponse response) {
         log.debug("Handling GET request for ${request.pathInfo}")
-        log.info("${request}")
-        log.info("${request.getPathInfo()}")
 
         if (request.getPathInfo() == "/listLanguages") {
             HttpTools.sendResponse(response, ["supportedLanguages": supportedLangTags], "application/json", HttpServletResponse.SC_OK)

--- a/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
@@ -26,7 +26,7 @@ class TransliterationAPI extends HttpServlet {
 
         if (!(body.containsKey("langTag") && body.containsKey("source"))) {
             log.warn("Transliteration parameter missing")
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Parameter missing; needs langTag and source")
+            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Parameter missing; needs langTag and source")
             return
         }
 
@@ -38,7 +38,7 @@ class TransliterationAPI extends HttpServlet {
             HttpTools.sendResponse(response,  romanized, "application/json")
         } else {
             log.warn("Language tag ${languageTag} not found")
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid language code")
+            HttpTools.sendError(response, HttpServletResponse.SC_BAD_REQUEST, "Invalid language code")
         }
     }
 
@@ -46,9 +46,7 @@ class TransliterationAPI extends HttpServlet {
     void doGet(HttpServletRequest request, HttpServletResponse response) {
         log.debug("Handling GET request for ${request.pathInfo}")
 
-        if (request.getPathInfo() == "/listLanguages") {
-            HttpTools.sendResponse(response, ["supportedLanguages": supportedLangTags], "application/json", HttpServletResponse.SC_OK)
-        } else if (request.getPathInfo().startsWith("/language/")) {
+        if (request.getPathInfo().startsWith("/language/")) {
             handleLanguageCheck(request, response)
         } else {
             HttpTools.sendResponse(response, null, null, HttpServletResponse.SC_NOT_FOUND)

--- a/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
@@ -1,0 +1,47 @@
+package whelk.rest.api
+
+import groovy.util.logging.Log4j2 as Log
+import whelk.util.Romanizer
+
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static whelk.util.Jackson.mapper
+
+@Log
+class TransliterationAPI extends HttpServlet {
+
+    @Override
+    void init() {
+        log.info("Starting Transliteration API")
+    }
+
+    @Override
+    void doPost(HttpServletRequest request, HttpServletResponse response) {
+        log.debug("Handling GET request for ${request.pathInfo}")
+        log.info("${request}")
+        log.info("Request body")
+
+
+        Map body = getRequestBody(request);
+        def languageTag = body["langTag"]
+        def source = body["source"]
+        log.info(languageTag)
+        log.info(source)
+
+        def romanized = Romanizer.romanize(source.toString(), languageTag.toString())
+        HttpTools.sendResponse(response,  romanized, "application/json")
+    }
+
+    static Map getRequestBody(HttpServletRequest request) {
+        byte[] body = request.getInputStream().getBytes()
+
+        try {
+            return mapper.readValue(body, Map)
+        } catch (EOFException) {
+            return [:]
+        }
+    }
+
+}

--- a/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/TransliterationAPI.groovy
@@ -25,6 +25,13 @@ class TransliterationAPI extends HttpServlet {
         log.info("Request body")
 
         Map body = getRequestBody(request)
+
+        if (!(body.containsKey("langTag") && body.containsKey("source"))) {
+            log.warn("Transliteration parameter missing")
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,  "Parameter missing; needs langTag and source")
+            return
+        }
+
         def languageTag = body["langTag"]
         def source = body["source"]
         log.info(languageTag)
@@ -80,5 +87,4 @@ class TransliterationAPI extends HttpServlet {
             return [:]
         }
     }
-
 }

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -94,6 +94,10 @@
         <servlet-name>DigitalReproductionAPI</servlet-name>
         <servlet-class>se.kb.libris.digi.DigitalReproductionAPI</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>TransliterationAPI</servlet-name>
+        <servlet-class>whelk.rest.api.TransliterationAPI</servlet-class>
+    </servlet>
 
 
     <servlet>
@@ -140,6 +144,11 @@
     <servlet-mapping>
         <servlet-name>MarcframeData</servlet-name>
         <url-pattern>/sys/marcframe.json</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>TransliterationAPI</servlet-name>
+        <url-pattern>/_transliterate</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -148,7 +148,7 @@
 
     <servlet-mapping>
         <servlet-name>TransliterationAPI</servlet-name>
-        <url-pattern>/_transliterate</url-pattern>
+        <url-pattern>/_transliterate/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/rest/src/test/groovy/whelk/rest/api/TransliterationAPISpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/TransliterationAPISpec.groovy
@@ -1,0 +1,158 @@
+package whelk.rest.api
+
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+
+import javax.servlet.ServletInputStream
+import javax.servlet.ServletOutputStream
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpServletResponseWrapper
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND
+import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT
+import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
+
+class TransliterationAPISpec extends Specification {
+    TransliterationAPI transliteration
+
+    HttpServletRequest request
+    HttpServletResponse response
+    JsonSlurper jsonSlurper
+
+    void setup() {
+        transliteration = new TransliterationAPI()
+        jsonSlurper = new JsonSlurper()
+
+        request = GroovyMock(HttpServletRequest.class)
+        request.getRequestURI() >> {
+            request.getPathInfo()
+        }
+
+        CapturingServletOutputStream out = new CapturingServletOutputStream()
+        response = new HttpServletResponseWrapper(GroovyMock(HttpServletResponse.class)) {
+            int status = 0
+            String contentType
+            def headers = [:]
+
+            ServletOutputStream getOutputStream() {
+                return out
+            }
+
+            void sendError(int sc, String mess) {
+                this.status = sc
+            }
+
+            void setHeader(String h, String v) {
+                headers.put(h, v)
+            }
+
+            String getHeader(String h) {
+                return headers.get(h)
+            }
+
+            String getResponseBody() {
+                return out.asString()
+            }
+        }
+    }
+
+    def "POST to / should return transliteration"() {
+        given:
+        def input = "{\"langTag\": \"${tag}\", \"source\": \"${source}\"}"
+        def bytes = input.getBytes("UTF-8")
+        def is = GroovyMock(ServletInputStream)
+        is.getBytes() >> { bytes }
+        is.getText("UTF-8") >> { input }
+        request.getInputStream() >> { is }
+        request.getPathInfo() >> { "/" }
+        request.getMethod() >> { "POST" }
+        transliteration.doPost(request, response)
+
+        expect:
+        response.getStatus() == expectedStatus
+        if (expectedStatus == SC_OK) {
+            Map parsedResponse = jsonSlurper.parseText(response.getResponseBody())
+            parsedResponse.containsKey(expectedKey)
+            parsedResponse[expectedKey] == expectedValue
+        }
+
+        where:
+        tag | source | expectedKey | expectedValue | expectedStatus
+        "uk"  | "Королівська бібліотека Швеції"  | "uk-Latn-t-uk-Cyrl-m0-iso-1995"   | "Korolivsʹka biblioteka Šveciï"    | SC_OK
+        "grc" | "Εθνική βιβλιοθήκη της Σουηδίας" | "grc-Latn-t-grc-Grek-x0-skr-1980" | "Ethnikē bibliothēkē tēs Souēdias" | SC_OK
+        "nonexistent" | "klsdfjsklfjsdf" | "" | "" | SC_BAD_REQUEST
+    }
+
+
+    def "POST with missing parameter(s) should return 400()"() {
+        given:
+        def bytes = input.getBytes("UTF-8")
+        def is = GroovyMock(ServletInputStream)
+        is.getBytes() >> { bytes }
+        is.getText("UTF-8") >> { input }
+        request.getInputStream() >> { is }
+        request.getPathInfo() >> { "/" }
+        request.getMethod() >> { "POST" }
+        transliteration.doPost(request, response)
+
+        expect:
+        response.getStatus() == SC_BAD_REQUEST
+
+        where:
+        input << [
+                '{"langTag": "uk", "sauce": "foo"}',
+                '{"langTag": "uk"}',
+                '{"source": "foo"}',
+        ]
+    }
+
+    def "GET/HEAD /language/<language-tag> should check if language is supported"() {
+        given:
+        request.getPathInfo() >> { "/language/" + langTag }
+        request.getMethod() >> { method }
+        switch (method) {
+            case "GET":
+                transliteration.doGet(request, response)
+                break
+            case "HEAD":
+                transliteration.doHead(request, response)
+                break
+        }
+
+        expect:
+        response.getStatus() == expectedStatus
+
+        where:
+        langTag    | method  | expectedStatus
+        "be"       | "GET"   | SC_NO_CONTENT
+        "grc"      | "GET"   | SC_NO_CONTENT
+        "uk"       | "GET"   | SC_NO_CONTENT
+        "mn-Mong"  | "GET"   | SC_NO_CONTENT
+        "rom-Cyrl" | "GET"   | SC_NO_CONTENT
+        "xxxxxxxx" | "GET"   | SC_NOT_FOUND
+        "be"       | "HEAD"  | SC_NO_CONTENT
+        "grc"      | "HEAD"  | SC_NO_CONTENT
+        "uk"       | "HEAD"  | SC_NO_CONTENT
+        "mn-Mong"  | "HEAD"  | SC_NO_CONTENT
+        "rom-Cyrl" | "HEAD"  | SC_NO_CONTENT
+        "xxxxxxxx" | "HEAD"  | SC_NOT_FOUND
+    }
+
+    def "GET /listLanguages should return JSON with list of supported languages"() {
+        given:
+        request.getPathInfo() >> { "/listLanguages" }
+
+        when:
+        transliteration.doGet(request, response)
+
+        then:
+        response.getStatus() == SC_OK
+        response.getContentType() == "application/json"
+        Map parsedResponse = jsonSlurper.parseText(response.getResponseBody())
+        parsedResponse.containsKey("supportedLanguages")
+        parsedResponse["supportedLanguages"] instanceof List
+        ((List) parsedResponse["supportedLanguages"]).containsAll(["be", "grc", "uk", "mn-Mong", "rom-Cyrl"])
+    }
+}

--- a/rest/src/test/groovy/whelk/rest/api/TransliterationAPISpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/TransliterationAPISpec.groovy
@@ -139,20 +139,4 @@ class TransliterationAPISpec extends Specification {
         "rom-Cyrl" | "HEAD"  | SC_NO_CONTENT
         "xxxxxxxx" | "HEAD"  | SC_NOT_FOUND
     }
-
-    def "GET /listLanguages should return JSON with list of supported languages"() {
-        given:
-        request.getPathInfo() >> { "/listLanguages" }
-
-        when:
-        transliteration.doGet(request, response)
-
-        then:
-        response.getStatus() == SC_OK
-        response.getContentType() == "application/json"
-        Map parsedResponse = jsonSlurper.parseText(response.getResponseBody())
-        parsedResponse.containsKey("supportedLanguages")
-        parsedResponse["supportedLanguages"] instanceof List
-        ((List) parsedResponse["supportedLanguages"]).containsAll(["be", "grc", "uk", "mn-Mong", "rom-Cyrl"])
-    }
 }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -140,7 +140,7 @@ class Whelk {
                         Normalizers.typeSingularity(jsonld),
                         Normalizers.language(this),
                         Normalizers.identifiedBy(),
-                        Normalizers.romanizer(this),
+//                        Normalizers.romanizer(this),
                 ] + Normalizers.heuristicLinkers(this)
         )
     }

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -140,7 +140,6 @@ class Whelk {
                         Normalizers.typeSingularity(jsonld),
                         Normalizers.language(this),
                         Normalizers.identifiedBy(),
-//                        Normalizers.romanizer(this),
                 ] + Normalizers.heuristicLinkers(this)
         )
     }


### PR DESCRIPTION
@lrosenstrom did the initial part, I just extended the API a bit (LXL-3971) and added some tests. To be used with https://github.com/libris/lxlviewer/tree/feature/romanization (LXL-3906).

Examples (assuming mockAuthentication true):
```bash
~ curl -X POST "http://localhost:8180/_transliterate" -d '{"langTag": "grc", "source": "Εθνική βιβλιοθήκη της Σουηδίας"}'
{"grc-Latn-t-grc-Grek-x0-skr-1980":"Ethnikē bibliothēkē tēs Souēdias"}

# Parameter missing
~ curl -X POST "http://localhost:8180/_transliterate" -d '{"source": "Εθνική βιβλιοθήκη της Σουηδίας"}'
...
<title>Error 400 Parameter missing; needs langTag and source</title>
...

# Invalid language
~ curl -X POST "http://localhost:8180/_transliterate" -d '{"langTag": "foo", "source": "Εθνική βιβλιοθήκη της Σουηδίας"}'
...
<title>Error 400 Invalid language code</title>
...

# Can we romanize `uk`?
~ curl -i http://localhost:8180/_transliterate/language/uk
HTTP/1.1 204 No Content # yes, language tag is romanizable

# Can we romanize `foo`?
~ curl -i http://localhost:8180/_transliterate/language/foo
HTTP/1.1 404 Not Found # no, language tag is not romanizable

# What languages (language tags) can be romanized?
~ curl http://localhost:8180/_transliterate/listLanguages
{"supportedLanguages":["be","bg","el","grc","kk","mk","mn-Cyrl","ru","sr","uk","am","az","chu","ka","hi","hy","kir","mn-Mong","tt","tg","tk","uz","zh","abk-Cyrl","ady-Cyrl","alt-Cyrl","ava-Cyrl","bak-Cyrl","bua-Cyrl","che-Cyrl","chm-Cyrl","chv-Cyrl","dar-Cyrl","inh-Cyrl","kaa-Cyrl","kbd-Cyrl","kom-Cyrl","krc-Cyrl","krl-Cyrl","kum-Cyrl","lez-Cyrl","lit-Cyrl","nog-Cyrl","oss-Cyrl","rom-Cyrl","rum-Cyrl","sah-Cyrl","sel-Cyrl","tut-Cyrl","udm-Cyrl","xal-Cyrl"]}
```