### PR TITLE
Add test for /_changesets; 'changesets' => '_changesets' in changeset @id

### DIFF
--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -39,7 +39,7 @@ public class History {
         m_pathOwnership = new HashMap<>();
 
         m_changeSetsMap = new HashMap();
-        m_changeSetsMap.put("@id", versions.get(0).doc.getCompleteId() + "/changesets");
+        m_changeSetsMap.put("@id", versions.get(0).doc.getCompleteId() + "/_changesets");
         m_changeSetsMap.put("changeSets", new ArrayList<>());
 
         // The list we get is sorted chronologically, oldest first.

--- a/whelk-core/src/test/groovy/whelk/history/HistorySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/history/HistorySpec.groovy
@@ -1,6 +1,5 @@
 package whelk.history
 
-import spock.lang.Ignore
 import spock.lang.Specification
 import whelk.Document
 import whelk.JsonLd
@@ -61,8 +60,7 @@ class HistorySpec extends Specification {
         changeSets[1].removedPaths == [["@graph", 1, "a"]] as Set
         changeSets[1].addedPaths == [["@graph", 1, "a"]] as Set
     }
-    
-    @Ignore("LXL-3934")
+
     def "nested value modified"() {
         given:
         def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, [:], JsonLdSpec.VOCAB_DATA)
@@ -85,16 +83,14 @@ class HistorySpec extends Specification {
 
         def history = new History(versions, ld)
         List<Map> changeSets = history.m_changeSetsMap['changeSets']
-        
-        printJson(changeSets)
-        
+
+        //printJson(changeSets)
+
         expect:
         changeSets.size() == 2
         changeSets[1].removedPaths == [["@graph", 1, "a", 0, "b"]] as Set
         changeSets[1].addedPaths == [["@graph", 1, "a", 0, "b"]] as Set
     }
-    
-    
 
     def printJson(def c) {
         println(groovy.json.JsonOutput.prettyPrint(Jackson.mapper().writeValueAsString(c)))


### PR DESCRIPTION
Hardly PR-worthy but note that in the changeset `@id`, `changesets` is now `_changesets` to reflect the actual URL we use (previously the `@id` would 404). I assume `_changesets` is what we want. (i.e. https://libris-qa.kb.se/9slgbxnm1x552vm/changesets => https://libris-qa.kb.se/9slgbxnm1x552vm/_changesets)

I realized that we did already have some History tests, so I just re-enabled the one that was ignored (#1172 made it work again). Plus added a basic test in CrudSpec.