### PR TITLE
Add IgnoreOnRevert to STRN in linkfields with spec

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe-patterns.json
+++ b/whelk-core/src/main/resources/ext/marcframe-patterns.json
@@ -1199,7 +1199,7 @@
   "serialSpecificDetails": {
     "$k": {"about": "_:instance", "addProperty": "seriesStatement", "TODO:targetMatch": "4xx, 8xx"},
     "$r": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ReportNumber", "property": "value", "TODO:targetMatch": "088"},
-    "$u": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "STRN", "property": "value", "TODO:targetMatch": "027"},
+    "$u": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "STRN", "property": "value", "ignoreOnRevert": true, "TODO:targetMatch": "027"},
     "$z": {"about": "_:instance", "addLink": "identifiedBy", "resourceType": "ISBN", "property": "value", "TODO:targetMatch": "020"}
   },
 

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -18574,9 +18574,24 @@
           }}
         },
         {
-          "source": {"780": {"ind1": "0", "ind2": "1", "subfields": [{"t": "A Title"}]}},
+          "name": "No reverse of STRN ($u) for ISSN-central.",
+          "source": {"780": {"ind1": "0", "ind2": "0", "subfields": [{"t": "Samhälle, opinion, massmedia"},{"u": "GU-STJM-SOM"},{"x": "0284-4788"}]}},
+          "normalized": {"780": {"ind1": "0", "ind2": "0", "subfields": [{"t": "Samhälle, opinion, massmedia"},{"x": "0284-4788"}]}},
           "result": {"mainEntity": {
-            "continuesInPart": [{
+            "continues": [{
+              "@type": "Instance",
+              "hasTitle": [{"@type": "Title", "mainTitle": "Samhälle, opinion, massmedia"}],
+              "identifiedBy": [
+                {"@type": "STRN", "value": "GU-STJM-SOM"},
+                {"@type": "ISSN", "value": "0284-4788"}
+              ]
+            }]
+          }}
+        },
+        {
+          "source": {"780": {"ind1": "0", "ind2": "0", "subfields": [{"t": "A Title"}]}},
+          "result": {"mainEntity": {
+            "continues": [{
               "@type": "Instance",
               "hasTitle": [{"@type": "Title", "mainTitle": "A Title"}]
             }]


### PR DESCRIPTION
Add ignoreOnRevert for STRN identifiers in linkfield pattern ($u). This will mute occurences in any linked publication.

LXL-3964