### PR TITLE
Search: Make filtering on multi-language properties work 

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -239,7 +239,7 @@
                 "include_in_parent": true,
                 "properties": {
                     "@type": {"type": "keyword"},
-                    "mainTitle": {
+                    "__mainTitle": {
                         "type": "text",
                         "analyzer": "softmatcher",
                         "copy_to": "_all",
@@ -252,7 +252,7 @@
                     }
                 }
             },
-            "prefLabel": {
+            "__prefLabel": {
                 "type": "text",
                 "fields": {
                     "keyword": {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -93,6 +93,7 @@ class JsonLd {
     private Map<String, Set<String>> inRange
 
     Map langContainerAlias = [:]
+    Map langContainerAliasInverted
 
     /**
      * This includes terms that are declared as either set or list containers
@@ -193,6 +194,8 @@ class JsonLd {
                 }
             }
         }
+
+        langContainerAliasInverted = langContainerAlias.collectEntries { e -> [(e.value): e.key] }
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -17,6 +17,7 @@ import whelk.util.Unicode
 
 import java.util.concurrent.LinkedBlockingQueue
 
+import static whelk.JsonLd.asList
 import static whelk.exception.UnexpectedHttpStatusException.isBadRequest
 import static whelk.exception.UnexpectedHttpStatusException.isNotFound
 import static whelk.util.Jackson.mapper
@@ -317,11 +318,28 @@ class ElasticSearch {
                 REMOVABLE_BASE_URIS,
                 document.getThingInScheme() ? ['tokens', 'chips'] : ['chips'])
 
-        // TODO: replace with elastic ICU Analysis plugin?
-        // https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html
-        DocumentUtil.findKey(framed, JsonLd.SEARCH_KEY) { value, path ->
-            if (!Unicode.isNormalizedForSearch(value)) {
+        DocumentUtil.traverse(framed) { value, path ->
+            if (path && JsonLd.SEARCH_KEY == path.last() && !Unicode.isNormalizedForSearch(value)) {
+                // TODO: replace with elastic ICU Analysis plugin?
+                // https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html
                 return new DocumentUtil.Replace(Unicode.normalizeForSearch(value))
+            }
+            
+            // { "foo": "FOO", "fooByLang": { "en": "EN", "sv": "SV" } }
+            // -->
+            // { "foo": "FOO", "fooByLang": { "en": "EN", "sv": "SV" }, "__foo": ["FOO", "EN", "SV"] }
+            if (value instanceof Map) {
+                var flattened = [:]
+                value.each { k, v ->
+                    if (k in whelk.jsonld.langContainerAlias) {
+                        var __k = flattenedLangMapKey(k)
+                        flattened[__k] = (flattened[__k] ?: []) + asList(v)
+                    } else if (k in whelk.jsonld.langContainerAliasInverted) {
+                        var __k = flattenedLangMapKey(whelk.jsonld.langContainerAliasInverted[k])
+                        flattened[__k] = (flattened[__k] ?: []) + ((Map) v).values().flatten()
+                    }
+                }
+                value.putAll(flattened)
             }
         }
 
@@ -330,6 +348,10 @@ class ElasticSearch {
         }
 
         return JsonOutput.toJson(framed)
+    }
+    
+    static String flattenedLangMapKey(key) {
+        return '__' + key
     }
 
     private static Map toSearchCard(Whelk whelk, Map thing, Set<String> preserveLinks) {
@@ -356,9 +378,8 @@ class ElasticSearch {
     }
 
     private static void filterLanguages(Whelk whelk, Map thing) {
-        Set languageContainers = whelk.jsonld.langContainerAlias.values() as Set
         DocumentUtil.traverse(thing, { value, path ->
-            if (path && path.last() in languageContainers) {
+            if (path && path.last() in whelk.jsonld.langContainerAliasInverted) {
                 Map<String, String> langContainer = value
                 var keep = langContainer.findAll { langTag, str -> langTag in whelk.jsonld.locales }
                 

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -359,7 +359,17 @@ class ElasticSearch {
         Set languageContainers = whelk.jsonld.langContainerAlias.values() as Set
         DocumentUtil.traverse(thing, { value, path ->
             if (path && path.last() in languageContainers) {
-                return new DocumentUtil.Replace(value.findAll {lang, str -> lang in whelk.jsonld.locales})
+                Map<String, String> langContainer = value
+                var keep = langContainer.findAll { langTag, str -> langTag in whelk.jsonld.locales }
+                
+                var transformed = langContainer.findAll { langTag, str -> langTag.contains('-t-') }
+                keep.putAll(transformed)
+                transformed.keySet().each { tLangTag ->
+                    var original = langContainer.findAll { langTag, str -> tLangTag.contains(langTag) }
+                    keep.putAll(original)
+                }
+                
+                return new DocumentUtil.Replace(keep)
             }
         })
     }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -1,17 +1,17 @@
 package whelk.search
 
-import groovy.transform.CompileDynamic
+
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Log4j2 as Log
 import whelk.JsonLd
 import whelk.Whelk
-import whelk.component.ElasticSearch
 import whelk.exception.InvalidQueryException
 import whelk.util.DocumentUtil
 import whelk.util.Unicode
 
+import static whelk.component.ElasticSearch.flattenedLangMapKey
 import static whelk.util.Jackson.mapper
 
 @CompileStatic
@@ -593,7 +593,7 @@ class ESQuery {
         for (int i = 0 ; i < maxLen ; i++) {
             List<Map> musts = nestedQuery.findResults {
                 it.value.length > i 
-                    ? ['match': [(it.key): it.value[i]]]
+                    ? ['match': [(expandLangMapKeys(it.key)): it.value[i]]]
                     : null
             }
             
@@ -662,7 +662,7 @@ class ESQuery {
                     boolean isSimple = isSimple(val)
                     clauses.add([(isSimple ? 'simple_query_string' : 'query_string'): [
                             'query'           : isSimple ? val : escapeNonSimpleQueryString(val),
-                            'fields'          : [field],
+                            'fields'          : [expandLangMapKeys(field)],
                             'default_operator': 'AND'
                     ]])
                 }
@@ -670,6 +670,15 @@ class ESQuery {
         }
 
         return ['bool': ['should': clauses]]
+    }
+    
+    private String expandLangMapKeys(String field) {
+        var parts = field.split('\\.')
+        if (parts && parts[-1] in jsonld.langContainerAlias.keySet()) {
+            parts[-1] = flattenedLangMapKey(parts[-1])
+            return parts.join('.')
+        }
+        return field
     }
 
     private static boolean parseBoolean(String parameterName, String value) {

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -8,6 +8,11 @@ class ESQuerySpec extends Specification {
     void setup() {
         es = new ESQuery()
         es.setKeywords(['bar'] as Set)
+
+        Map context = ["@context": ["langAliasedByLang": ["@id": "langAliased", "@container": "@language"]]]
+        Map display = [:]
+        Map vocab = [:]
+        es.jsonld = new JsonLd(context, display, vocab)
     }
 
     def "should get query string"() {
@@ -96,6 +101,12 @@ class ESQuerySpec extends Specification {
                                             ]]
                                    ]]
 
+        ['langAliased': ['baz']] | [['bool': ['must': [
+                                                ['bool': [
+                                                    'should': [
+                                                        ['simple_query_string' : ['query': 'baz',
+                                                                                  'fields': ['__langAliased'],
+                                                                                  'default_operator': 'AND']]]]]]]]]
     }
 
     def "should create bool filter"(String key, String[] vals, Map result) {


### PR DESCRIPTION
### Make filtering on multi-language properties work 

Make filtering on for example `prefLabel=foo` also match `prefLabelByLang.sv`, `prefLabelByLang.en` etc.

Filtering on `prefLabelByLang.sv` explicitly still works.

Add an extra field to the ES index that contains both the language tagged and plain strings for a property.

For example:
```
{
  "foo": "FOO",
  "fooByLang": { "en": "EN", "sv": "SV" }
}
```
is indexed as
```
{
  "foo": "FOO",
  "fooByLang": { "en": "EN", "sv": "SV" },
  "__foo": ["FOO", "EN", "SV"]
}
```

Queries are adjusted accordingly to filter on this field instead.
Internal fields starting with '_' are already removed from the results.

This makes searching on mainTitle in the cataloging client work for instances with romanized + original script titles.

----

### Keep transformed + original strings in embellishments 
When indexing, for things added by embellish we remove language tagged string that are not in the whelk locale in order to keep
the index size down. With this change we also keep transformed strings and their original counterpart (i.e. for now romanized + original script). For example title of Instance linked from Item.