### PR TITLE
Search: Boost Records more than CacheRecords

### DIFF
--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -9,8 +9,8 @@ import whelk.JsonLd
 import whelk.TargetVocabMapper
 import whelk.Whelk
 import whelk.converter.TrigToJsonLdParser
-import whelk.exception.CancelUpdateException
 import whelk.util.DocumentUtil
+
 import static whelk.JsonLd.asList
 import static whelk.JsonLd.findInData
 import static whelk.util.Jackson.mapper
@@ -128,7 +128,7 @@ class DatasetImporter {
             idsInInput.add(dsRecord.getShortId())
         }
 
-        String recordType = sourceUrl ==~ /^(https?):.+/ ? 'CacheRecord' : 'Record'
+        String recordType = sourceUrl ==~ /^(https?):.+/ ? JsonLd.CACHE_RECORD_TYPE : JsonLd.RECORD_TYPE
 
         long updatedCount = 0
         long createdCount = 0

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -48,6 +48,9 @@ class JsonLd {
     static final String APIX_FAILURE_KEY = "apixExportFailedAt"
     static final String ENCODING_LEVEL_KEY = "marc:encLevel"
 
+    static final String RECORD_TYPE = 'Record'
+    static final String CACHE_RECORD_TYPE = 'CacheRecord'
+    
     static final String SEARCH_KEY = "_str"
 
     static final List<String> NS_SEPARATORS = ['#', '/', ':']

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -540,14 +540,14 @@ class MarcRuleSet {
 
             dfn = processInclude(config, dfn, tag)
 
-            if (dfn.aboutType && dfn.aboutType != 'Record') {
+            if (dfn.aboutType && dfn.aboutType != JsonLd.RECORD_TYPE) {
                 if (dfn.aboutEntity) {
                     assert tag && aboutTypeMap.containsKey(dfn.aboutEntity)
                 }
                 aboutTypeMap[dfn.aboutEntity ?: '?thing'] << dfn.aboutType
             }
             for (matchDfn in dfn['match']) {
-                if (matchDfn.aboutType && matchDfn.aboutType != 'Record') {
+                if (matchDfn.aboutType && matchDfn.aboutType != JsonLd.RECORD_TYPE) {
                     aboutTypeMap[matchDfn.aboutEntity ?: dfn.aboutEntity ?: '?thing'] << matchDfn.aboutType
                 }
             }


### PR DESCRIPTION
Per the suggestion in LXL-3919.
So that for instance sao is ranked higher than external term collections like Queerlit.

It is not possible to specify negative boost values so just boost the base `Record` type instead.

1000 seems like a number that works...