### PR TITLE
Fix dependers handling in DatasetImporter

### DIFF
--- a/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
+++ b/apix_server/src/main/java/whelk/apixserver/ApixCatServlet.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import whelk.Document;
-import whelk.util.LegacyIntegrationTools;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -192,7 +191,7 @@ public class ApixCatServlet extends HttpServlet
                 Utils.send200Response(response, Xml.formatApixErrorResponse("Conversion from MARC failed.", ApixCatServlet.ERROR_CONVERSION_FAILED));
                 return;
             }
-            Utils.s_whelk.createDocument(incomingDocument, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), collection, false, true);
+            Utils.s_whelk.createDocument(incomingDocument, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), collection, false);
             s_logger.info("Successful new on : " + incomingDocument.getShortId());
             Utils.send201Response(response, Utils.APIX_BASEURI + "/0.1/cat/libris/" + collection + "/" + incomingDocument.getShortId());
         } else // save/overwrite existing
@@ -208,11 +207,8 @@ public class ApixCatServlet extends HttpServlet
                 id = Utils.s_whelk.getStorage().getSystemIdByIri("http://libris.kb.se/" + collection + "/" + id);
 
             incomingDocument.deepReplaceId( Document.getBASE_URI().resolve(id).toString() );
-            Utils.s_whelk.storeAtomicUpdate(id, false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
-                    (Document doc) ->
-                    {
-                        doc.data = incomingDocument.data;
-                    });
+            Utils.s_whelk.storeAtomicUpdate(id, false, false, Utils.APIX_SYSTEM_CODE, 
+                    request.getRemoteUser(), (Document doc) -> doc.data = incomingDocument.data);
             s_logger.info("Successful update on : " + incomingDocument.getShortId());
             Utils.send303Response(response, Utils.APIX_BASEURI + "/0.1/cat/libris/" + collection + "/" + incomingDocument.getShortId());
         }
@@ -244,7 +240,7 @@ public class ApixCatServlet extends HttpServlet
             return;
         }
 
-        Utils.s_whelk.createDocument(incomingDocument, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "hold", false, true);
+        Utils.s_whelk.createDocument(incomingDocument, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "hold", false);
         s_logger.info("Successful new (hold on bib) on : " + incomingDocument.getShortId());
         Utils.send201Response(response, Utils.APIX_BASEURI + "/0.1/cat/libris/" + collection + "/" + incomingDocument.getShortId());
     }

--- a/apix_server/src/main/java/whelk/apixserver/Digidaily.java
+++ b/apix_server/src/main/java/whelk/apixserver/Digidaily.java
@@ -236,14 +236,12 @@ public class Digidaily {
                 marcXmlRecordWriter.writeRecord(eRecord);
                 if (newbib) {
                     bibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, false);
-                    Utils.s_whelk.createDocument(bibToBeSaved, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "bib", false, true);
+                    Utils.s_whelk.createDocument(bibToBeSaved, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "bib", false);
                     out.write(bibToBeSaved.getShortId() + "\tDIGI CREATED\n");
                 } else {
                     bibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
-                            (Document doc) -> {
-                                doc.data = bibToBeSaved.data;
-                            });
+                    Utils.s_whelk.storeAtomicUpdate(bibToBeSaved.getShortId(), false, false, 
+                            Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), (Document doc) -> doc.data = bibToBeSaved.data);
                     out.write(bibToBeSaved.getShortId() + "\tDIGI UPDATED\n");
                 }
             }
@@ -275,7 +273,7 @@ public class Digidaily {
                     MarcXmlRecordWriter marcXmlRecordWriter = new MarcXmlRecordWriter(baos);
                     marcXmlRecordWriter.writeRecord(eRecord);
                     Document holdToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "hold", null, false);
-                    Utils.s_whelk.createDocument(holdToBeSaved, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "hold", false, true);
+                    Utils.s_whelk.createDocument(holdToBeSaved, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), "hold", false);
                     out.write(holdToBeSaved.getShortId() + "\tMFHD CREATED\n");
                 }
             }
@@ -304,10 +302,8 @@ public class Digidaily {
                     MarcXmlRecordWriter marcXmlRecordWriter = new MarcXmlRecordWriter(baos);
                     marcXmlRecordWriter.writeRecord(eRecord);
                     Document printBibToBeSaved = Utils.convertToRDF(baos.toString("UTF-8"), "bib", null, true);
-                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, false, true, Utils.APIX_SYSTEM_CODE, request.getRemoteUser(),
-                            (Document doc) -> {
-                                doc.data = printBibToBeSaved.data;
-                            });
+                    Utils.s_whelk.storeAtomicUpdate(printBibToBeSaved.getShortId(), false, false, 
+                            Utils.APIX_SYSTEM_CODE, request.getRemoteUser(), (Document doc) -> doc.data = printBibToBeSaved.data);
                     out.write(printBibToBeSaved.getShortId() + "\tPRINT UPDATED\n");
                 }
             }

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -2,7 +2,6 @@ package whelk.importer;
 
 import groovy.lang.Tuple;
 import io.prometheus.client.Counter;
-import se.kb.libris.Normalizers;
 import se.kb.libris.util.marc.Datafield;
 import se.kb.libris.util.marc.Field;
 import se.kb.libris.util.marc.MarcRecord;
@@ -146,7 +145,7 @@ class XL
                             + existing.getDataAsString());
                 }
                 else {
-                    m_whelk.storeAtomicUpdate(idToMerge, false, false, true, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
+                    m_whelk.storeAtomicUpdate(idToMerge, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), (Document existing) -> {
                         String existingChecksum = existing.getChecksum(m_whelk.getJsonld());
 
                         List<String> recordIDs = existing.getRecordIdentifiers();
@@ -259,7 +258,7 @@ class XL
             {
                 try
                 {
-                    m_whelk.storeAtomicUpdate(replaceSystemId, false, false, true, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
+                    m_whelk.storeAtomicUpdate(replaceSystemId, false, false, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(),
                             (Document doc) ->
                     {
                         String existingEncodingLevel = doc.getEncodingLevel();
@@ -304,7 +303,7 @@ class XL
             else
             {
                 // Doing simple "new"
-                m_whelk.createDocument(rdfDoc, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), collection, false, true);
+                m_whelk.createDocument(rdfDoc, IMPORT_SYSTEM_CODE, m_parameters.getChangedBy(), collection, false);
             }
         }
         else

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -45,6 +45,9 @@ class ImporterMain {
         if (flags['skip-index']) {
             whelk.setSkipIndex(true)
         }
+        if (flags['skip-dependers']) {
+            whelk.setSkipIndexDependers(true)
+        }
         new DatasetImporter(whelk, datasetUri, flags, datasetDescPath).importDataset(sourceUrl)
     }
 
@@ -54,6 +57,9 @@ class ImporterMain {
         Whelk whelk = Whelk.createLoadedSearchWhelk(props)
         if (flags['skip-index']) {
             whelk.setSkipIndex(true)
+        }
+        if (flags['skip-dependers']) {
+            whelk.setSkipIndexDependers(true)
         }
         DatasetImporter.loadDescribedDatasets(whelk, datasetDescPath, sourceBaseDir, onlyDatasets as Set, flags)
     }

--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -694,11 +694,11 @@ class Crud extends HttpServlet {
                             .orElseThrow({ -> new BadRequestException("Missing If-Match header in update") })
                     
                     log.info("If-Match: ${ifMatch}")
-                    whelk.storeAtomicUpdate(doc, false, true, true, "xl", activeSigel, ifMatch.documentCheckSum())
+                    whelk.storeAtomicUpdate(doc, false, true, "xl", activeSigel, ifMatch.documentCheckSum())
                 }
                 else {
                     log.debug("Saving NEW document ("+ doc.getId() +")")
-                    boolean success = whelk.createDocument(doc, "xl", activeSigel, collection, false, true)
+                    boolean success = whelk.createDocument(doc, "xl", activeSigel, collection, false)
                     if (!success) {
                         return null
                     }

--- a/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
@@ -100,14 +100,14 @@ class RefreshAPI extends HttpServlet
 
     void refreshLoudly(Document doc) {
         boolean minorUpdate = false
-        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, true, true, "xl", "Libris admin", {
+        whelk.storeAtomicUpdate(doc.getShortId(), minorUpdate, true, "xl", "Libris admin", {
             Document _doc ->
                 _doc.data = doc.data
         })
     }
 
     void refreshQuietly(Document doc) {
-        whelk.storage.refreshDerivativeTables(doc, true)
+        whelk.storage.refreshDerivativeTables(doc)
         whelk.elastic.index(doc, whelk)
     }
 }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -519,7 +519,7 @@ class WhelkTool {
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
-            whelk.storeAtomicUpdate(doc, !item.loud, true, true, changedIn, scriptJobUri, item.preUpdateChecksum)
+            whelk.storeAtomicUpdate(doc, !item.loud, true, changedIn, scriptJobUri, item.preUpdateChecksum)
         }
         modifiedLog.println(doc.shortId)
     }
@@ -530,8 +530,8 @@ class WhelkTool {
         doc.setGenerationDate(new Date())
         doc.setGenerationProcess(scriptJobUri)
         if (!dryRun) {
-            if (!whelk.createDocument(doc, changedIn, scriptJobUri,
-                    LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld()), false, true))
+            var collection = LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld())
+            if (!whelk.createDocument(doc, changedIn, scriptJobUri, collection, false))
                 throw new WhelkException("Failed to save a new document. See general whelk log for details.")
         }
         createdLog.println(doc.shortId)


### PR DESCRIPTION
Summary
-------
In DatasetImporter
* Make `--skip-dependers` flag only affect indexing
* Handle circular dependencies among deleted docs in dataset

Changes
-------
Remove the option to not update `lddb__dependencies` when loading a
dataset (`--skip-dependers`) since using it puts the database in an
inconsistent state. Updating `lddb_dependencies` is cheap because it is
only the _outgoing_ links for a modified doc that are updated.

`--skip-dependers` now only affects reindexing. Reindexing dependers
might be expensive when reloading core datasets. The flag can be
removed if we improve the logic for calculating which documents
need to be reindex for an update.

Handle circular dependencies among deleted docs in dataset. If no other
docs depend on the they can be deleted safely.