### PR TITLE
Add linking of serial editions to newspaper job

### DIFF
--- a/whelktool/scripts/cleanups/2022/02/lxl-3785-supplementTo-isIssueOf.groovy
+++ b/whelktool/scripts/cleanups/2022/02/lxl-3785-supplementTo-isIssueOf.groovy
@@ -115,18 +115,18 @@ selectBySqlWhere(where) { bib ->
         return
     }
 
-    if (!isMimerRecord(thing.'@id')) {
-        notMimer.println(thing.'@id')
-        return
-    }
-    
     if(marcGf(thing).with { it && it.any {l -> l != 'issue'}}) {
         otherMarcGf.println("${thing.'@id'}\t${marcGf(thing)}")
         return
     }
-    
+
+    if (!isMimerRecord(thing.'@id')) {
+        notMimer.println(thing.'@id')
+        return
+    }
+
     def isIssueOf = asList(thing.isIssueOf) as Set
-    
+
     def i = ((List) thing.supplementTo).iterator()
     while (i.hasNext()) {
         Map supplementTo = (Map) i.next()

--- a/whelktool/scripts/cleanups/2022/02/lxl-3785-supplementTo-isIssueOf.groovy
+++ b/whelktool/scripts/cleanups/2022/02/lxl-3785-supplementTo-isIssueOf.groovy
@@ -1,60 +1,64 @@
-/* 
-In order to only check new records specify file where timestamp of last run is saved with:
+/***************************************************************************************
+
+SYSTEM PARAMETERS:
+
 -Dlast-run-file=</path/to/file>
+    If given, a timestamp of this run is saved in this file, and used to only
+    select new records on the next run.
 
-(Schedule this script to run continuously until Mimer MODS conversion is fixed)
+****************************************************************************************
 
-***********************************************************************************************************************
+PURPOSE: Clean up newspaper (dagstidningar + tidskrifter) shapes.
 
-Clean up newspaper (dagstidningar + tidskrifter) shapes.
-Link digitized newspaper monographs (issues) to their series. That is, replace supplementTo and/or isPartOf with isIssueOf.
+(Schedule this script to run continuously until Mimer MODS conversion is fixed.)
+
+ACTIONS:
+
+This performs one or both of these changes (depending on what is applicable per record):
+
+1. Link digitized newspaper monographs (issues) to their series. That is,
+   replace :supplementTo and/or :isPartOf with :isIssueOf.
+
+2. Change opaque signe codes in :editionStatement to links newspaper editions
+   using :isIssueOfEdition.
 
 Don't touch "Projects" and "Channel records" in supplementTo for now.
 
-Example
-Before
-...
-bf2:title [
-    a bf2:Title ;
-    bf2:mainTitle "DAGENS NYHETER  1900-05-28"
-    ] ;
-...
-bf2:supplementTo [
-    a bf2:Instance ;
-    bf2:instanceOf [
-      a bf2:Work ;
-      bf2:contribution [
-        a bflc:PrimaryContribution ;
-        bf2:agent [
-          a bf2:Agent ;
-          sdo:name "DAGENS NYHETER"
-          ]
-        ]
-      ] ;
-    :describedBy [
-      a :Record ;
-      :controlNumber "13991099"
-      ] ;
-    bf2:identifiedBy [
-      a bf2:Issn ;
-      rdf:value "1101-2447"
-      ] , [
-      a bf2:Strn ;
-      rdf:value "http://libris.kb.se/resource/bib/13991099"
-      ]
-    ] ;
-...
+****************************************************************************************
 
-After
-...
-bf2:title [
-    a bf2:Title ;
-    bf2:mainTitle "DAGENS NYHETER  1900-05-28"
-    ] ;
-...
-kbv:isIssueOf <https://libris.kb.se/m5z2w4lz3m2zxpk#it> ;
-...
+EXAMPLE
 
+BEFORE:
+
+    ?issue
+        ...
+        :hasTitle [ a :Title ; :mainTitle "DAGENS NYHETER  1900-05-28" ] ;
+        ...
+        :supplementTo [ a :Instance ;
+                :instanceOf [ a :Work ;
+                        :contribution [ a :PrimaryContribution ;
+                                :agent [ a :Agent ; :name "DAGENS NYHETER" ]
+                            ]
+                    ] ;
+                :describedBy [ a :Record ; :controlNumber "13991099" ] ;
+                :identifiedBy [ a :Issn ; :value "1101-2447" ] ,
+                    [ a :Strn ; :value "http://libris.kb.se/resource/bib/13991099" ]
+            ] ;
+        ...
+        :editionStatement "0"
+
+AFTER:
+
+    ?issue
+        ...
+        :hasTitle [ a :Title ; :mainTitle "DAGENS NYHETER  1900-05-28" ] ;
+        ...
+        :isIssueOf <https://libris.kb.se/m5z2w4lz3m2zxpk#it> ;
+        ...
+        :isIssueOfEdition <https://libris.kb.se/dataset/signe/edition/0> ;
+        ...
+
+****************************************************************************************
 
 Shapes encountered in dry-run
 
@@ -78,9 +82,9 @@ Examples
 [@type, hasTitle, describedBy, identifiedBy]
 {@type=Instance, hasTitle=[{@type=Title, mainTitle=SVENSKA DAGBLADET}], describedBy=[{@type=Record, controlNumber=13434192}], identifiedBy=[{@type=ISSN, value=2001-3868}]} [0jbj4c5b264549m, 3mfm5p5f1xm7xsv, q828thb23j7cmqr]
 
+There were no supplementTo with multiple controlnumbers (refering to newspaper serials).
 
-There were no supplementTo with multiple controlnumbers (refering to newspaper serials)
-*/
+***************************************************************************************/
 
 import groovy.transform.Memoized
 


### PR DESCRIPTION
This adds to the exiting newspaper job currently running continuously to amend newspaper data imported from Mimer.

The `editionStatement` of a newspaper issue is a code for a serial edition described in the local Signe system (which has the intended serial edition statement as its label).

The addition here adds an `isIssueOfEdition` link constructed from this code, if such as edition exists in the system. It then removes the editionStatement.

Statistics from QA run (full run with no `lastRunTimestamp`): took 4.6 h and modified 1,885,390 records. 

(Data from the Signe system is to be imported into Libris as a dataset.)