### PR TITLE
Add support for search-chips

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -171,8 +171,13 @@ class Embellisher {
         // at jdk.proxy1.$Proxy37.apply(Unknown Source) ~[?:?]
         // at java_util_function_Function$apply.call(Unknown Source) ~[?:?]
         // at whelk.Embellisher.load(Embellisher.groovy:149) ~[main/:?]
-        
-        if (lens == 'chips') {
+
+        if (lens == 'search-chips') {
+            // NB! This depends on search-chips being subsets of cards. Since we shrink the cards to search-chips. 
+            var searchChips = true
+            data = data.collect{ (Map) jsonld.toChip(it, [], searchChips) }
+        }
+        else if (lens == 'chips') {
             data = data.collect{ (Map) jsonld.toChip(it) }
         }
 

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -759,7 +759,7 @@ class JsonLd {
         // If result is too small, use chip instead.
         // TODO: Support and use extends + super in card defs instead.)
         if (card.size() < 2) {
-            card = removeProperties(thing, getLens(thing, ['chips']))
+            card = removeProperties(thing, getLens(thing, searchCard ? ['search-chips', 'chips'] : ['chips']))
         }
 
         restorePreserved(card, thing, preservePaths)
@@ -815,17 +815,17 @@ class JsonLd {
         return result
     }
 
-    Object toChip(Object object, List<List> preservePaths = []) {
+    Object toChip(Object object, List<List> preservePaths = [], boolean searchChip = false) {
         if (object instanceof List) {
             return object.withIndex().collect { it, ix ->
-                toChip(it, pathRemainders([ix], preservePaths))
+                toChip(it, pathRemainders([ix], preservePaths), searchChip)
             }
         } else if ((object instanceof Map)) {
             Map result = [:]
-            Map reduced = removeProperties(object, getLens(object, ['chips']))
+            Map reduced = removeProperties(object, getLens(object, searchChip ? ['search-chips', 'chips'] : ['chips']))
             restorePreserved(reduced, (Map) object, preservePaths)
             reduced.each { key, value ->
-                result[key] = toChip(value, pathRemainders([key], preservePaths))
+                result[key] = toChip(value, pathRemainders([key], preservePaths), searchChip)
             }
             return result
         } else {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -309,8 +309,8 @@ class ElasticSearch {
 
     String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
-
-        whelk.embellish(copy, ['chips'])
+        
+        whelk.embellish(copy, ['search-chips'])
 
         if (log.isDebugEnabled()) {
             log.debug("Framing ${document.getShortId()}")
@@ -394,7 +394,7 @@ class ElasticSearch {
 
     private static void recordToChip(Whelk whelk, Map thing) {
         if (thing[JsonLd.GRAPH_KEY]) {
-            thing[JsonLd.GRAPH_KEY][0] = whelk.jsonld.toChip(thing[JsonLd.GRAPH_KEY][0])
+            thing[JsonLd.GRAPH_KEY][0] = whelk.jsonld.toChip(thing[JsonLd.GRAPH_KEY][0], [], true)
         }
     }
 


### PR DESCRIPTION
Search-chips work in the same way as search-cards. They are indexed but not displayed. Embellish documents for indexing with search-chips instead of regular chips. Note that a search-chip has to be a subset of the card for the same type. Because they are made by shrinking cards.