### PR TITLE
Strip trailing line breaks in strings on doc save

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -41,7 +41,7 @@ class Unicode {
     
     // U+2060 WORD JOINER
     private static final Pattern LEADING_SPACE = Pattern.compile('^[\\p{Blank}\u2060]+', Pattern.UNICODE_CHARACTER_CLASS)
-    private static final Pattern TRAILING_SPACE = Pattern.compile('[\\p{Blank}\u2060]+$', Pattern.UNICODE_CHARACTER_CLASS)
+    private static final Pattern TRAILING_SPACE = Pattern.compile('([\\p{Blank}\u2060]|\\R)+$', Pattern.UNICODE_CHARACTER_CLASS)
     
     private static final Map EXTRA_NORMALIZATION_MAP
     

--- a/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
@@ -52,6 +52,11 @@ class UnicodeSpec extends Specification {
         '\u2007\u2007\u2007FIGURE SPACE\u2007\u2007\u2007'          | 'FIGURE SPACE'
         '\u2060\u2060\u2060WORD JOINER\u2060\u2060\u2060'           | 'WORD JOINER'
         'keep\u00A0\u202F\u2007\u2060us'                            | 'keep\u00A0\u202F\u2007\u2060us'
+        'LINE FEED\n\n\n'                                           | 'LINE FEED'
+        'CARRIAGE RETURN\r\r\r'                                     | 'CARRIAGE RETURN'
+        'line breaks\u000A\u000B\u000C\u000D\u0085\u2028\u2029'     | 'line breaks'
+        '\r\nkeep leading line breaks'                              | '\r\nkeep leading line breaks'
+        
     }
     
     def "double quotation marks"() {


### PR DESCRIPTION
Reported as a real world problem: trailing newline in uri property is treated as a part of the uri in presentation.