### PR TITLE
Add script for linking CC licenses given in `uri`

### DIFF
--- a/whelktool/scripts/cleanups/2023/03/link-cc-licenses.groovy
+++ b/whelktool/scripts/cleanups/2023/03/link-cc-licenses.groovy
@@ -1,0 +1,40 @@
+/*
+select distinct ?uri (count(?g) as ?count) (sample(?g) as ?sample) {
+    graph ?g {?s kbv:uri ?uri . filter(REGEX(?uri, "https?://creativecommons.org/")) }
+} order by desc(?count)
+*/
+import groovy.transform.Memoized
+
+import whelk.Document
+import whelk.util.DocumentUtil
+
+URI_KEY = 'uri'
+
+selectBySqlWhere("collection = 'bib' and data::text LIKE '%://creativecommons.org/%'") { bib ->
+    var data = bib.doc.data
+    DocumentUtil.traverse(data, { value, path ->
+        if (!path || path[-1] != URI_KEY) {
+            return
+        }
+        def uri = value instanceof List && value.size() > 0 ? value[0] : value
+        if (uri instanceof String && uri.indexOf('://creativecommons.org/') > -1) {
+            var licenseId = getLicenseId(uri)
+            if (licenseId) {
+                def owner = DocumentUtil.getAtPath(data, path[0..-2])
+                assert owner instanceof Map && owner[URI_KEY].is(value)
+                owner.clear()
+                owner[ID] = licenseId
+                bib.scheduleSave()
+            }
+        }
+    })
+}
+
+@Memoized
+String getLicenseId(String id) {
+    id = id.replace(/\/licenses\/([123]\.[0-9])(\/.*)?/, '/licenses/4.0/')
+    if (!id.endsWith('/')) {
+        id += '/'
+    }
+    return findCanonicalId(id)
+}

--- a/whelktool/scripts/cleanups/2023/03/link-cc-licenses.groovy
+++ b/whelktool/scripts/cleanups/2023/03/link-cc-licenses.groovy
@@ -12,10 +12,7 @@ URI_KEY = 'uri'
 
 selectBySqlWhere("collection = 'bib' and data::text LIKE '%://creativecommons.org/%'") { bib ->
     var data = bib.doc.data
-    DocumentUtil.traverse(data, { value, path ->
-        if (!path || path[-1] != URI_KEY) {
-            return
-        }
+    DocumentUtil.findKey(data, URI_KEY, { value, path ->
         def uri = value instanceof List && value.size() > 0 ? value[0] : value
         if (uri instanceof String && uri.indexOf('://creativecommons.org/') > -1) {
             var licenseId = getLicenseId(uri)


### PR DESCRIPTION
This should be combined with informing the sources of that data that they can now properly link up these licenses using `@id` only.

We may want to check incoming uri values in general, either in the cataloguing interface and/or on save by extending the LinkFinder-based normalization step with such logic.