### PR TITLE
Add and-matches- prefix to /find in REST API

### DIFF
--- a/rest/API.md
+++ b/rest/API.md
@@ -232,7 +232,8 @@ It is possible to combine multiple fields with `OR` by using the prefix `or-`.
 * `minEx-<field>` - Greater than (exclusive minimum).
 * `max-<field>` - Less or equal to.
 * `maxEx-<field>` - Less than.
-* `matches-<field>` - Value is matching (see date-search below).
+* `matches-<field>` - Value is matching (see date-search and "include narrower terms" search below).
+* `and-matches-<field>` - Combine multiple `matches-` filters for the _same_ field with `AND` instead of `OR`.
 
 Filter-expression                                     | Filter-parameters
 ------------------------------------------------------|----------------------------------------------
@@ -366,6 +367,26 @@ $ curl -XGET -H "Accept: application/ld+json" -G \
 ...
 ```
 
+#### Example
+
+Has subject term/sao/Monster (or a narrower term, e.g., Drakar, Gorgoner).
+```
+$ curl -XGET -H "Accept: application/ld+json" \
+    'https://libris-qa.kb.se/find.jsonld?matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Monster'
+...
+```
+
+#### Example
+
+Has subject term/sao/Monster (or a narrower term, e.g., Drakar, Gorgoner), _and_ term/sao/Magi (or a narrower term,
+e.g., Amuletter, Häxeri).
+```
+$ curl -XGET -H "Accept: application/ld+json" -G \
+    'https://libris-qa.kb.se/find.jsonld' \
+    -d and-matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Monster \
+    -d and-matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Magi
+...
+```
 
 ### `/_remotesearch` - Search external databases - Requires authentication
 

--- a/rest/API_sv.md
+++ b/rest/API_sv.md
@@ -219,7 +219,8 @@ Det går att kombinera olika egenskaper med `ELLER` genom att använda prefixet 
 * `minEx-<egenskap>` - Värdet är större än (Ex står för "Exclusive").
 * `max-<egenskap>` - Värdet är mindre eller lika med.
 * `maxEx-<egenskap>` - Värdet är mindre än.
-* `matches-<egenskap>` - Värdet matchar (se datum-sökning nedan).
+* `matches-<egenskap>` - Värdet matchar (se datumsökning och "inkludera underordnade termer"-sökning nedan).
+* `and-matches-<field>` - Kombinera flera `matches`-filter för _samma_ fält med `OCH` istället för `ELLER`.
 
  Filter-uttryck                                        | Filter-parametrar    
 -------------------------------------------------------|-----------------------                 
@@ -352,6 +353,26 @@ $ curl -XGET -H "Accept: application/ld+json" -G \
 ...
 ```
 
+#### Exempel
+
+Har ämne term/sao/Monster (eller en underordnad term, t.ex. Drakar, Gorgoner).
+```
+$ curl -XGET -H "Accept: application/ld+json" \
+    'https://libris-qa.kb.se/find.jsonld?matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Monster'
+...
+```
+
+#### Exempel
+
+Har ämne term/sao/Monster (eller en underordnad term, t.ex. Drakar, Gorgoner), _och_ term/sao/Magi (eller en underordnad term,
+t.ex. Amuletter, Häxeri).
+```
+$ curl -XGET -H "Accept: application/ld+json" -G \
+    'https://libris-qa.kb.se/find.jsonld' \
+    -d and-matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Monster \
+    -d and-matches-instanceOf.subject.@id=https://id.kb.se/term/sao/Magi
+...
+```
 
 ### `/_remotesearch` - Sök i externa databaser  - Kräver autentisering
 

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -807,7 +807,7 @@ class ESQuery {
     /**
      * Construct "range query" filters for parameters prefixed with any {@link RangeParameterPrefix}
      * Ranges for different parameters are ANDed together
-     * Multiple ranges for the same parameter are ORed together
+     * Multiple ranges for the same parameter are ORed together, unless prefixed with `and-`
      *
      * Range endpoints are matched in the order they appear
      * e.g. minEx-x=1984&maxEx-x=1988&minEx-x=1993&min-x=2000&maxEx-x=1995


### PR DESCRIPTION
Continuation of #1197.

Might be a nicer way to do this, I just can't think of any at the moment.

Also added an example of a use of `matches-` that was previously undocumented (intentionally? :thinking:).