### PR TITLE
Treat `@id` as `uri` if configured in marcframe

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2598,6 +2598,7 @@ class MarcSubFieldHandler extends ConversionPart {
     boolean repeatProperty
     boolean overwrite
     boolean infer
+    boolean equivalentToId
     String resourceType
     String subUriTemplate
     Pattern matchUriToken = null
@@ -2686,6 +2687,7 @@ class MarcSubFieldHandler extends ConversionPart {
         overwrite = subDfn.overwrite == true
 
         infer = subDfn.infer == true
+        equivalentToId = subDfn.equivalentToId == true
 
         if (subDfn.splitValueProperties) {
             /*TODO: assert subDfn.splitValuePattern=~ /^\^.+\$$/,
@@ -2918,6 +2920,10 @@ class MarcSubFieldHandler extends ConversionPart {
                     if (propertyValue)
                         break
                 }
+            }
+
+            if (propertyValue == null && equivalentToId) {
+                propertyValue = entity['@id']
             }
 
             boolean checkResourceType = true

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -11596,7 +11596,7 @@
       "$f": {"addProperty": "marc:standardizedTerminologyForAccessRestriction"},
       "$g": {"addProperty": "marc:availabilityDate"},
       "$q": {"property": "marc:supplyingAgency"},
-      "$u": {"addProperty": "uri"},
+      "$u": {"addProperty": "uri", "equivalentToId": true},
       "$2": null,
       "NOTE:$2": {"NOTE:LC": "nac"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
@@ -11622,7 +11622,10 @@
           },
           "normalized": {
             "506": {"ind1": " ", "ind2": " ",
-              "subfields": [{"a": "Fritt tillgänglig"}]
+              "subfields": [
+                {"a": "Fritt tillgänglig"},
+                {"u": "https://id.kb.se/policy/freely-available"}
+              ]
             }
           }
         }
@@ -12242,7 +12245,7 @@
       "$f": {"addProperty": "marc:useAndReproductionRights"},
       "$g": {"addProperty": "marc:availabilityDate"},
       "$q": {"property": "marc:supplyingAgency"},
-      "$u": {"addProperty": "uri"},
+      "$u": {"addProperty": "uri", "equivalentToId": true},
       "NOTE:$2": {"link": "source", "resourceType": "Source", "property": "label"},
       "$3": {"link": "appliesTo", "resourceType": "Resource", "property": "label"},
       "$5": {"link": "applicableInstitution", "resourceType": "Agent", "property": "code"},
@@ -12304,7 +12307,10 @@
           },
           "normalized": {
             "540": {"ind1": " ", "ind2": " ",
-              "subfields": [{"a": "CC0 1.0 universell"}]
+              "subfields": [
+                {"a": "CC0 1.0 universell"},
+                {"u": "http://creativecommons.org/publicdomain/zero/1.0/"}
+              ]
             }
           }
         }


### PR DESCRIPTION
This is only used for revert, to generate a subfield (specified for `$u` of bib 540 and 506).

With this in place we're in a reasonably good place to run https://github.com/libris/librisxl/pull/1221. That should be combined with informing the sources of that data that they can properly link up these licenses using `@id` only.

We _may_ want to check incoming `uri` values in general, either in the cataloguing interface and/or on save by extending the `LinkFinder`-based normalization step with such logic. That goes beyond the scope of this PR.