### PR TITLE
Search: Fix sorting on lang taggable property, e.g. hasTitle.mainTitle

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -478,6 +478,7 @@ class ESQuery {
     }
 
     private String getInferredTermPath(String termPath) {
+        termPath = expandLangMapKeys(termPath)
         if (termPath in keywordFields) {
             return "${termPath}.keyword"
         } else {


### PR DESCRIPTION
which are now indexed as e.g. `hasTitle.__mainTitle`