### PR TITLE
Attempt to run whelk-dependent integration tests

### DIFF
--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -132,6 +132,9 @@ task integTest(type: Test) {
     outputs.upToDateWhen { false }
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
+    systemProperties(
+        'xl.secret.properties': System.getProperty("xl.secret.properties")
+    )
     testLogging {
         showStandardStreams = true
         exceptionFormat = "full"

--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -7,9 +7,17 @@ import spock.lang.*
 @Unroll
 class MarcFrameConverterSpec extends Specification {
 
-    static converter = new MarcFrameConverter() {
-        def config
+    static Whelk whelk = null
+    static {
+        try {
+            whelk = Whelk.createLoadedSearchWhelk()
+        } catch (Exception e) {
+            System.err.println("Unable to instantiate whelk: $e")
+        }
+    }
 
+    static converter = new MarcFrameConverter(null, whelk?.jsonld, whelk?.languageResources) {
+        def config
         void initialize(Map config) {
             super.initialize(config)
             this.config = config
@@ -44,6 +52,9 @@ class MarcFrameConverterSpec extends Specification {
 
                 if (tag == 'postProcessing') {
                     ruleSet.postProcSteps.eachWithIndex { step, i ->
+                        if (step.requiresResources && !whelk) {
+                            return
+                        }
                         dfn[i]._spec.each {
                             postProcStepSpecs << [step: step, spec: it, thingLink: thingLink]
                         }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
@@ -7,8 +7,9 @@ import org.codehaus.jackson.map.ObjectMapper
 import whelk.JsonLd
 
 interface MarcFramePostProcStep {
-    def ID = JsonLd.ID_KEY
-    def TYPE = JsonLd.TYPE_KEY
+    var ID = JsonLd.ID_KEY
+    var TYPE = JsonLd.TYPE_KEY
+    boolean getRequiresResources()
     void setLd(JsonLd ld)
     void setMapper(ObjectMapper mapper)
     void init()
@@ -23,6 +24,7 @@ abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
     Pattern matchValuePattern
     JsonLd ld
     ObjectMapper mapper
+    boolean requiresResources = false
 
     void setMatchValuePattern(String pattern) {
         matchValuePattern = Pattern.compile(pattern)
@@ -213,6 +215,7 @@ class MappedPropertyStep implements MarcFramePostProcStep {
     String type
     JsonLd ld
     ObjectMapper mapper
+    boolean requiresResources = false
 
     String sourceEntity
     String sourceLink

--- a/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
@@ -17,6 +17,7 @@ class NormalizeWorkTitlesStep extends MarcFramePostProcStepBase {
 
     private static final List<String> titleProps = [HAS_TITLE, 'musicKey', 'musicMedium', 'version', LEGAL_DATE, 'originDate', 'marc:arrangedStatementForMusic']
 
+    boolean requiresResources = true
     LanguageLinker langLinker
 
     void modify(Map record, Map thing) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -22,6 +22,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         Map scripts
     }
 
+    boolean requiresResources = true
     MarcFrameConverter converter
     LanguageResources languageResources
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
@@ -1,6 +1,6 @@
 {
   "type": "NormalizeWorkTitles",
-  "_TODO:requires-whelk:_spec": [
+  "_spec": [
     {
       "name": "move translationOf title for bib 240",
       "result": {

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
@@ -1,6 +1,6 @@
 {
   "type": "Romanization",
-  "_TODO:requires-whelk-with-i18n-dataset:_spec": [
+  "_spec": [
     {
       "name": "revert-245",
       "result": {


### PR DESCRIPTION
Some MarcFramePostProcStep:s are resource-dependent and need a backing whelk to load those. This change adds a flag on those steps, which is used to let MarcFrameConverterSpec conditionally run the specs for these if it is able to instantiate a whelk upon startup (commonly when integTest is run).

(This is conditional to make it possible to run the non-resource-dependent steps locally without having a whelk up.)

Remaining:
* [ ] Make failing Romanization specs pass

To consider:
* [ ] Can we untangle the dependency on `RomanizationStep.LanguageResources` from `MarcframeConverter`  (general > specific)  by abstracting something? (Like a "resource provider" from the whole `Whelk` API... :thinking: )

When merged:
* [ ] Add `local(f"../gradlew -Dxl.secret.properties={secrets.create_whelk_secret_properties()} integTest")`  to `app.whelk.run_core_integration_tests` in devops repo.