### PR TITLE
Copy path to avoid mutation

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
@@ -83,7 +83,7 @@ class JsonLdValidator {
             if (!passedPreValidation(key, value, path, validation)) {
                 return
             }
-            validation.at = path
+            validation.at = path.collect()
 
             if (checkLangContainer(path, key, value, validation)) {
                 return 


### PR DESCRIPTION
Fixes empty path in error message, e.g.:
```
{
	"message": "Invalid JSON-LD",
	"status_code": 400,
	"status": "Bad Request",
	"errors": [
		{
			"type": "OBJECT_TYPE_EXPECTED",
			"description": "Expected value type of key to be object",
			"path": [],
			"key": "source",
			"value": "expressionOf"
		}
	]
}
```