### PR TITLE
MARC 880 conversion without LanguageResources

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/MarcCliExport.java
@@ -70,7 +70,7 @@ public class MarcCliExport
         if (args[0].equals("--sao"))
         {
             MarcRecordWriter output = new MarcXmlRecordWriter(System.out, "UTF-8");
-            new MarcCliExport(Whelk.createLoadedSearchWhelk()).dumpSao(output);
+            new MarcCliExport(Whelk.createLoadedCoreWhelk()).dumpSao(output);
             output.close();
             return;
         }
@@ -78,7 +78,7 @@ public class MarcCliExport
         if (args[0].equals("--auth"))
         {
             MarcRecordWriter output = new Iso2709MarcRecordWriter(System.out, "UTF-8");
-            new MarcCliExport(Whelk.createLoadedSearchWhelk()).dumpAuth(output);
+            new MarcCliExport(Whelk.createLoadedCoreWhelk()).dumpAuth(output);
             output.close();
             return;
         }
@@ -97,7 +97,7 @@ public class MarcCliExport
         if (args.length == 2)
         {
             Path idFilePath = new File(args[1]).toPath();
-            new MarcCliExport(Whelk.createLoadedSearchWhelk()).dumpSpecific(profile, idFilePath, output);
+            new MarcCliExport(Whelk.createLoadedCoreWhelk()).dumpSpecific(profile, idFilePath, output);
         } else if (args.length == 1)
         {
             // If the "profile" contains start/stop times, we should generate an interval-export instead
@@ -109,13 +109,13 @@ public class MarcCliExport
                 start = start +"T00:00:00Z";
                 stop = stop +"T23:59:59Z";
                 var parameters = new ProfileExport.Parameters(profile, start, stop, ProfileExport.DELETE_MODE.IGNORE, false);
-                Whelk whelk = Whelk.createLoadedSearchWhelk();
+                Whelk whelk = Whelk.createLoadedCoreWhelk();
                 ProfileExport pf = new ProfileExport(whelk, whelk.getStorage().createAdditionalConnectionPool("ProfileExport"));
                 pf.exportInto(output, parameters);
                 pf.shutdown();
             }
             else
-                new MarcCliExport(Whelk.createLoadedSearchWhelk()).dump(profile, output);
+                new MarcCliExport(Whelk.createLoadedCoreWhelk()).dump(profile, output);
         }
         output.close();
     }

--- a/marc_export/src/main/java/whelk/export/marc/MarcHttpExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/MarcHttpExport.java
@@ -56,7 +56,7 @@ public class MarcHttpExport extends HttpServlet
 
     public void init()
     {
-        whelk = Whelk.createLoadedSearchWhelk();
+        whelk = Whelk.createLoadedCoreWhelk();
         profileExport = new ProfileExport(whelk, whelk.getStorage().createAdditionalConnectionPool("ProfileExport"));
     }
 

--- a/oaipmh/src/main/java/whelk/export/servlet/OaiPmh.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/OaiPmh.java
@@ -81,7 +81,7 @@ public class OaiPmh extends HttpServlet
 
     static
     {
-        s_whelk = Whelk.createLoadedSearchWhelk();
+        s_whelk = Whelk.createLoadedCoreWhelk();
         supportedFormats = new HashMap<String, FormatDescription>();
         supportedFormats.put("oai_dc", new FormatDescription(new JsonLD2DublinCoreConverter(), true, "http://www.openarchives.org/OAI/2.0/oai_dc.xsd", "http://www.openarchives.org/OAI/2.0"));
         supportedFormats.put("marcxml", new FormatDescription(new JsonLD2MarcXMLConverter(s_whelk.getMarcFrameConverter()), true, "http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd", "http://www.loc.gov/MARC21/slim"));

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -239,8 +239,7 @@ class Whelk {
         languageResources = new RomanizationStep.LanguageResources(
                 languageLinker: languageLinker,
                 languages: idsToThings('Language'),
-                transformedLanguageForms: idsToThings('TransformedLanguageForm'),
-                scripts: idsToThings('Script')
+                transformedLanguageForms: idsToThings('TransformedLanguageForm')
         )
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -210,7 +210,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
 
             def subFields = field[SUBFIELDS].collect {
                 def subfield = it.keySet()[0]
-                [(BIB880 + '-' + subfield): stripPrefix(it[subfield], OG_MARK)]
+                [(BIB880 + '-' + subfield): stripMark(it[subfield], OG_MARK)]
             }
 
             def hasBib880 = thing.computeIfAbsent(HAS_BIB880, s -> [])
@@ -248,8 +248,11 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         MARC_SCRIPT_CODES.findResult{ tLang.contains(it.key) ? it.value : null } ?: ''
     }
 
-    private static String stripPrefix(String s, String prefix) {
-        s.startsWith(prefix) ? s.substring(prefix.length()) : s
+    private static String stripMark(String s, String mark) {
+        // Multiple properties can become one MARC subfield. So marks can also occur inside strings.
+        s.startsWith(mark)
+            ? s.replace(mark, '')
+            : s
     }
 
     @MapConstructor

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -357,7 +357,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
     def putOriginalLiteralInNonByLang(Map thing, List byLangPath, String tLang) {
         putLiteralInNonByLang(thing, byLangPath) { Map parent, String key, String base ->
             def romanized = parent[key].find { langTag, literal -> langTag == tLang }
-            def original = parent[key].find { langTag, literal -> tLang.contains("${MATCH_T_TAG}${langTag}-") }?.value
+            def original = parent[key].find { langTag, literal -> tLang.contains("${MATCH_T_TAG}${langTag}") }?.value
             if (romanized && original) {
                 parent[base] = original instanceof List
                         ? original.collect { OG_MARK + it }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -21,21 +21,16 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         LanguageLinker languageLinker
         Map languages
         Map transformedLanguageForms
-        Map scripts
     }
 
     MarcFrameConverter converter
     LanguageResources languageResources
 
+    Map langAliases
     Map byLangToBase
     
-    Map tLangCodes
     Map langIdToLangTag
-    Map langAliases
-    Map langToTLang
-
     
-
     // Note: MARC standard allows ISO 15924 in $6 but Libris practice doesn't
     private static final Map MARC_SCRIPT_CODES =
             [
@@ -291,7 +286,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
     }
 
     boolean addAltLang(Map thing, Map converted, String lang) {
-        if (!langIdToLangTag[lang] || !langToTLang[lang]) {
+        if (!langIdToLangTag[lang]) {
             return false
         }
         def nonByLangPaths = []
@@ -414,28 +409,10 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         if (!languageResources) {
             return
         }
-
-        this.tLangCodes = getTLangCodes(languageResources.transformedLanguageForms)
-        this.langToTLang = tLangCodes.collectEntries { k, v -> [v.inLanguage, k] }
+        
         this.langAliases = ld.langContainerAlias
         this.byLangToBase = langAliases.collectEntries { k, v -> [v, k] }
         this.langIdToLangTag = languageResources.languages
                 .findAll { k, v -> v.langTag }.collectEntries { k, v -> [k, v.langTag] }
-    }
-
-    static Map<String, Map> getTLangCodes(Map<String, Map> transformedLanguageForms) {
-        def t = transformedLanguageForms
-                .values()
-                .findAll { ((String) it.langTag)?.contains(MATCH_T_TAG) }
-                .collectEntries {
-                    def data = [:]
-                    if (it.inLanguage) {
-                        data.inLanguage = it.inLanguage[ID]
-                    }
-                    if (it.fromLangScript) {
-                        data.fromLangScript = it.fromLangScript[ID]
-                    }
-                    [it.langTag, data]
-                }
     }
 }


### PR DESCRIPTION
* Remove dependency on `LanguageResources` from KBV to MARC 880 conversion.
* Pick one romanization scheme deterministically if multiple (alphabetically on langTag, same as lxlviewer)
* Can still be refactored a bit