### PR TITLE
Feature/fix linkage in 880 revert

### DIFF
--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -8,22 +8,23 @@ import spock.lang.*
 class MarcFrameConverterSpec extends Specification {
 
     static Whelk whelk = null
+    static MarcFrameConverter converter = null
+
     static {
         try {
             whelk = Whelk.createLoadedSearchWhelk()
         } catch (Exception e) {
             System.err.println("Unable to instantiate whelk: $e")
         }
-    }
-
-    static converter = new MarcFrameConverter(null, whelk?.jsonld, whelk?.languageResources) {
-        def config
-        void initialize(Map config) {
-            super.initialize(config)
-            this.config = config
-            super.conversion.doPostProcessing = false
-            super.conversion.flatLinkedForm = false
-            super.conversion.baseUri = new URI("/")
+        converter = new MarcFrameConverter(null, whelk?.jsonld, whelk?.languageResources) {
+            def config
+            void initialize(Map config) {
+                super.initialize(config)
+                this.config = config
+                super.conversion.doPostProcessing = false
+                super.conversion.flatLinkedForm = false
+                super.conversion.baseUri = new URI("/")
+            }
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -430,13 +430,16 @@ class MarcConversion {
         def marcRuleSet = getRuleSetFromJsonLd(data)
 
         if (doPostProcessing) {
+            // Temporarily turn off to prevent recursive calls from postprocessing steps
+            doPostProcessing = false
             applyInverses(data, data[marcRuleSet.thingLink])
-            sharedPostProcSteps.each {
+            marcRuleSet.postProcSteps.reverseEach {
                 it.unmodify(data, data[marcRuleSet.thingLink])
             }
-            marcRuleSet.postProcSteps.each {
+            sharedPostProcSteps.reverseEach {
                 it.unmodify(data, data[marcRuleSet.thingLink])
             }
+            doPostProcessing = true
         }
 
         Map state = [:]

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -166,7 +166,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
 
         def fieldRefs = []
 
-        DocumentUtil.findKey(thingCopy, FIELDREF) { value, path ->
+        DocumentUtil.findKey(thingCopy, FIELD_REFS) { value, path ->
             def romanizedField = romanizedFieldsByTmpRef[value]
             if (romanizedField) {
                 def fieldNumber = romanizedField.keySet()[0]
@@ -344,6 +344,9 @@ class RomanizationStep extends MarcFramePostProcStepBase {
                 tmpRef += 1
             }
             return DocumentUtil.NOP
+        }
+        if (thing['editionStatement']) {
+            thing[BIB250_REF] = tmpRef.toString()
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -55,13 +55,9 @@ class RomanizationStep extends MarcFramePostProcStepBase {
     String SUBFIELDS = 'subfields'
     String IND1 = 'ind1'
     String IND2 = 'ind2'
-
-    String BIB035_REF = 'marc:bib035-fieldref'
-    String BIB041_REF = 'marc:bib041-fieldref'
     String BIB250_REF = 'marc:bib250-fieldref'
-    String HOLD035_REF = 'marc:hold035-fieldref'
 
-    List FIELD_REFS = [FIELDREF, BIB035_REF, BIB041_REF, BIB250_REF, HOLD035_REF]
+    List FIELD_REFS = [FIELDREF, BIB250_REF]
 
     void modify(Map record, Map thing) {
         try {
@@ -232,12 +228,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         }
 
         String propertyName() {
-            switch (toField) {
-                case '035': return BIB035_REF // TODO: also 'marc:hold035-fieldref'
-                case '041': return BIB041_REF
-                case '250': return BIB250_REF
-                default: return FIELDREF
-            }
+            return toField == '250' ? BIB250_REF : FIELDREF
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -149,6 +149,10 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         uniqueTLangs.each { tLang ->
             unmodifyTLang(thing, tLang, byLangPaths, record)
         }
+        
+        if (thing[HAS_BIB880]) {
+            ((List) thing[HAS_BIB880]).sort { bib880 -> bib880[PART_LIST]?[0]?[FIELDREF] ?: '' }
+        }
 
         byLangPaths.each { putRomanizedLiteralInNonByLang(thing, it as List) }
     }

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
@@ -85,11 +85,11 @@
               "hasTitle": [
                 {
                   "@type": "Title",
-                  "mainTitle": "Vremja ženščin",
-                  "marc:fieldref": [
-                    "880-01"
-                  ]
+                  "mainTitle": "Vremja ženščin"
                 }
+              ],
+              "marc:fieldref": [
+                "880-01"
               ]
             }
           },
@@ -194,7 +194,7 @@
       }
     },
     {
-      "name": "construct-880-for-245[$a + $c]",
+      "name": "construct-880-for-245",
       "result": {
         "mainEntity": {
           "@type": "Instance",
@@ -382,5 +382,78 @@
         }
       }
     },
+    {
+      "name": "construct-880-for-250",
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "hasTitle": [
+            {
+              "@type": "Title",
+              "mainTitleByLang": {
+                "zh": "民族理论和民族政策纲要",
+                "zh-Latn-t-zh-Hani-m0-alaloc": "Minzu lilun he minzu zhengce gangyao"
+              }
+            }
+          ],
+          "editionStatementByLang": {
+            "zh": "第2版.(修訂本)",
+            "zh-Latn-t-zh-Hani-m0-alaloc": "Di 2 ban. (Xiuding ben)"
+          }
+        }
+      },
+      "back": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "hasTitle": [
+            {
+              "@type": "Title",
+              "mainTitle": "Minzu lilun he minzu zhengce gangyao",
+              "marc:fieldref": [
+                "880-01"
+              ]
+            }
+          ],
+          "editionStatement": "Di 2 ban. (Xiuding ben)",
+          "marc:bib250-fieldref": [
+            "880-02"
+          ],
+          "marc:hasBib880": [
+            {
+              "@type": "marc:Bib880",
+              "marc:partList": [
+                {
+                  "marc:fieldref": "245-01/$1"
+                },
+                {
+                  "marc:bib880-a": "民族理论和民族政策纲要"
+                }
+              ],
+              "marc:bib880-i1": "1",
+              "marc:bib880-i2": "0"
+            },
+            {
+              "@type": "marc:Bib880",
+              "marc:partList": [
+                {
+                  "marc:fieldref": "250-02/$1"
+                },
+                {
+                  "marc:bib880-a": "第2版.(修訂本)"
+                }
+              ],
+              "marc:bib880-i1": " ",
+              "marc:bib880-i2": " "
+            }
+          ]
+        }
+      }
+    }
   ]
 }

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-romanization.json
@@ -2,29 +2,21 @@
   "type": "Romanization",
   "_spec": [
     {
-      "name": "revert-245",
+      "name": "construct-880-for-240",
       "result": {
         "mainEntity": {
           "@type": "Instance",
           "instanceOf": {
-            "@type": "Text"
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
+            "@type": "Text",
+            "hasTitle": [
+              {
+                "@type": "Title",
+                "mainTitleByLang": {
+                  "ru": "Время женщин",
+                  "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
+                }
               }
-            }
-          ],
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
+            ]
           }
         }
       },
@@ -32,44 +24,26 @@
         "mainEntity": {
           "@type": "Instance",
           "instanceOf": {
-            "@type": "Text"
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitle": "romany",
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
-              },
-              "marc:fieldref": "880-01"
-            }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
+            "@type": "Text",
+            "hasTitle": [
+              {
+                "@type": "Title",
+                "mainTitle": "Vremja ženščin",
+                "marc:fieldref": [
+                  "880-01"
+                ]
+              }
+            ]
           },
           "marc:hasBib880": [
             {
               "@type": "marc:Bib880",
               "marc:partList": [
                 {
-                  "marc:fieldref": "245-01/(N"
+                  "marc:fieldref": "240-01/(N"
                 },
                 {
-                  "marc:bib880-a": "Время женщин :"
-                },
-                {
-                  "marc:bib880-b": "романы /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
+                  "marc:bib880-a": "Время женщин"
                 }
               ],
               "marc:bib880-i1": "1",
@@ -80,36 +54,24 @@
       }
     },
     {
-      "name": "revert-repeated-245",
+      "name": "construct-880-for-130",
       "result": {
         "mainEntity": {
           "@type": "Instance",
           "instanceOf": {
-            "@type": "Text"
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
-              }
-            },
-            {
-              "@type": "Title",
-              "mainTitleByLang": {
-                "ru": "Аз съм бременна",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Az sŭm bremenna"
-              }
+            "@type": "Text",
+            "expressionOf": {
+              "@type": "Work",
+              "hasTitle": [
+                {
+                  "@type": "Title",
+                  "mainTitleByLang": {
+                    "ru": "Время женщин",
+                    "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
+                  }
+                }
+              ]
             }
-          ],
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
           }
         }
       },
@@ -117,675 +79,308 @@
         "mainEntity": {
           "@type": "Instance",
           "instanceOf": {
-            "@type": "Text"
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitle": "romany",
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
-              },
-              "marc:fieldref": "880-01"
-            },
-            {
-              "@type": "Title",
-              "mainTitle": "Az sŭm bremenna",
-              "mainTitleByLang": {
-                "ru": "Аз съм бременна",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Az sŭm bremenna"
-              },
-              "marc:fieldref": "880-02"
+            "@type": "Text",
+            "expressionOf": {
+              "@type": "Work",
+              "hasTitle": [
+                {
+                  "@type": "Title",
+                  "mainTitle": "Vremja ženščin",
+                  "marc:fieldref": [
+                    "880-01"
+                  ]
+                }
+              ]
             }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
           },
           "marc:hasBib880": [
             {
               "@type": "marc:Bib880",
               "marc:partList": [
                 {
-                  "marc:fieldref": "245-01/(N"
+                  "marc:fieldref": "130-01/(N"
                 },
                 {
-                  "marc:bib880-a": "Время женщин :"
-                },
-                {
-                  "marc:bib880-b": "романы /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
+                  "marc:bib880-a": "Время женщин"
                 }
               ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "245-02/(N"
-                },
-                {
-                  "marc:bib880-a": "Аз съм бременна /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
-                }
-              ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
+              "marc:bib880-i1": "0",
+              "marc:bib880-i2": " "
             }
           ]
         }
       }
     },
     {
-      "name": "revert-various-fields",
+      "name": "construct-880-for-240-translation",
       "result": {
         "mainEntity": {
           "@type": "Instance",
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "0-4 sui zhineng xunlian baikequanshu",
-              "mainTitleByLang": {
-                "zh": "0-4岁智能训练百科全书",
-                "zh-Latn-t-zh-Hani-m0-alaloc": "0-4 sui zhineng xunlian baikequanshu"
-              }
-            },
-            {
-              "@type": "ParallelTitle",
-              "mainTitle": "Intelligent training encyclopedia of 0-4 year old"
-            }
-          ],
           "instanceOf": {
             "@type": "Text",
             "language": [
               {
-                "@id": "https://id.kb.se/language/chi"
+                "@id": "https://id.kb.se/language/swe"
+              }
+            ],
+            "translationOf": [
+              {
+                "@type": "Work",
+                "language": [
+                  {
+                    "@id": "https://id.kb.se/language/rus"
+                  }
+                ]
+              }
+            ],
+            "hasTitle": [
+              {
+                "@type": "Title",
+                "mainTitleByLang": {
+                  "ru": "Время женщин",
+                  "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "back": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "hasTitle": [
+              {
+                "@type": "Title",
+                "mainTitle": "Vremja ženščin",
+                "marc:fieldref": [
+                  "880-01"
+                ]
+              }
+            ],
+            "language": [
+              {
+                "@id": "https://id.kb.se/language/swe"
+              }
+            ],
+            "translationOf": [
+              {
+                "@type": "Work",
+                "language": [
+                  {
+                    "@id": "https://id.kb.se/language/rus"
+                  }
+                ]
               }
             ]
           },
-          "publication": [
+          "marc:hasBib880": [
             {
-              "year": "2007",
-              "@type": "PrimaryPublication",
-              "agent": {
-                "@type": "Agent",
-                "label": "Heilongjiang kexue jizhu chubanshe",
-                "labelByLang": {
-                  "zh": "黑龙江科学技术出版社",
-                  "zh-Latn-t-zh-Hani-m0-alaloc": "Heilongjiang kexue jizhu chubanshe"
+              "@type": "marc:Bib880",
+              "marc:partList": [
+                {
+                  "marc:fieldref": "240-01/(N"
+                },
+                {
+                  "marc:bib880-a": "Время женщин"
                 }
-              },
+              ],
+              "marc:bib880-i1": "1",
+              "marc:bib880-i2": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "construct-880-for-245[$a + $c]",
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "hasTitle": [
+            {
+              "@type": "Title",
+              "mainTitleByLang": {
+                "ar": "ملحمة الأيراج الشعرية",
+                "ar-Latn-t-ar-Arab-m0-alaloc": "Malḥamat al-abrāj al-shaʻrīyah"
+              }
+            }
+          ],
+          "responsibilityStatementByLang": {
+            "ar": "فارس ابراهيم",
+            "ar-Latn-t-ar-Arab-m0-alaloc": "Fāris Ibrāhīm"
+          }
+        }
+      },
+      "back": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "hasTitle": [
+            {
+              "@type": "Title",
+              "mainTitle": "Malḥamat al-abrāj al-shaʻrīyah",
+              "marc:fieldref": [
+                "880-01"
+              ]
+            }
+          ],
+          "responsibilityStatement": "Fāris Ibrāhīm",
+          "marc:hasBib880": [
+            {
+              "@type": "marc:Bib880",
+              "marc:partList": [
+                {
+                  "marc:fieldref": "245-01/(3/r"
+                },
+                {
+                  "marc:bib880-a": "ملحمة الأيراج الشعرية /"
+                },
+                {
+                  "marc:bib880-c": "فارس ابراهيم."
+                }
+              ],
+              "marc:bib880-i1": "1",
+              "marc:bib880-i2": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "construct-880-for-repeated-264",
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "manufacture": [
+            {
+              "@type": "Manufacture",
               "place": [
                 {
                   "@type": "Place",
-                  "label": "Haerbin",
                   "labelByLang": {
-                    "zh": "哈尔滨",
-                    "zh-Latn-t-zh-Hani-m0-alaloc": "Haerbin"
+                    "ar": "ستوكهلم",
+                    "ar-Latn-t-ar-Arab-m0-alaloc": "Stūkhūlm"
+                  }
+                }
+              ]
+            }
+          ],
+          "publication": [
+            {
+              "year": "2022",
+              "@type": "PrimaryPublication",
+              "agent": {
+                "@type": "Agent",
+                "label": [
+                  "[Fares Ibrahim]"
+                ]
+              },
+              "place": [
+                {
+                  "@type": "Place",
+                  "labelByLang": {
+                    "ar": "ستوكهلم",
+                    "ar-Latn-t-ar-Arab-m0-alaloc": "Stūkhūlm"
                   }
                 }
               ],
               "country": {
-                "@id": "https://id.kb.se/country/cc"
+                "@id": "https://id.kb.se/country/sw"
               }
             }
-          ],
-          "issuanceType": "Monograph",
-          "responsibilityStatement": "Zhang Qian",
-          "responsibilityStatementByLang": {
-            "zh": "张倩主编",
-            "zh-Latn-t-zh-Hani-m0-alaloc": "Zhang Qian"
-          }
+          ]
         }
       },
       "back": {
         "mainEntity": {
           "@type": "Instance",
-          "hasTitle": [
+          "instanceOf": {
+            "@type": "Text"
+          },
+          "manufacture": [
             {
-              "@type": "Title",
-              "mainTitle": "0-4 sui zhineng xunlian baikequanshu",
-              "mainTitleByLang" : {
-                "zh" : "0-4岁智能训练百科全书",
-                "zh-Latn-t-zh-Hani-m0-alaloc" : "0-4 sui zhineng xunlian baikequanshu"
-              },
-              "marc:fieldref": "880-01"
-            },
-            {
-              "@type": "ParallelTitle",
-              "mainTitle": "Intelligent training encyclopedia of 0-4 year old"
+              "@type": "Manufacture",
+              "place": [
+                {
+                  "@type": "Place",
+                  "label": "Stūkhūlm"
+                }
+              ],
+              "marc:fieldref": [
+                "880-01"
+              ]
             }
           ],
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/chi"
-              }
-            ]
-          },
           "publication": [
             {
-              "year": "2007",
+              "year": "2022",
               "@type": "PrimaryPublication",
               "agent": {
                 "@type": "Agent",
-                "label": "Heilongjiang kexue jizhu chubanshe",
-                "labelByLang" : {
-                  "zh" : "黑龙江科学技术出版社",
-                  "zh-Latn-t-zh-Hani-m0-alaloc" : "Heilongjiang kexue jizhu chubanshe"
-                }
+                "label": [
+                  "[Fares Ibrahim]"
+                ]
               },
               "place": [
                 {
                   "@type": "Place",
-                  "label": "Haerbin",
-                  "labelByLang" : {
-                    "zh" : "哈尔滨",
-                    "zh-Latn-t-zh-Hani-m0-alaloc" : "Haerbin"
-                  }
+                  "label": "Stūkhūlm"
                 }
               ],
               "country": {
-                "@id": "https://id.kb.se/country/cc"
+                "@id": "https://id.kb.se/country/sw"
               },
-              "marc:fieldref": "880-02"
+              "marc:fieldref": [
+                "880-02"
+              ]
             }
           ],
-          "issuanceType": "Monograph",
           "marc:hasBib880": [
             {
               "@type": "marc:Bib880",
               "marc:partList": [
                 {
-                  "marc:fieldref": "245-01/$1"
+                  "marc:fieldref": "264-01/(3/r"
                 },
                 {
-                  "marc:bib880-a": "0-4岁智能训练百科全书 /"
-                },
-                {
-                  "marc:bib880-c": "张倩主编."
+                  "marc:bib880-a": "ستوكهلم"
                 }
               ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
+              "marc:bib880-i1": " ",
+              "marc:bib880-i2": "3"
             },
             {
               "@type": "marc:Bib880",
               "marc:partList": [
                 {
-                  "marc:fieldref": "264-02/$1"
+                  "marc:fieldref": "264-02/(3/r"
                 },
                 {
-                  "marc:bib880-a": "哈尔滨 :"
+                  "marc:bib880-a": "ستوكهلم :"
                 },
                 {
-                  "marc:bib880-b": "黑龙江科学技术出版社,"
+                  "marc:bib880-b": "[Fares Ibrahim],"
+                },
+                {
+                  "marc:bib880-c": "2022"
                 }
               ],
               "marc:bib880-i1": " ",
               "marc:bib880-i2": "1"
             }
-          ],
-          "responsibilityStatement": "Zhang Qian",
-          "responsibilityStatementByLang" : {
-            "zh" : "张倩主编",
-            "zh-Latn-t-zh-Hani-m0-alaloc" : "Zhang Qian"
-          }
-        }
-      }
-    },
-    {
-      "name": "convert-245",
-      "source": {
-        "mainEntity": {
-          "@type": "Instance",
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/rus"
-              }
-            ]
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "subtitle": "romany",
-              "marc:fieldref": "880-01"
-            }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "marc:hasBib880": [
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "245-01/(N"
-                },
-                {
-                  "marc:bib880-a": "Время женщин :"
-                },
-                {
-                  "marc:bib880-b": "романы /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
-                }
-              ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
-            }
           ]
         }
-      },
-      "result": {
-        "mainEntity": {
-          "@type": "Instance",
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/rus"
-              }
-            ]
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitle": "romany",
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
-              }
-            }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
-          }
-        }
       }
     },
-    {
-      "name": "convert-repeated-245",
-      "source": {
-        "mainEntity": {
-          "@type": "Instance",
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/rus"
-              }
-            ]
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "subtitle": "romany",
-              "marc:fieldref": "880-01"
-            },
-            {
-              "@type": "Title",
-              "mainTitle": "Az sŭm bremenna",
-              "marc:fieldref": "880-02"
-            }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "marc:hasBib880": [
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "245-01/(N"
-                },
-                {
-                  "marc:bib880-a": "Время женщин :"
-                },
-                {
-                  "marc:bib880-b": "романы /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
-                }
-              ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "245-02/(N"
-                },
-                {
-                  "marc:bib880-a": "Аз съм бременна /"
-                },
-                {
-                  "marc:bib880-c": "Елена Чижова."
-                }
-              ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": "0"
-            }
-          ]
-        }
-      },
-      "result": {
-        "mainEntity": {
-          "@type": "Instance",
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/rus"
-              }
-            ]
-          },
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "Vremja ženščin",
-              "mainTitleByLang": {
-                "ru": "Время женщин",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Vremja ženščin"
-              },
-              "subtitle": "romany",
-              "subtitleByLang": {
-                "ru": "романы",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "romany"
-              }
-            },
-            {
-              "@type": "Title",
-              "mainTitle": "Az sŭm bremenna",
-              "mainTitleByLang": {
-                "ru": "Аз съм бременна",
-                "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Az sŭm bremenna"
-              }
-            }
-          ],
-          "responsibilityStatement": "Elena Čižova",
-          "responsibilityStatementByLang": {
-            "ru": "Елена Чижова",
-            "ru-Latn-t-ru-Cyrl-m0-iso-1995": "Elena Čižova"
-          }
-        }
-      }
-    },
-    {
-      "name": "convert-various-fields",
-      "source": {
-        "mainEntity": {
-          "@type": "Instance",
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "0-4 sui zhineng xunlian baikequanshu",
-              "marc:fieldref": "880-01"
-            },
-            {
-              "@type": "ParallelTitle",
-              "mainTitle": "Intelligent training encyclopedia of 0-4 year old"
-            }
-          ],
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/chi"
-              }
-            ]
-          },
-          "publication": [
-            {
-              "year": "2007",
-              "@type": "PrimaryPublication",
-              "agent": {
-                "@type": "Agent",
-                "label": "Heilongjiang kexue jizhu chubanshe"
-              },
-              "place": [
-                {
-                  "@type": "Place",
-                  "label": "Haerbin"
-                }
-              ],
-              "country": {
-                "@id": "https://id.kb.se/country/cc"
-              },
-              "marc:fieldref": "880-04"
-            }
-          ],
-          "issuanceType": "Monograph",
-          "marc:hasBib880": [
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "245-01"
-                },
-                {
-                  "marc:bib880-a": "0-4岁智能训练百科全书 /"
-                },
-                {
-                  "marc:bib880-c": "张倩主编."
-                }
-              ],
-              "marc:bib880-i1": "0",
-              "marc:bib880-i2": "0"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "260-04"
-                },
-                {
-                  "marc:bib880-a": "哈尔滨 :"
-                },
-                {
-                  "marc:bib880-b": "黑龙江科学技术出版社,"
-                },
-                {
-                  "marc:bib880-c": "2007."
-                }
-              ],
-              "marc:bib880-i1": " ",
-              "marc:bib880-i2": " "
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "300-00"
-                },
-                {
-                  "marc:bib880-a": "21, 519页 ;"
-                },
-                {
-                  "marc:bib880-c": "22 cm."
-                }
-              ],
-              "marc:bib880-i1": " ",
-              "marc:bib880-i2": " "
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "500-00"
-                },
-                {
-                  "marc:bib880-a": "21世纪最有影响力的育婴书."
-                }
-              ],
-              "marc:bib880-i1": " ",
-              "marc:bib880-i2": " "
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "520-00"
-                },
-                {
-                  "marc:bib880-a": "本书包括智能训练从胎教开始、智能训练专家课堂、0-1岁智能训练方案、1-2岁智能训练方案、2-3岁智能训练方案、3-4岁智能训练方案等内容。"
-                }
-              ],
-              "marc:bib880-i1": " ",
-              "marc:bib880-i2": " "
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "650-00"
-                },
-                {
-                  "marc:bib880-a": "婴幼儿"
-                },
-                {
-                  "marc:bib880-x": "智力开发"
-                },
-                {
-                  "marc:bib880-2": "cct"
-                }
-              ],
-              "marc:bib880-i1": "0",
-              "marc:bib880-i2": "7"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "650-00"
-                },
-                {
-                  "marc:bib880-a": "婴幼儿"
-                },
-                {
-                  "marc:bib880-2": "cct"
-                }
-              ],
-              "marc:bib880-i1": "0",
-              "marc:bib880-i2": "7"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "650-00"
-                },
-                {
-                  "marc:bib880-a": "智力开发"
-                },
-                {
-                  "marc:bib880-2": "cct"
-                }
-              ],
-              "marc:bib880-i1": "0",
-              "marc:bib880-i2": "7"
-            },
-            {
-              "@type": "marc:Bib880",
-              "marc:partList": [
-                {
-                  "marc:fieldref": "700-06"
-                },
-                {
-                  "marc:bib880-a": "张倩."
-                }
-              ],
-              "marc:bib880-i1": "1",
-              "marc:bib880-i2": " "
-            }
-          ],
-          "responsibilityStatement": "Zhang Qian"
-        }
-      },
-      "result": {
-        "mainEntity": {
-          "@type": "Instance",
-          "hasTitle": [
-            {
-              "@type": "Title",
-              "mainTitle": "0-4 sui zhineng xunlian baikequanshu",
-              "mainTitleByLang": {
-                "zh": "0-4岁智能训练百科全书",
-                "zh-Latn-t-zh-Hani-m0-alaloc": "0-4 sui zhineng xunlian baikequanshu"
-              }
-            },
-            {
-              "@type": "ParallelTitle",
-              "mainTitle": "Intelligent training encyclopedia of 0-4 year old"
-            }
-          ],
-          "instanceOf": {
-            "@type": "Text",
-            "language": [
-              {
-                "@id": "https://id.kb.se/language/chi"
-              }
-            ]
-          },
-          "publication": [
-            {
-              "year": "2007",
-              "@type": "PrimaryPublication",
-              "agent": {
-                "@type": "Agent",
-                "label": "Heilongjiang kexue jizhu chubanshe",
-                "labelByLang": {
-                  "zh": "黑龙江科学技术出版社",
-                  "zh-Latn-t-zh-Hani-m0-alaloc": "Heilongjiang kexue jizhu chubanshe"
-                }
-              },
-              "place": [
-                {
-                  "@type": "Place",
-                  "label": "Haerbin",
-                  "labelByLang": {
-                    "zh": "哈尔滨",
-                    "zh-Latn-t-zh-Hani-m0-alaloc": "Haerbin"
-                  }
-                }
-              ],
-              "country": {
-                "@id": "https://id.kb.se/country/cc"
-              }
-            }
-          ],
-          "issuanceType": "Monograph",
-          "responsibilityStatement": "Zhang Qian",
-          "responsibilityStatementByLang": {
-            "zh": "张倩主编",
-            "zh-Latn-t-zh-Hani-m0-alaloc": "Zhang Qian"
-          }
-        }
-      }
-    }
   ]
 }

--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -7535,7 +7535,7 @@
         "uriTemplate": "http://libris.kb.se/auth/{_}",
         "matchUriToken": "^\\d{1,14}$"
       },
-      "$6": {"property": "marc:fieldref"},
+      "$6": {"about": "_:title", "property": "marc:fieldref"},
       "subfieldOrder": "6 a g d m n r p k l s f o 1 0",
       "_spec": [
         {


### PR DESCRIPTION
This addresses a few known issues with the 880 revert conversion.
- Missing fieldref in 240 and mismatched fieldrefs for repeated fields. Fieldrefs are now placed out in a reliable way, see 3619cc3.
- Missing 130 for romanized work titles (after "titeljonglering"). `RomanizationStep` and `NormalizeWorkTitlesStep` should no longer interfere with each other, see 32d4a7d.

Added a few test cases for some of the (before) problematic cases that I'm aware of. Feel free to add more.

- [x] integTest