### PR TITLE
History: More precise diffs

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -341,6 +341,10 @@ class JsonLd {
     String expand(String ref) {
         return expand(ref, (Map) displayData[CONTEXT_KEY])
     }
+    
+    static boolean isLink(Map jsonLd) {
+        jsonLd.size() == 1 && jsonLd[ID_KEY]
+    }
 
     static URI findRecordURI(Map jsonLd) {
         String foundIdentifier = findIdentifier(jsonLd)

--- a/whelk-core/src/test/groovy/JsonLdSpec.groovy
+++ b/whelk-core/src/test/groovy/JsonLdSpec.groovy
@@ -749,6 +749,17 @@ class JsonLdSpec extends Specification {
         assert JsonLd.getIdMap(input) == output
     }
 
+    def "should recognize link"() {
+        expect:
+        JsonLd.isLink(data) == expected
+
+        where:
+        data                         || expected
+        ['@id': 'foo']               || true
+        ['@id': 'foo', 'bar': 'bar'] || false
+        ['bar': 'bar']               || false
+    }
+
     static final String FLAT_INPUT = readFile("flatten-001-in.jsonld")
     static final String FLAT_OUTPUT = readFile("flatten-001-out.jsonld")
     static final String FRAMED_INPUT = readFile("frame-001-in.jsonld")

--- a/whelk-core/src/test/groovy/whelk/history/HistorySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/history/HistorySpec.groovy
@@ -1,5 +1,6 @@
 package whelk.history
 
+
 import spock.lang.Specification
 import whelk.Document
 import whelk.JsonLd
@@ -9,8 +10,7 @@ import whelk.util.JsonLdSpec
 class HistorySpec extends Specification {
     def "array(set) order does not matter"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, [:], JsonLdSpec.VOCAB_DATA)
-        def versions = [
+        def changeSets = diff([
                 ['@graph': [
                         ['modified': '2022-02-02T12:00:00Z'],
                         ['a': [
@@ -25,12 +25,8 @@ class HistorySpec extends Specification {
                                 ['@id': 'id1'],
                         ]]
                 ]]
-        ].collect { data ->
-            new DocumentVersion(new Document(data), '', '')
-        }
+        ])
 
-        def history = new History(versions, ld)
-        List<Map> changeSets = history.m_changeSetsMap['changeSets']
         expect:
         changeSets.size() == 2
         !changeSets[1].removedPaths
@@ -39,8 +35,7 @@ class HistorySpec extends Specification {
 
     def "simple value modified"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, [:], JsonLdSpec.VOCAB_DATA)
-        def versions = [
+        def changeSets = diff([
                 ['@graph': [
                         ['modified': '2022-02-02T12:00:00Z'],
                         ['a': 'x']
@@ -49,22 +44,55 @@ class HistorySpec extends Specification {
                         ['modified': '2022-02-02T12:00:00Z'],
                         ['a': 'y']
                 ]]
-        ].collect { data ->
-            new DocumentVersion(new Document(data), '', '')
-        }
+        ])
 
-        def history = new History(versions, ld)
-        List<Map> changeSets = history.m_changeSetsMap['changeSets']
         expect:
         changeSets.size() == 2
         changeSets[1].removedPaths == [["@graph", 1, "a"]] as Set
         changeSets[1].addedPaths == [["@graph", 1, "a"]] as Set
     }
 
+    def "simple value added"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        [:]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['a': 'x']
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        !changeSets[1].removedPaths
+        changeSets[1].addedPaths == [["@graph", 1, "a"]] as Set
+    }
+
+    def "simple value removed"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['a': 'x']
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        [:]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].removedPaths == [["@graph", 1, "a"]] as Set
+        !changeSets[1].addedPaths
+    }
+
     def "nested value modified"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, [:], JsonLdSpec.VOCAB_DATA)
-        def versions = [
+        def changeSets = diff([
                 ['@graph': [
                         ['modified': '2022-02-02T12:00:00Z'],
                         ['a': [
@@ -77,19 +105,499 @@ class HistorySpec extends Specification {
                                 ['b': 'y']
                         ]]
                 ]]
-        ].collect { data ->
-            new DocumentVersion(new Document(data), '', '')
-        }
-
-        def history = new History(versions, ld)
-        List<Map> changeSets = history.m_changeSetsMap['changeSets']
-
-        //printJson(changeSets)
+        ])
 
         expect:
         changeSets.size() == 2
         changeSets[1].removedPaths == [["@graph", 1, "a", 0, "b"]] as Set
         changeSets[1].addedPaths == [["@graph", 1, "a", 0, "b"]] as Set
+    }
+
+    def "nested value added"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': 
+                                 ['c': [
+                                         ['a': 'x']
+                                 ]]
+                        ]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i':
+                                 ['c': [
+                                         ['a': 'x', 
+                                          'b': 'y']
+                                 ]]
+                        ]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", "c", 0, "b"]] as Set
+        !changeSets[1].removedPaths
+    }
+
+    def "nested value modified 2"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i':
+                                 ['c': [
+                                         ['a': 'x',
+                                          'b': 'y']
+                                 ]]
+                        ]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i':
+                                 ['c': [
+                                         ['a': 'x',
+                                          'b': 'y2']
+                                 ]]
+                        ]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", "c", 0, "b"]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i", "c", 0, "b"]] as Set
+    }
+
+    def "nested value removed"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i':
+                                 ['c': [
+                                         ['a': 'x',
+                                          'b': 'y']
+                                 ]]
+                        ]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i':
+                                 ['c': [
+                                         ['a': 'x']
+                                 ]]
+                        ]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].removedPaths == [["@graph", 1, "i", "c", 0, "b"]] as Set
+        !changeSets[1].addedPaths
+    }
+
+    def "even more nested value removed"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['a': [
+                                 ['b': [
+                                         ['c': [
+                                                 ['d': 'x',
+                                                  'e': 'y']
+                                         ]]
+                                 ]]
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['a': [
+                                 ['b': [
+                                         ['c': [
+                                                 ['d': 'x']
+                                         ]]
+                                 ]]
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].removedPaths == [["@graph", 1, "a", 0, "b", 0, "c", 0, "e"]] as Set
+        !changeSets[1].addedPaths
+    }
+
+    def "array middle remove"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['a': 'x', 'b': 'y'],
+                                ['@id': 'b'],
+                                ['@id': 'c'],
+                                ['@id': 'd'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                                ['@id': 'd'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        !changeSets[1].addedPaths
+        changeSets[1].removedPaths == [["@graph", 1, "i", 0], ["@graph", 1, "i", 2]] as Set
+    }
+
+    def "completely changed"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['p': ['a': 'x', 'b': 'y']]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['p': ['c': 'z', 'd': 'å']]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "p"]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "p"]] as Set
+    }
+
+    def "array middle add"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                                ['@id': 'd'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'a'],
+                                ['@id': 'b'],
+                                ['@id': 'c'],
+                                ['@id': 'd'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 0], ["@graph", 1, "i", 2]] as Set
+        !changeSets[1].removedPaths
+    }
+
+    def "array swap and add"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'a'],
+                                ['@id': 'b'],
+                                ['@id': 'c'],
+                                ['@id': 'd'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'a'],
+                                ['@id': 'd'],
+                                ['@id': 'c'],
+                                ['@id': 'E'],
+                                ['@id': 'b'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 3]] as Set
+        !changeSets[1].removedPaths
+    }
+
+    def "array swap"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'a'],
+                                ['@id': 'b'],
+                                ['@id': 'c'],
+                                ['@id': 'd'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'a'],
+                                ['@id': 'd'],
+                                ['@id': 'c'],
+                                ['@id': 'b'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        !changeSets[1].addedPaths
+        !changeSets[1].removedPaths
+    }
+
+    def "array middle add local"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                                ['@id': 'd'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                                ['a': 'x', 'b': 'y'],
+                                ['@id': 'd'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 1]] as Set
+        !changeSets[1].removedPaths
+    }
+    
+    def "array swap and edit"() {
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['a': 'x', 'b': 'y'],
+                                ['c': 'z', 'd': 'å'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['c': 'z', 'd': 'å2'],
+                                ['a': 'x', 'b': 'y2'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 0], ["@graph", 1, "i", 1]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i", 0], ["@graph", 1, "i", 1]] as Set
+    }
+    
+    def "array edit and remove"() {
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['a': 'x', 'b': 'y'],
+                                ['c': 'z', 'd': 'å'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['c': 'z', 'd': 'å2'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 0]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i", 0], ["@graph", 1, "i", 1]] as Set
+    }
+
+    
+    def "link in array"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['a': 'x'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                        ]]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 0]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i", 0]] as Set
+    }
+    
+    def "link"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': ['a': 'x']]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': ['@id': 'b']]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i"]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i"]] as Set
+    }
+    
+    def "unlink"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': ['@id': 'b']]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': ['a': 'x']]
+                ]]
+        ])
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i"]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i"]] as Set
+    }
+
+    def "unlink in array"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['@id': 'b'],
+                        ]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-02T12:00:00Z'],
+                        ['i': [
+                                ['a': 'x'],
+                        ]]
+                ]]
+        ])
+        
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 1, "i", 0]] as Set
+        changeSets[1].removedPaths == [["@graph", 1, "i", 0]] as Set
+    }
+
+    def "modified only"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        [
+                                '@id': 'ID',
+                                'modified': '2022-02-02T12:00:00Z',
+                        ],
+                        [:]
+                ]],
+                ['@graph': [
+                        [
+                                '@id': 'ID',
+                                'modified': '2022-02-03T12:00:00Z',
+                        ],
+                        [:]
+                ]]
+        ])
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [["@graph", 0, "modified"]] as Set
+        changeSets[1].removedPaths == [["@graph", 0, "modified"]] as Set
+    }
+
+    def "string in array"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['i': ['c': ['l': ["a", "b", "c"]]]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['i': ['c': ['l': ["a", "B", "c"]]]]
+                ]]
+        ])
+        
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [['@graph', 1, 'i', 'c', 'l', 1]] as Set
+        changeSets[1].removedPaths == [['@graph', 1, 'i', 'c', 'l', 1]] as Set
+    }
+
+    def "single string in array"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['i': ['c': ['l': ["a"]]]]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['i': ['c': ['l': ["A"]]]]
+                ]]
+        ])
+        
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [['@graph', 1, 'i', 'c', 'l', 0]] as Set
+        changeSets[1].removedPaths == [['@graph', 1, 'i', 'c', 'l', 0]] as Set
+    }
+
+    def "language container"() {
+        given:
+        def changeSets = diff([
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['fooByLang': ['a': 'A']]
+                ]],
+                ['@graph': [
+                        ['modified': '2022-02-03T12:00:00Z'],
+                        ['fooByLang': ['b': 'B']]
+                ]]
+        ])
+
+        expect:
+        changeSets.size() == 2
+        changeSets[1].addedPaths == [['@graph', 1, 'fooByLang', 'b']] as Set
+        changeSets[1].removedPaths == [['@graph', 1, 'fooByLang', 'a']] as Set
     }
 
     def "Owner changes deep in structure"() {
@@ -196,6 +704,23 @@ class HistorySpec extends Specification {
         history.getOwnership(["@graph", 1, "a", 1, "b"]).m_manualEditor == "sigel2" // Doesn't exist anymore, (should revert to list owner).
     }
 
+    def diff(List<Map> versions) {
+        def display = [
+                "@context": [
+                        "fooByLang": ["@id": "foo", "@container": "@language"]
+                ],
+        ]
+        
+        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, display, JsonLdSpec.VOCAB_DATA)
+        def v = versions.collect { data ->
+            new DocumentVersion(new Document(data), '', '')
+        }
+
+        def history = new History(v, ld)
+        List<Map> changeSets = history.m_changeSetsMap['changeSets']
+        return changeSets
+    }
+    
     def printJson(def c) {
         println(groovy.json.JsonOutput.prettyPrint(Jackson.mapper().writeValueAsString(c)))
     }


### PR DESCRIPTION
* Fix an issue when modifying objects inside arrays. Adding a property to an object inside an array would report the whole object as removed in addition to the property being added. And vice versa when removing properties.
* Return more helpful diffs when objects are completely replaced. Before each property inside the object would be listed as removed/added. Now only the object is removed + added.
* Always include `addedPaths` and `removedPaths` in the response even if they are empty.
* Add more tests