### PR TITLE
Fix determination of content type from suffix

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -7,6 +7,7 @@ import static whelk.rest.api.CrudUtils.*
 class CrudGetRequest {
     private HttpServletRequest request
     private String resourceId
+    private String dataLeaf
     private String contentType
     private View view
     private Lens lens
@@ -19,7 +20,7 @@ class CrudGetRequest {
     private CrudGetRequest(HttpServletRequest request) {
         this.request = request
         parsePath(getPath())
-        contentType = getBestContentType(request)
+        contentType = getBestContentType(getAcceptHeader(request), dataLeaf)
         lens = parseLens(request)
         profile = parseProfile(request)
     }
@@ -86,6 +87,7 @@ class CrudGetRequest {
         def matcher = path =~ ~/^\/(.+?)(\/(data|data-view|_changesets)(\.(\w+))?)?$/
         if (matcher.matches()) {
             resourceId = matcher[0][1]
+            dataLeaf = matcher[0][2]
             view = View.fromString(matcher[0][3])
         } else {
             throw new Crud.NotFoundException("Not found:" + path)


### PR DESCRIPTION
We inspect URI paths for suffixes, but do so too eagerly.

Formal request paths may contain dots (e.g. `etc` or `1.0`), so we need to recognize the ones we use as representation paths.

We already use "data leafs" for this, i.e. the last path component is special if it has a certain name (`data`, `find` or begins with an underscore).

This fix makes sure only this representation data leaf path is used to check for suffix-based content negotiation.

(And also refactors and simplifies some parts of the request inspection where this is happening.)