### PR TITLE
Feature/880 script

### DIFF
--- a/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LanguageLinker.groovy
@@ -7,7 +7,7 @@ class LanguageLinker extends BlankNodeLinker implements DocumentUtil.Linker {
     List ignoreCodes = []
 
     LanguageLinker(List ignoreCodes = [], Statistics stats = null) {
-        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabelByLang', 'hiddenLabel', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm'], stats)
+        super('Language', ['label', 'code', 'prefLabelByLang', 'altLabelByLang', 'hiddenLabelByLang', 'hiddenLabel', 'langCode', 'langCodeBib', 'langCodeFull', 'langCodeTerm', 'langTag'], stats)
         this.ignoreCodes = ignoreCodes
     }
 

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -14,9 +14,9 @@ def where = """
     AND data#>>'{@graph,1,${u.HAS_BIB880}}' IS NOT NULL
 """
 
-selectBySqlWhere(where) {
-    def (record, thing) = it.graph
-    def id = it.doc.shortId
+selectBySqlWhere(where) { bib ->
+    def (record, thing) = bib.graph
+    def id = bib.doc.shortId
 
     def romanizableLangs = thing.instanceOf.subMap('language').with {
         u.langLinker.linkAll(it)
@@ -122,7 +122,7 @@ selectBySqlWhere(where) {
             thing[u.HAS_BIB880] = hasBib880
         }
         incrementStats('Romanized langs', tLangTag)
-        it.scheduleSave()
+        bib.scheduleSave()
     } else {
         incrementStats('Handled records', 'unhandled')
     }

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -103,20 +103,20 @@ selectBySqlWhere(where) {
             // If there is no fieldref in the path it's still ok if no arrays are of of size > 1.
             def isSafePath = adjustArrayIndices(p, refPath) || !existRepeated(thing, p)
             if (!isSafePath) {
-                unsafePath.println([id, ref, p.join('.'), refPath.join('.')].join('\t'))
+                unsafePath.println([id, bib880data.ref, p.join('.'), refPath.join('.')].join('\t'))
                 incrementStats('Unsafe path: no fieldref in path and multiple elements in array', p.join('.'))
                 return
             }
 
             def original = getAtPath(bib880data.converted, pCopy)
             if (looksLikeScript(original.toString(), 'Latn')) {
-                looksLikeLatin.println([id, ref, p.join('.'), original].join('\t'))
+                looksLikeLatin.println([id, bib880data.ref, p.join('.'), original].join('\t'))
                 return
             }
 
             def parentObject = getAtPath(thing, p.dropRight(1))
             if (!parentObject) {
-                missingRomanized.println([id, ref, p.join('.'), original].join('\t'))
+                missingRomanized.println([id, bib880data.ref, p.join('.'), original].join('\t'))
                 incrementStats('No romanized value at path', p.join('.'))
                 return
             }
@@ -125,7 +125,7 @@ selectBySqlWhere(where) {
                 def k = p.last()
                 if (it[k]) {
                     def byLangProp = u.langAliases[k]
-                    romanized.println([id, original, tLangTag, it[k], ref].join('\t'))
+                    romanized.println([id, original, tLangTag, it[k], bib880data.ref].join('\t'))
                     it[byLangProp] =
                             [
                                     (langTag) : original,

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -125,7 +125,7 @@ selectBySqlWhere(where) {
                 def k = p.last()
                 if (it[k]) {
                     def byLangProp = u.langAliases[k]
-                    romanized.println([id, original, tLangTag, it[k], bib880data.ref].join('\t'))
+                    romanized.println([id, tLangTag, p.join('.'), bib880data.ref, original, it[k]].join('\t'))
                     it[byLangProp] =
                             [
                                     (langTag) : original,
@@ -150,7 +150,9 @@ selectBySqlWhere(where) {
         indexesOfHandled.sort().reverseEach {
             hasBib880.removeAt(it)
         }
-        thing[u.HAS_BIB880] = hasBib880
+        if (!hasBib880.isEmpty()) {
+            thing[u.HAS_BIB880] = hasBib880
+        }
         incrementStats('Romanized langs', tLangTag)
         it.scheduleSave()
     } else {

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -28,7 +28,7 @@ selectBySqlWhere(where) { bib ->
     if (romanizableLangs.isEmpty()) {
         incrementStats('No romanizable language', asList(thing.instanceOf.language))
     }
-    if (romanizableLangs.size() > 2) {
+    if (romanizableLangs.size() > 1) {
         incrementStats('Multiple romanizable langs', romanizableLangs)
         return
     }

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -40,7 +40,7 @@ selectBySqlWhere(where) {
     }
     def tLangTag = "$langTag${u.MATCH_T_TAG}$langTag"
 
-    def hasBib880 = asList(thing[u.HAS_BIB880])
+    def hasBib880 = asList(thing.remove(u.HAS_BIB880))
 
     Map seqNumToBib880Data = [:]
     Set duplicateSeqNums = []

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -326,13 +326,15 @@ class Util {
     Util(whelk) {
         this.langAliases = whelk.jsonld.langContainerAlias
         this.byLangToBase = langAliases.collectEntries { k, v -> [v, k] }
-        this.langIdToLangTag = whelk.languageResources.languages
-                .findAll { k, v -> v.langTag }.collectEntries { k, v -> [k, v.langTag] }
+        this.langIdToLangTag = whelk.storage.loadAll("https://id.kb.se/dataset/languages")
+                .collect { it.data['@graph'][1] }
+                .findAll { it.langTag }
+                .collectEntries { [it['@id'], it.langTag] }
         this.converter = whelk.marcFrameConverter
         this.converter.conversion.doPostProcessing = false
         this.langLinker = whelk.languageResources.languageLinker
-        this.romanizableLangs = whelk.languageResources.transformedLanguageForms.findResults { k, v ->
-            v.inLanguage?.'@id'
+        this.romanizableLangs = whelk.storage.loadAll("https://id.kb.se/dataset/i18n/tlangs").findResults {
+            it.data['@graph'][1].inLanguage?.'@id'
         }
     }
 }

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -79,11 +79,6 @@ selectBySqlWhere(where) { bib ->
                     p = removeIndexFromPathIfNotArray(thing, p)
                 }
             }
-            if (!safePath) {
-                unsafePath.println([id, bib880data.ref, p.join('.'), refPath.join('.')].join('\t'))
-                incrementStats('Unsafe path: no fieldref in path and multiple elements in array', p.join('.'))
-                return
-            }
 
             def original = getAtPath(bib880data.converted, pCopy)
             if (looksLikeScript(original.toString(), 'Latn')) {

--- a/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
+++ b/whelktool/scripts/2023/01/lxl-3908-romanized-to-byLang/bib880.groovy
@@ -3,125 +3,158 @@ import whelk.util.DocumentUtil
 
 Util u = new Util(getWhelk())
 
+romanized = getReportWriter("romanized.tsv")
+missingRomanized = getReportWriter("missing-romanized.tsv")
+unsafePath = getReportWriter("unsafe-path.tsv")
+lost = getReportWriter("lost-values.tsv")
+looksLikeLatin = getReportWriter("looks-like-latin.tsv")
+
 def where = """
     collection = 'bib'
     AND data#>>'{@graph,1,${u.HAS_BIB880}}' IS NOT NULL
 """
 
 selectBySqlWhere(where) {
-    println(it.doc.shortId)
-    return
-    
     def (record, thing) = it.graph
+    def id = it.doc.shortId
 
-    // TODO: multiple languages?
-    def lang = thing.instanceOf.subMap('language').with {
+    def romanizableLangs = thing.instanceOf.subMap('language').with {
         u.langLinker.linkAll(it)
-        asList(it.language).findResult { it[u.ID] } ?: 'https://id.kb.se/language/und'
+        asList(it.language).findResults { it[u.ID] in u.romanizableLangs ? it[u.ID] : null }
     }
 
-    def langTag = u.langToLangTag[lang]
+    def lang = romanizableLangs.size() == 1 ? romanizableLangs[0] : 'https://id.kb.se/language/und'
+
+    if (romanizableLangs.isEmpty()) {
+        incrementStats('No romanizable language', asList(thing.instanceOf.language))
+    }
+    if (romanizableLangs.size() > 2) {
+        incrementStats('Multiple romanizable langs', romanizableLangs)
+        return
+    }
+
+    def langTag = u.langIdToLangTag[lang]
     if (!langTag) {
-        incrementStats('Missing langTag', lang)
+        incrementStats('Missing langTag for language', lang)
         return
     }
+    def tLangTag = "$langTag${u.MATCH_T_TAG}$langTag"
 
-    def hasBib880 = thing.remove(u.HAS_BIB880)
+    def hasBib880 = asList(thing[u.HAS_BIB880])
 
-    def tLangCandidates = u.langToTLang[lang]
-    if (!tLangCandidates) {
-        incrementStats('Missing tLang', lang)
-        return
+    Map seqNumToBib880Data = [:]
+    Set duplicateSeqNums = []
+
+    hasBib880.eachWithIndex { bib880, i ->
+        def ref = getFieldRef(bib880, u)
+        if (ref.isEmpty()) {
+            return
+        }
+
+        def converted = tryConvert(bib880, u)
+        if (converted.isEmpty()) {
+            incrementStats('Invalid Bib880', 'failed conversion')
+            return
+        }
+
+        def seqNum = ref.get().takeRight(2)
+
+        if (seqNumToBib880Data.containsKey(seqNum)) {
+            duplicateSeqNums.add(seqNum)
+            return
+        }
+
+        seqNumToBib880Data[seqNum] = [
+                'ref'          : ref.get(),
+                'converted'    : converted.get()['@graph'][1],
+                'idxOfOriginal': i
+        ]
     }
-    def tLang = tLangCandidates.size() == 1 ? tLangCandidates[0].code : null
 
-    def failed = false
+    duplicateSeqNums.each {
+        incrementStats('duplicate sequence number', it)
+        seqNumToBib880Data.remove(it)
+    }
 
-    Map bib880ByField = [:]
-    asList(hasBib880).each { bib880 ->
-        def partList = asList(bib880[u.PART_LIST])
-        if (!partList) {
-            incrementStats('edge cases', 'missing partlist')
-            failed = true
+    DocumentUtil.findKey(thing, u.FIELDREFS) { ref, path ->
+        if (ref instanceof List) {
+            if (ref.size() > 1) {
+                incrementStats('multiple fieldrefs', 'multiple fieldrefs')
+                return
+            } else {
+                ref = ref[0]
+            }
+        }
+
+        def seqNum = ref.takeRight(2)
+        def bib880data = seqNumToBib880Data[seqNum]
+        if (!bib880data) {
             return
         }
-        def linkField = partList[0][u.FIELDREF]
-        if (!(linkField =~ /^\d{3}-\d{2}/)) {
-            incrementStats('edge cases', 'missing or malformed fieldref')
-            failed = true
-            return
-        }
-        if (!tLang) {
-            // Ambiguous tLang, try decide by examining script type of the original strings
-            def strings = partList.drop(1)*.values().flatten()
-            for (String s : strings) {
-                def compact = s.replaceAll(/[^\p{L}]/, '')
-                if (compact) {
-                    tLang = chooseTLang(compact, tLangCandidates)
-                }
-                if (tLang) {
-                    break
+        def nonByLangPaths = collectNonByLangPaths(bib880data.converted, u.langAliases.keySet(), id)
+
+        for (List p : nonByLangPaths) {
+            def pCopy = p.collect()
+            def refPath = path.dropRight(1)
+
+            // Since we convert the bib880s one by one, array indexes in the path will always be 0.
+            // However in the description (thing) where we want to insert the bib880 values, there may be more than one object in some arrays.
+            // So we check the index of the object containing the fieldref to get the path right.
+            // If there is no fieldref in the path it's still ok if no arrays are of of size > 1.
+            def isSafePath = adjustArrayIndices(p, refPath) || !existRepeated(thing, p)
+            if (!isSafePath) {
+                unsafePath.println([id, ref, p.join('.'), refPath.join('.')].join('\t'))
+                incrementStats('Unsafe path: no fieldref in path and multiple elements in array', p.join('.'))
+                return
+            }
+
+            def original = getAtPath(bib880data.converted, pCopy)
+            if (looksLikeScript(original.toString(), 'Latn')) {
+                looksLikeLatin.println([id, ref, p.join('.'), original].join('\t'))
+                return
+            }
+
+            def parentObject = getAtPath(thing, p.dropRight(1))
+            if (!parentObject) {
+                missingRomanized.println([id, ref, p.join('.'), original].join('\t'))
+                incrementStats('No romanized value at path', p.join('.'))
+                return
+            }
+
+            asList(parentObject).each {
+                def k = p.last()
+                if (it[k]) {
+                    def byLangProp = u.langAliases[k]
+                    romanized.println([id, original, tLangTag, it[k], ref].join('\t'))
+                    it[byLangProp] =
+                            [
+                                    (langTag) : original,
+                                    (tLangTag): it[k]
+                            ]
+                    it.remove(k)
                 }
             }
         }
-        def parts = linkField.split('-')
-        def tag = parts[0]
-        def seqNum = parts[1].take(2)
-        if (seqNum != '00') {
-            def entry = bib880ByField.computeIfAbsent(tag, s -> [])
-            entry.add(['ref': '880-' + seqNum, 'bib880': bib880])
-        }
+
+        bib880data['handled'] = true
+        return new DocumentUtil.Remove()
     }
 
-    if (!failed && !tLang) {
-        incrementStats('Ambiguous tLang, could not decide which to use', lang)
-        return
-    }
-
-    Map bib880Map = [:]
-    Map sameField = [:]
-
-    bib880ByField.each { tag, data ->
-        def converted = null
-        try {
-            def marcJson = data.collect { bib880ToMarcJson(it.bib880, u) }
-            def marc = [leader: "00887cam a2200277 a 4500", fields: marcJson]
-            converted = u.converter.runConvert(marc)
-        } catch (Exception e) {
-            incrementStats('edge cases', 'failed conversion')
-            failed = true
-            return
+    def indexesOfHandled = seqNumToBib880Data.findResults { seqNum, data -> data.handled ? data.idxOfOriginal : null }
+    if (!indexesOfHandled.isEmpty()) {
+        if (indexesOfHandled.size() == hasBib880.size()) {
+            incrementStats('Handled records', 'completely handled')
+        } else {
+            incrementStats('Handled records', 'partly handled')
         }
-
-        def refs = data.collect {
-            bib880Map[it.ref] = converted
-            it.ref
-        } as Set
-
-        refs.each {
-            sameField[it] = refs
+        indexesOfHandled.sort().reverseEach {
+            hasBib880.removeAt(it)
         }
-    }
-
-    Set handled = []
-    def handle880Ref = { ref, path ->
-        if (sameField[ref]?.intersect(handled)) {
-            handled.add(ref)
-            return new DocumentUtil.Remove()
-        }
-        def converted = bib880Map[ref]
-        if (converted) {
-            mergeLanguage(converted['@graph'][1], thing, u, langTag, tLang)
-            handled.add(ref)
-            return new DocumentUtil.Remove()
-        }
-    }
-
-    if (!failed) {
-        u.FIELDREFS.each {
-            DocumentUtil.findKey(thing, it, handle880Ref)
-        }
+        thing[u.HAS_BIB880] = hasBib880
+        incrementStats('Romanized langs', tLangTag)
         it.scheduleSave()
+    } else {
+        incrementStats('Handled records', 'unhandled')
     }
 }
 
@@ -135,40 +168,36 @@ def getWhelk() {
     return whelk
 }
 
-void mergeLanguage(Map thing, Map converted, Util u, String langTag, String tLang) {
-    def nonByLangPaths = []
-    DocumentUtil.findKey(converted, u.langAliases.keySet()) { value, path ->
-        nonByLangPaths.add(path.collect())
-        return
+Optional<String> getFieldRef(Map bib880, Util u) {
+    def partList = asList(bib880[u.PART_LIST])
+    if (!partList) {
+        incrementStats('Invalid Bib880', 'missing partlist')
+        return Optional.empty()
     }
-
-    nonByLangPaths.each { path ->
-        def containingObject = getAtPath(thing, path.dropRight(1))
-        if (!containingObject) {
-            //TODO: No romanized version seems to exists...
-            return
-        }
-
-        def byLang = [:]
-        asList(containingObject).each {
-            it.each { k, v ->
-                if (k == path.last()) {
-                    def byLangProp = u.langAliases[k]
-                    byLang[byLangProp] =
-                            [
-                                    (langTag): getAtPath(converted, path),
-                                    (tLang)  : v
-                            ]
-                }
-            }
-            it.putAll(byLang)
-        }
+    def fieldref = partList[0][u.FIELDREF]
+    if (!fieldref) {
+        incrementStats('Invalid Bib880', 'missing fieldref')
+        return Optional.empty()
     }
+    if (!(fieldref =~ /^\d{3}-\d{2}/)) {
+        incrementStats('Invalid Bib880', 'malformed fieldref')
+        return Optional.empty()
+    }
+    return Optional.of(fieldref.take(6))
 }
 
-def chooseTLang(String s, List tLangs) {
-    def scriptUri = 'https://id.kb.se/i18n/script/' + Unicode.guessIso15924ScriptCode(s).orElse(null)
-    return tLangs.find { it.fromLangScript == scriptUri }?.code
+Optional<Map> tryConvert(Map bib880, Util u) {
+    def converted = null
+
+    try {
+        def marcJson = bib880ToMarcJson(bib880, u)
+        def marc = [leader: "00887cam a2200277 a 4500", fields: [marcJson]]
+        converted = u.converter.runConvert(marc)
+    } catch (Exception e) {
+        return Optional.empty()
+    }
+
+    return Optional.of(converted)
 }
 
 Map bib880ToMarcJson(Map bib880, Util u) {
@@ -186,14 +215,94 @@ Map bib880ToMarcJson(Map bib880, Util u) {
     ]]
 }
 
+List collectNonByLangPaths(Map thing, Set byLangBaseProps, String id) {
+    def nonByLangPaths = []
+
+    DocumentUtil.findKey(thing, byLangBaseProps) { value, path ->
+        def stripped = value.toString().replaceAll(~/\p{IsCommon}|\p{IsInherited}|\p{IsUnknown}/, '')
+
+        if (stripped.isEmpty() || stripped.every { looksLikeScript(it, 'Latn') }) {
+            lost.println([id, path.join('.'), value].join('\t'))
+        } else {
+            nonByLangPaths.add(path.collect())
+        }
+
+        return
+    }
+
+    return nonByLangPaths
+}
+
+// Get array index right when the referenced object is contained in an array of size > 1
+// For example:
+// [publication, 0, place, label] -> [publication, 1, place, label]
+// [seriesMembership, 0, inSeries, instanceOf, hasTitle, 0, mainTitle] -> [seriesMembership, 0, inSeries, instanceOf, 1, hasTitle, 0, mainTitle]
+// Returns false if refPath is not a subpath of the adjusted path
+boolean adjustArrayIndices(List path, List refPath) {
+    def copy = path.collect()
+
+    if (path.any { it instanceof Integer }) {
+        for (int i : 0..<refPath.size()) {
+            if (path[i] instanceof String && refPath[i] instanceof String) {
+                if (path[i] != refPath[i]) {
+                    path.clear()
+                    path.addAll(copy)
+                    return false
+                }
+            } else if (path[i] instanceof Integer && refPath[i] instanceof Integer) {
+                if (path[i] != refPath[i]) {
+                    path[i] = refPath[i]
+                }
+            } else if (path[i] instanceof String && refPath[i] instanceof Integer) {
+                path.add(i, refPath[i])
+            } else if (path[i] instanceof Integer && refPath[i] instanceof String) {
+                path.removeAt(i)
+            }
+        }
+    }
+
+    return true
+}
+
+// Check if any array in the path is of size > 1
+boolean existRepeated(Map thing, List path) {
+    def copy = path.collect()
+
+    def existRepeated = path.findIndexValues { it instanceof Integer }
+            *.toInteger()
+            .any {
+                def obj = getAtPath(thing, path.take(it))
+                if (obj instanceof Map) {
+                    // Not an array at subpath location, adjust accordingly (bättre förklaring)
+                    path.removeAt(it)
+                }
+                return obj instanceof List && obj.size() > 1
+            }
+
+    if (existRepeated) {
+        path.clear()
+        path.addAll(copy)
+    }
+
+    return existRepeated
+}
+
+boolean looksLikeScript(String s, String scriptCode) {
+    Unicode.guessIso15924ScriptCode(s).map { it == scriptCode }.orElse(false)
+}
+
 class Util {
     def converter
     def langLinker
 
-    Map tLangCodes
-    Map langToTLang
     Map langAliases
-    Map langToLangTag
+    Map byLangToBase
+    Map langIdToLangTag
+
+    Set romanizableLangs
+
+    static final String TARGET_SCRIPT = 'Latn'
+    static final String MATCH_T_TAG = "-${TARGET_SCRIPT}-t-"
 
     static final String HAS_BIB880 = 'marc:hasBib880'
     static final String BIB880 = 'marc:bib880'
@@ -204,40 +313,18 @@ class Util {
     static final String IND2 = 'ind2'
     static final String ID = '@id'
 
-    List FIELDREFS = [FIELDREF, 'marc:bib035-fieldref', 'marc:bib041-fieldref',
-                      'marc:bib250-fieldref', 'marc:hold035-fieldref']
+    List FIELDREFS = [FIELDREF, 'marc:bib250-fieldref']
 
     Util(whelk) {
-        this.langLinker = whelk.languageResources.languageLinker
-        this.tLangCodes = getTLangCodes(whelk.languageResources.transformedLanguageForms)
-        this.langToTLang = getLangToTLangs(tLangCodes)
         this.langAliases = whelk.jsonld.langContainerAlias
-        this.langToLangTag = whelk.languageResources.languages
-                .findAll { it.value.langTag }.collectEntries { k, v ->  [k, v.langTag] }
-    }
-
-    static Map<String, Map> getTLangCodes(Map transformedLanguageForms) {
-        return transformedLanguageForms
-                .collectEntries { k, v ->
-                    def data = [:]
-                    if (v.inLanguage) {
-                        data.inLanguage = v.inLanguage['@id']
-                    }
-                    if (v.fromLangScript) {
-                        data.fromLangScript = v.fromLangScript['@id']
-                    }
-                    [v.langTag, data]
-                }
-    }
-
-    static Map<String, List> getLangToTLangs(Map tLangs) {
-        def langToTLangs = [:]
-
-        tLangs.each { code, data ->
-            def entry = langToTLangs.computeIfAbsent(data.inLanguage, x -> [])
-            entry.add(data.plus(['code': code]))
+        this.byLangToBase = langAliases.collectEntries { k, v -> [v, k] }
+        this.langIdToLangTag = whelk.languageResources.languages
+                .findAll { k, v -> v.langTag }.collectEntries { k, v -> [k, v.langTag] }
+        this.converter = whelk.marcFrameConverter
+        this.converter.conversion.doPostProcessing = false
+        this.langLinker = whelk.languageResources.languageLinker
+        this.romanizableLangs = whelk.languageResources.transformedLanguageForms.findResults { k, v ->
+            v.inLanguage?.'@id'
         }
-
-        return langToTLangs
     }
 }

--- a/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
+++ b/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
@@ -14,6 +14,7 @@ import whelk.filter.LanguageLinker
 moved = getReportWriter('moved.tsv')
 propertyAlreadyExists = getReportWriter('property-already-exists.tsv')
 langDiff = getReportWriter('lang-diff.tsv')
+hasFieldRef = getReportWriter('has-fieldref.txt')
 
 HAS_TITLE = 'hasTitle'
 MAIN_TITLE = 'mainTitle'
@@ -72,6 +73,10 @@ selectBySqlWhere(where) {
             return
         }
     } else {
+        if (expressionOf['marc:fieldref']) {
+            hasFieldRef.println(id)
+            return
+        }
         def expressionOfAsString = stringify(expressionOf)
         def prefTitle = localExpressionOfToPrefTitle[expressionOfAsString]
         if (prefTitle) {
@@ -143,7 +148,9 @@ void moveLanguagesFromTitle(Map expressionOf) {
     def languages = []
 
     asList(expressionOf[HAS_TITLE]).each { t ->
-        assert t[MAIN_TITLE] instanceof String
+        if (!t[MAIN_TITLE]) {
+            return
+        }
         def (mt, l) = splitTitleLanguages(t[MAIN_TITLE])
         if (l) {
             languages += l

--- a/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
+++ b/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
@@ -204,7 +204,7 @@ String stringifyProps(Map work, List props) {
 String stringifyTitle(Map work) {
     def titleKeys = ['mainTitle', 'partName', 'partNumber', 'marc:formSubheading']
     def paths = titleKeys.collect { [HAS_TITLE, 0] + it }
-    def titleParts = paths.collect { getAtPath(work, asList(it)) }.grep()
+    def titleParts = paths.collect { getAtPath(work, it) ?: getAtPath(work, it.dropRight(1) + [it.last() + 'byLang']) }.grep()
 
     return titleParts.join(' · ')
 }

--- a/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
+++ b/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
@@ -204,7 +204,10 @@ String stringifyProps(Map work, List props) {
 String stringifyTitle(Map work) {
     def titleKeys = ['mainTitle', 'partName', 'partNumber', 'marc:formSubheading']
     def paths = titleKeys.collect { [HAS_TITLE, 0] + it }
-    def titleParts = paths.collect { getAtPath(work, it) ?: getAtPath(work, it.dropRight(1) + [it.last() + 'byLang']) }.grep()
+    def titleParts = paths.collect {
+        getAtPath(work, it)
+            ?: getAtPath(work, it.dropRight(1) + [it.last() + 'byLang'])?.find { !it.key.contains('-t-') }?.value
+    }.grep()
 
     return titleParts.join(' · ')
 }

--- a/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
+++ b/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/expressionOf.groovy
@@ -32,7 +32,7 @@ localExpressionOfToPrefTitle = loadLocalExpressionOfToPrefTitleMappings('title-m
 linkedExpressionOfToPrefTitle = loadLinkedExpressionOfToPrefTitleMappings('title-mappings/linked-expressionOf.tsv')
 bibleToVersion = loadBibleVersions('title-mappings/bible-versions.tsv')
 
-TITLE_RELATED_PROPS = ['musicMedium', 'version', 'legalDate', 'originDate', 'originPlace', 'marc:arrangedStatementForMusic']
+TITLE_RELATED_PROPS = ['musicMedium', 'version', 'legalDate', 'originDate', 'marc:arrangedStatementForMusic']
 
 def where = """
     collection = 'bib'
@@ -212,17 +212,17 @@ String stringifyTitle(Map work) {
 // e.g. {"Bible. · [O.T., Psalms., Sternhold and Hopkins.] · eng": "Bibeln. Psaltaren"}
 Map loadLocalExpressionOfToPrefTitleMappings(String filename) {
     return new File(scriptDir, filename).readLines().drop(1).collectEntries {
-        def (hubTitle, stringifiedExpressionOf) = it.split('\t')
-        [stringifiedExpressionOf, hubTitle]
+        def (prefTitle, stringifiedExpressionOf) = it.split('\t')
+        [stringifiedExpressionOf, prefTitle]
     }
 }
 
 // e.g. {"https://libris.kb.se/0xbddxzj09vsjl9#it": "Bibeln. Haggai"}
 Map loadLinkedExpressionOfToPrefTitleMappings(String filename) {
     return new File(scriptDir, filename).readLines().drop(1).collectEntries {
-        def (uniformWorkTitleIri, hubTitle) = it.split('\t')
+        def (uniformWorkTitleIri, prefTitle) = it.split('\t')
         // replace only needed in test environments
-        [uniformWorkTitleIri.replace("https://libris.kb.se/", baseUri.toString()), hubTitle]
+        [uniformWorkTitleIri.replace("https://libris.kb.se/", baseUri.toString()), prefTitle]
     }
 }
 

--- a/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/work-title-to-translationOf.groovy
+++ b/whelktool/scripts/2023/03/lxl-3880-shuffle-work-titles/work-title-to-translationOf.groovy
@@ -6,6 +6,7 @@
 
 moved = getReportWriter('moved.tsv')
 propertyAlreadyExists = getReportWriter('property-already-exists.tsv')
+hasFieldRef = getReportWriter('has-fieldref.txt')
 
 HAS_TITLE = 'hasTitle'
 TRANSLATION_OF = 'translationOf'
@@ -58,6 +59,11 @@ boolean tryMoveTitle(Map work, String id, String via) {
         } else {
             return false
         }
+    }
+
+    if (work['marc:fieldref']) {
+        hasFieldRef.println(id)
+        return false
     }
 
     def translationOf = asList(work[TRANSLATION_OF])[0]


### PR DESCRIPTION
I've changed the script quite a lot since I think the last version was not reliable in several ways. This version is much more restrictive when it comes to choosing language, choosing where to insert values and throwing away values.

The more restrictive approach of course also means we won't handle all the Bib880s but at this stage I think this is good enough as preparation for moving work titles. Any fieldref associated with a work title left unhandled will now be reported for manual handling when we move work titles, shouldn't be too many.

We'll have to analyze the reports further to see how we can take care of the rest. More in [LXL-3908](https://jira.kb.se/browse/LXL-3908).

If we think this works well it's probably a good idea to move this logic into RomanizationStep.modify as well since it's currently a bit shaky.