### PR TITLE
Feature/translation of into has part on convert

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
@@ -43,9 +43,9 @@ class NormalizeWorkTitlesStep extends MarcFramePostProcStepBase {
     Closure doModify = { Map work, String via ->
         if (via == 'instanceOf') {
             langLinker.linkAll(work)
+            moveExpressionOfTitle(work)
+            moveTranslationOfIntoParts(work)
         }
-        moveExpressionOfTitle(work)
-        moveTranslationOfIntoParts(work)
         moveOriginalTitle(work)
     }
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
@@ -825,7 +825,7 @@
       }
     },
     {
-      "name": "hasPart: move title to translationOf",
+      "name": "hasPart: move translationOf into each part and then move titles to translationOf",
       "source": {
         "mainEntity": {
           "instanceOf": {
@@ -833,6 +833,16 @@
             "language": [
               {
                 "@id": "https://id.kb.se/language/eng"
+              }
+            ],
+            "translationOf": [
+              {
+                "@type": "Work",
+                "language": [
+                  {
+                    "@id": "https://id.kb.se/language/swe"
+                  }
+                ]
               }
             ],
             "hasPart": [
@@ -848,16 +858,6 @@
                     "@type": "Title",
                     "mainTitle": "DELENS TITEL"
                   }
-                ],
-                "translationOf": [
-                  {
-                    "@type": "Work",
-                    "language": [
-                      {
-                        "@id": "https://id.kb.se/language/swe"
-                      }
-                    ]
-                  }
                 ]
               },
               {
@@ -871,16 +871,6 @@
                   {
                     "@type": "Title",
                     "mainTitle": "DELENS TITEL"
-                  }
-                ],
-                "translationOf": [
-                  {
-                    "@type": "Work",
-                    "language": [
-                      {
-                        "@id": "https://id.kb.se/language/swe"
-                      }
-                    ]
                   }
                 ]
               }


### PR DESCRIPTION
We (me + Elisabet and Katja) came to the conclusion that it's better to move some than nothing at all (less manual work). 
On import this will move translationOf into each part in hasPart given that:
- There is exactly one instanceOf language
- There is exactly one instanceOf.translationOf language
- Every part has a title, no translationOf and exactly one language which the same as the instanceOf language.

Should be safe to do this!