### PR TITLE
Fix languages sometimes missing in transliteration API

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
@@ -96,7 +96,7 @@ class ElasticFind {
         p.put("_offset", [Integer.toString(offset)] as String[])
         p.put("_limit", [Integer.toString(PAGE_SIZE)] as String[])
 
-        p.putIfAbsent("_sort", ["_doc"] as String[])
+        p.putIfAbsent("_sort", ["_id"] as String[])
 
         return p
     }


### PR DESCRIPTION
Fix `ElasticFind.find`/`findIds` losing results

When results span multiple pages each page fetch might hit a different ES node. 
Sorting on `_doc` is not totally consistent across indices so some results would get lost. 
Sort on `_id` instead.

This showed up as languages sometimes missing in `Romanizer`.