### PR TITLE
Move only translated titles recursively

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
@@ -24,10 +24,6 @@ class NormalizeWorkTitlesStep extends MarcFramePostProcStepBase {
     LanguageLinker langLinker
 
     void modify(Map record, Map thing) {
-        _modify(record, thing)
-    }
-
-    void _modify(Map record, Map thing) {
         def work = thing[WORK_KEY]
         if (work instanceof Map) {
             langLinker?.linkAll(work)
@@ -38,10 +34,6 @@ class NormalizeWorkTitlesStep extends MarcFramePostProcStepBase {
     }
 
     void unmodify(Map record, Map thing) {
-       _unmodify(record, thing)
-    }
-
-    void _unmodify(Map record, Map thing) {
         def work = thing[WORK_KEY]
         if (work instanceof Map) {
             traverse(work, moveOriginalTitleToTranslation)

--- a/whelktool/scripts/cleanups/2023/04/resave-bib-records.groovy
+++ b/whelktool/scripts/cleanups/2023/04/resave-bib-records.groovy
@@ -1,0 +1,10 @@
+def where = """
+    collection = 'bib'
+    and deleted = false
+    and ( (modified > '2023-04-18' and modified < '2023-04-25')
+        or ( (data#>>'{@graph,0,generationDate}')::date > '2023-04-18' and (data#>>'{@graph,0,generationDate}')::date < '2023-04-25' ) )
+"""
+
+selectBySqlWhere(where) {
+    it.scheduleSave()
+}


### PR DESCRIPTION
Fixes LXL-4106. The problem was that `expressionOf` was constructed recursively for any work associated with the `instanceOf` property. 830 is not mapped to `expressionOf` in marcframe so the conversion fails when the title ends up in `seriesMembership.inSeries.instanceOf.expressionOf`. Now only the move from/to `translationOf` is done recursively.