### PR TITLE
Feature/safer bib880 conversion

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/NormalizeWorkTitlesStep.groovy
@@ -197,6 +197,6 @@ class NormalizeWorkTitlesStep extends MarcFramePostProcStepBase {
         def trlOfLang = trlOf ? asList(trlOf[LANGUAGE]) : []
         langLinker?.linkLanguages(expressionOf, workLang + trlOfLang)
         def exprOfLang = asList(expressionOf[LANGUAGE])
-        return (workLang + trlOfLang).containsAll(exprOfLang)
+        return exprOfLang.every { l -> (workLang + trlOfLang).any { l.subMap(['@id'] + langLinker?.fields).intersect(it) } }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -525,11 +525,11 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         List paths = []
 
         DocumentUtil.findKey(thing, byLangToBase.keySet()) { value, path ->
-            if (value instanceof Map && value.keySet().any { it =~ '-t-' }) {
-                paths.add(path.collect())
-            }
+            paths.add(path.collect())
             return
         }
+
+        paths = paths.findAll { DocumentUtil.getAtPath(thing, it).keySet().any { it =~ '-t-' } }
 
         return paths
     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -62,9 +62,12 @@ class RomanizationStep extends MarcFramePostProcStepBase {
     List FIELD_REFS = [FIELDREF, BIB250_REF]
 
     void modify(Map record, Map thing) {
+        def thingCopy = deepCopy(thing)
         try {
             _modify(record, thing)
         } catch (Exception e) {
+            thing.clear()
+            thing.putAll(thingCopy)
             log.error("Failed to convert 880: $e", e)
         }
     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -62,12 +62,13 @@ class RomanizationStep extends MarcFramePostProcStepBase {
     List FIELD_REFS = [FIELDREF, BIB250_REF]
 
     void modify(Map record, Map thing) {
-        def thingCopy = deepCopy(thing)
+        def bib880 = thing[HAS_BIB880]
         try {
             _modify(record, thing)
         } catch (Exception e) {
-            thing.clear()
-            thing.putAll(thingCopy)
+            if (bib880) {
+                thing[HAS_BIB880] = bib880
+            }
             log.error("Failed to convert 880: $e", e)
         }
     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -524,11 +524,11 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         List paths = []
 
         DocumentUtil.findKey(thing, byLangToBase.keySet()) { value, path ->
-            paths.add(path.collect())
+            if (value instanceof Map && value.keySet().any { it =~ '-t-' }) {
+                paths.add(path.collect())
+            }
             return
         }
-
-        paths = paths.findAll { DocumentUtil.getAtPath(thing, it).keySet().any { it =~ '-t-' } }
 
         return paths
     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -63,6 +63,9 @@ class RomanizationStep extends MarcFramePostProcStepBase {
 
     void modify(Map record, Map thing) {
         def bib880 = thing[HAS_BIB880]
+        if (!bib880) {
+            return
+        }
         try {
             _modify(record, thing)
         } catch (Exception e) {
@@ -294,7 +297,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
 
             seqNumToBib880Data[seqNum] = [
                     'ref'          : ref.get(),
-                    'converted'    : converted.get()['mainEntity'],
+                    'converted'    : converter.conversion.flatLinkedForm ? converted.get()['@graph'][1] : converted.get()['mainEntity'],
                     'idxOfOriginal': i
             ]
         }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -69,7 +69,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
             if (bib880) {
                 thing[HAS_BIB880] = bib880
             }
-            log.error("Failed to convert 880: $e", e)
+            log.error("Failed to convert 880 for record ${record[ID]}: $e", e)
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy
@@ -173,7 +173,7 @@ class RomanizationStep extends MarcFramePostProcStepBase {
         try {
             _unmodify(record, thing)
         } catch (Exception e) {
-            log.error("Failed to convert 880: $e", e)
+            log.error("Failed to convert 880 for record ${record[ID]}: $e", e)
         }
     }
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-normalizeworktitles.json
@@ -627,10 +627,12 @@
             "@type": "Text",
             "language": [
               {
-                "@id": "https://id.kb.se/language/gre"
+                "@id": "https://id.kb.se/language/gre",
+                "code": "gre"
               },
               {
-                "@id": "https://id.kb.se/language/eng"
+                "@id": "https://id.kb.se/language/eng",
+                "code": "eng"
               }
             ],
             "expressionOf": {
@@ -659,10 +661,12 @@
             "@type": "Text",
             "language": [
               {
-                "@id": "https://id.kb.se/language/gre"
+                "@id": "https://id.kb.se/language/gre",
+                "code": "gre"
               },
               {
-                "@id": "https://id.kb.se/language/eng"
+                "@id": "https://id.kb.se/language/eng",
+                "code": "eng"
               }
             ],
             "hasTitle": [


### PR DESCRIPTION
By resetting `thing` we don't risk losing any data should an exception occur between where we remove `marc:hasBib880` (line 95) and where we put it back in place (line 168). This _may_ solve https://jira.kb.se/browse/LXL-4112 (needs more investigation). For the better regardless.

Should also fix the following (from whelk log):
```
ERROR whelk.converter.marc.RomanizationStep - Failed to convert 880: groovy.lang.MissingMethodException: No signature of method: java.util.ArrayList.
keySet() is applicable for argument types: () values: []
Possible solutions: toSet(), toSet(), set(int, java.lang.Object), set(int, java.lang.Object), get(int), get(int)
groovy.lang.MissingMethodException: No signature of method: java.util.ArrayList.keySet() is applicable for argument types: () values: []
Possible solutions: toSet(), toSet(), set(int, java.lang.Object), set(int, java.lang.Object), get(int), get(int)
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:70) ~[groovy-3.0.9.jar:3.0.9]
        at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46) ~[groovy-3.0.9.jar:3.0.9]
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47) ~[groovy-3.0.9.jar:3.0.9]
        at java_util_Map$keySet$1.call(Unknown Source) ~[?:?]
        at whelk.converter.marc.RomanizationStep$_findByLangPaths_closure26.doCall(RomanizationStep.groovy:528) ~[whelk-core.jar:?
```
