### PR TITLE
Index blank works

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -920,14 +920,16 @@ class Document {
         
         record["mainEntity"]["@id"] = workId
         record["@id"] = record["@id"] + "#work-record"
-        record["@type"] = "VirtualRecord"
+        // record["@type"] = "VirtualRecord"
+        
+        instance.remove('instanceOf')
         
         work["@id"] = workId
-        work["@reverse"] = ["instanceOf": [["@id": instance["@id"]]]]
+        work["@reverse"] = ["instanceOf": [instance]]
         
         // TODO...
         if (!work['hasTitle']) {
-            work['hasTitle'] = (instance['hasTitle'] ?: []).collect{ it['@type'] == 'Title' || it['@type'] == 'KeyTitle' }
+            work['hasTitle'] = (instance['hasTitle'] ?: []).findAll{ it['@type'] == 'Title' || it['@type'] == 'KeyTitle' }
         }
 
         doc.set(["@graph", 1], work)

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -920,6 +920,11 @@ class Document {
         
         record["mainEntity"]["@id"] = workId
         record["@id"] = record["@id"] + "#work-record"
+        // TODO
+        // For now these will not be found by the search API since it has a boost on RECORD_TYPE and CACHE_RECORD_TYPE
+        // This is what we want since VirtualRecords should not be visible in the cataloguing interface.
+        // When we have unified the new "query language" search API with the current search API we need a different mechanism
+        // for separating them
         record["@type"] = JsonLd.VIRTUAL_RECORD_TYPE
         
         instance.remove('instanceOf')

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -925,14 +925,15 @@ class Document {
         def workId = instance["@id"].replace('#it', '') + "#work"
         
         record["mainEntity"]["@id"] = workId
-        record["@id"] = record["@id"] + "-work"
+        record["@id"] = record["@id"] + "#work-record"
         //record["@type"] = "VirtualRecord"
         
         work["@id"] = workId
         work["@reverse"] = ["instanceOf": [["@id": instance["@id"]]]]
         
+        // TODO...
         if (!work['hasTitle']) {
-            work['hasTitle'] = instance['hasTitle']
+            work['hasTitle'] = (instance['hasTitle'] ?: []).collect{ it['@type'] == 'Title' || it['@type'] == 'KeyTitle' }
         }
 
         doc.set(["@graph", 1], work)

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -902,7 +902,7 @@ class Document {
 
     Set<String> getVirtualRecordIds() {
         Map work = get(["@graph", 1, "instanceOf"])
-        return (!work || JsonLd.isLink(work) || isSuppressedRecord()) 
+        return (!work || JsonLd.isLink(work) || isSuppressedRecord() || work instanceof List)
             ? []
             : [ "${getShortId()}#work-record" ]
     }

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -920,7 +920,7 @@ class Document {
         
         record["mainEntity"]["@id"] = workId
         record["@id"] = record["@id"] + "#work-record"
-        // record["@type"] = "VirtualRecord"
+        record["@type"] = JsonLd.VIRTUAL_RECORD_TYPE
         
         instance.remove('instanceOf')
         

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -902,9 +902,15 @@ class Document {
 
     Set<String> getBlankNodeIds() {
         Map work = get(["@graph", 1, "instanceOf"])
-        return (!work || JsonLd.isLink(work)) 
+        return (!work || JsonLd.isLink(work) || isSuppressedRecord()) 
             ? []
             : [ "${getShortId()}#work" ]
+    }
+    
+    boolean isSuppressedRecord() {
+        (get(["@graph", 0, "technicalNote"]) ?: []).any { 
+            it instanceof Map && it.label == 'SUPPRESSRECORD' && it[JsonLd.TYPE_KEY] == 'TechnicalNote'
+        }
     }
 
     Document centerOn(String id) {
@@ -919,6 +925,7 @@ class Document {
         def workId = instance["@id"].replace('#it', '') + "#work"
         
         record["mainEntity"]["@id"] = workId
+        record["@id"] = record["@id"] + "-work"
         //record["@type"] = "VirtualRecord"
         
         work["@id"] = workId

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -900,21 +900,15 @@ class Document {
         return "{completeId=" + getCompleteId() + ", baseUri=" + baseUri.toString() + ", base identifiers:" + getRecordIdentifiers().join(',');
     }
 
-    Set<String> getBlankNodeIds() {
+    Set<String> getVirtualRecordIds() {
         Map work = get(["@graph", 1, "instanceOf"])
         return (!work || JsonLd.isLink(work) || isSuppressedRecord()) 
             ? []
-            : [ "${getShortId()}#work" ]
+            : [ "${getShortId()}#work-record" ]
     }
     
-    boolean isSuppressedRecord() {
-        (get(["@graph", 0, "technicalNote"]) ?: []).any { 
-            it instanceof Map && it.label == 'SUPPRESSRECORD' && it[JsonLd.TYPE_KEY] == 'TechnicalNote'
-        }
-    }
-
-    Document centerOn(String id) {
-        if ("${getShortId()}#work" != id) {
+    Document getVirtualRecord(String id) {
+        if ("${getShortId()}#work-record" != id) {
             throw new IllegalArgumentException(id)
         }
         
@@ -926,7 +920,7 @@ class Document {
         
         record["mainEntity"]["@id"] = workId
         record["@id"] = record["@id"] + "#work-record"
-        //record["@type"] = "VirtualRecord"
+        record["@type"] = "VirtualRecord"
         
         work["@id"] = workId
         work["@reverse"] = ["instanceOf": [["@id": instance["@id"]]]]
@@ -939,5 +933,11 @@ class Document {
         doc.set(["@graph", 1], work)
         
         return doc
+    }
+
+    private boolean isSuppressedRecord() {
+        (get(["@graph", 0, "technicalNote"]) ?: []).any {
+            it instanceof Map && it.label == 'SUPPRESSRECORD' && it[JsonLd.TYPE_KEY] == 'TechnicalNote'
+        }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/FeatureFlags.java
+++ b/whelk-core/src/main/groovy/whelk/FeatureFlags.java
@@ -1,0 +1,37 @@
+package whelk;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FeatureFlags {
+    final static Logger log = LogManager.getLogger(FeatureFlags.class);
+    
+    public enum Flag {
+        INDEX_BLANK_WORKS
+    }
+
+    private Set<Flag> enabled = new HashSet<>();
+    
+    public FeatureFlags(Properties whelkConfig) {
+        Arrays.stream(whelkConfig.getProperty("features", "").split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .forEach(flag -> {
+                    try {
+                        enabled.add(Flag.valueOf(flag));
+                        log.info(String.format("Enabled feature: %s", flag));
+                    } catch (IllegalArgumentException ignored) {
+                        log.warn(String.format("Unknown feature flag, ignoring: %s", flag));
+                    }
+                });
+    }
+    
+    public boolean isEnabled(Flag flag) {
+        return enabled.contains(flag);
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -42,7 +42,8 @@ class JsonLd {
 
     static final String RECORD_TYPE = 'Record'
     static final String CACHE_RECORD_TYPE = 'CacheRecord'
-    
+    static final String VIRTUAL_RECORD_TYPE = 'VirtualRecord'
+
     static final String SEARCH_KEY = "_str"
 
     static final List<String> NS_SEPARATORS = ['#', '/', ':']

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -296,8 +296,8 @@ class Whelk {
         indexAsyncOrSync {
             elastic.index(updated, this)
             if (features.isEnabled(INDEX_BLANK_WORKS)) {
-                (preUpdateDoc.getBlankNodeIds() - updated.getBlankNodeIds()).each { elastic.remove(it) }
-                updated.getBlankNodeIds().each {elastic.index(updated.centerOn(it), this) }
+                (preUpdateDoc.getVirtualRecordIds() - updated.getVirtualRecordIds()).each { elastic.remove(it) }
+                updated.getVirtualRecordIds().each {elastic.index(updated.getVirtualRecord(it), this) }
             }
             if (!skipIndexDependers) {
                 if (hasChangedMainEntityId(updated, preUpdateDoc)) {
@@ -446,7 +446,7 @@ class Whelk {
             indexAsyncOrSync {
                 elastic.index(document, this)
                 if (features.isEnabled(INDEX_BLANK_WORKS)) {
-                    document.getBlankNodeIds().each {elastic.index(document.centerOn(it), this) }
+                    document.getVirtualRecordIds().each {elastic.index(document.getVirtualRecord(it), this) }
                 }
                 if (!skipIndexDependers) {
                     reindexAffected(document, new TreeSet<>(), document.getExternalRefs())
@@ -520,7 +520,7 @@ class Whelk {
             indexAsyncOrSync {
                 elastic.remove(id)
                 if (features.isEnabled(INDEX_BLANK_WORKS)) {
-                    doc.getBlankNodeIds().each { elastic.remove(it) }
+                    doc.getVirtualRecordIds().each { elastic.remove(it) }
                 }
                 if (!skipIndexDependers) {
                     reindexAffected(doc, doc.getExternalRefs(), Collections.emptySet())

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -17,6 +17,7 @@ import whelk.util.Unicode
 
 import java.util.concurrent.LinkedBlockingQueue
 
+import static whelk.FeatureFlags.Flag.INDEX_BLANK_WORKS
 import static whelk.JsonLd.asList
 import static whelk.exception.UnexpectedHttpStatusException.isBadRequest
 import static whelk.exception.UnexpectedHttpStatusException.isNotFound
@@ -210,6 +211,28 @@ class ElasticSearch {
                     return null
                 }
             }.join('')
+
+            if (whelk.features.isEnabled(INDEX_BLANK_WORKS)) {
+                String bulkString2 = docs
+                        .collect { doc -> doc.getBlankNodeIds().collect {doc.centerOn(it) } }
+                        .flatten()
+                        .findResults{ Document doc ->
+                            try {
+                                String shapedData = getShapeForIndex(doc, whelk)
+                                String action = createActionRow(doc)
+                                return "${action}\n${shapedData}\n"
+                            } catch (Exception e) {
+                                if (doc.getShortId() == null) {
+                                    log.error("Document has null shortId, something is wrong. Some details: " + doc.toVerboseString(), e);
+                                } else {
+                                    log.error("Failed to index ${doc.getShortId()} in elastic: $e", e)
+                                }
+                                return null
+                            }
+                        }.join('')
+
+                bulkString += bulkString2
+            }
 
             if (bulkString) {
                 String response = bulkClient.performRequest('POST', '/_bulk', bulkString, BULK_CONTENT_TYPE)

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -214,7 +214,7 @@ class ElasticSearch {
 
             if (whelk.features.isEnabled(INDEX_BLANK_WORKS)) {
                 String bulkString2 = docs
-                        .collect { doc -> doc.getBlankNodeIds().collect {doc.centerOn(it) } }
+                        .collect { doc -> doc.getVirtualRecordIds().collect {doc.getVirtualRecord(it) } }
                         .flatten()
                         .findResults{ Document doc ->
                             try {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -630,7 +630,7 @@ class ElasticSearch {
         if (id.contains("/")) {
             return Base64.encodeBase64URLSafeString(id.getBytes("UTF-8"))
         } else {
-            return id // If XL-minted identifier, use the same charsequence
+            return id.replace('#', '_') // If XL-minted identifier, use the same charsequence
         }
     }
     

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -48,6 +48,10 @@ class ESQuery {
                             'boost': 1000.0
                     ]],
                     ['constant_score': [
+                            'filter': [ 'term': [ (JsonLd.RECORD_KEY + '.' + JsonLd.TYPE_KEY) : JsonLd.VIRTUAL_RECORD_TYPE ]],
+                            'boost': 900.0
+                    ]],
+                    ['constant_score': [
                             'filter': [ 'term': [ (JsonLd.RECORD_KEY + '.' + JsonLd.TYPE_KEY) : JsonLd.CACHE_RECORD_TYPE ]],
                             'boost': 1.0
                     ]]

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -48,10 +48,6 @@ class ESQuery {
                             'boost': 1000.0
                     ]],
                     ['constant_score': [
-                            'filter': [ 'term': [ (JsonLd.RECORD_KEY + '.' + JsonLd.TYPE_KEY) : JsonLd.VIRTUAL_RECORD_TYPE ]],
-                            'boost': 900.0
-                    ]],
-                    ['constant_score': [
                             'filter': [ 'term': [ (JsonLd.RECORD_KEY + '.' + JsonLd.TYPE_KEY) : JsonLd.CACHE_RECORD_TYPE ]],
                             'boost': 1.0
                     ]]


### PR DESCRIPTION
Add a new feature flag INDEX_BLANK_WORKS.
When enabled blank/local works are indexed as separate documents in ES so that the can be searched in the same way as linked stand-alone works.

If this works well and the need arises we could rewrite it in a more general fashion. Using vocab to decide what to index.