### PR TITLE
Fix ISO 9:1995 -> ISO/R 9:1968 for slavic languages

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/Romanizer.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Romanizer.groovy
@@ -21,19 +21,19 @@ class Romanizer {
     ]
 
     private static final List<Transform> AUTO = [
-            auto('be-Cyrl',  'be-Latn-t-be-Cyrl-m0-iso-1995', ['be-iso.txt', 'slavic-iso.txt']),
-            auto('bg-Cyrl',  'bg-Latn-t-bg-Cyrl-m0-iso-1995', ['bg-iso.txt', 'slavic-iso.txt']),
-            auto('bs-Cyrl',  'bs-Latn-t-bs-Cyrl-m0-iso-1995', ['bs-sr-iso.txt', 'slavic-iso.txt']),
+            auto('be-Cyrl',  'be-Latn-t-be-Cyrl-m0-iso-1968', ['be-iso.txt', 'slavic-iso.txt']),
+            auto('bg-Cyrl',  'bg-Latn-t-bg-Cyrl-m0-iso-1968', ['bg-iso.txt', 'slavic-iso.txt']),
+            auto('bs-Cyrl',  'bs-Latn-t-bs-Cyrl-m0-iso-1968', ['bs-sr-iso.txt', 'slavic-iso.txt']),
             auto('el'     ,  'el-Latn-t-el-Grek-x0-btj', ['el-btj.txt']),
             auto('grc'    ,  'grc-Latn-t-grc-Grek-x0-skr-1980', ['grc-skr.txt']),
             auto('yi-Hebr',  'yi-Latn-t-yi-Hebr-x0-yivo', ['yi-yivo.txt']),
             auto('yi-Hebr',  'yi-Latn-t-yi-Hebr-m0-alaloc', ['yi-alaloc.txt']),
             auto('kk-Cyrl',  'kk-Latn-t-kk-Cyrl-m0-iso-1995', ['kk-iso.txt']),
-            auto('mk-Cyrl',  'mk-Latn-t-mk-Cyrl-m0-iso-1995', ['mk-iso.txt', 'slavic-iso.txt']),
+            auto('mk-Cyrl',  'mk-Latn-t-mk-Cyrl-m0-iso-1968', ['mk-iso.txt', 'slavic-iso.txt']),
             auto('mn-Cyrl',  'mn-Latn-t-mn-Cyrl-x0-lessing', ['mn-lessing.txt']),
-            auto('ru-Cyrl',  'ru-Latn-t-ru-Cyrl-m0-iso-1995', ['ru-iso.txt', 'slavic-iso.txt']),
-            auto('sr-Cyrl',  'sr-Latn-t-sr-Cyrl-m0-iso-1995', ['bs-sr-iso.txt', 'slavic-iso.txt']),
-            auto('uk-Cyrl',  'uk-Latn-t-uk-Cyrl-m0-iso-1995', ['uk-iso.txt', 'slavic-iso.txt']),
+            auto('ru-Cyrl',  'ru-Latn-t-ru-Cyrl-m0-iso-1968', ['ru-iso.txt', 'slavic-iso.txt']),
+            auto('sr-Cyrl',  'sr-Latn-t-sr-Cyrl-m0-iso-1968', ['bs-sr-iso.txt', 'slavic-iso.txt']),
+            auto('uk-Cyrl',  'uk-Latn-t-uk-Cyrl-m0-iso-1968', ['uk-iso.txt', 'slavic-iso.txt']),
 
             // Converted from LOC mappings
             // TODO: investigate how well these handle case/capitalization

--- a/whelk-core/src/main/resources/romanizer/el-btj.txt
+++ b/whelk-core/src/main/resources/romanizer/el-btj.txt
@@ -3,7 +3,7 @@
 # Modern greek
 # "Transkriberingsschema för nygrekisk skrift efter Bibliotekstjänsts förslag till praxis för folkbiblioteken"
 # https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c36160a/1601918887752/Transkriberingsschema%20f%C3%B6r%20nygrekisk%20skrift.pdf
-# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman
+# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/libris-romaniseringspraxis
 
 :: NFD (NFC) ; # decompose to treat diacritics separately
 

--- a/whelk-core/src/main/resources/romanizer/grc-skr.txt
+++ b/whelk-core/src/main/resources/romanizer/grc-skr.txt
@@ -3,7 +3,7 @@
 # Ancient greek
 # "Gammalgrekiska texter (från före 1454) translittereras enligt schema fastlagt för vetenskapliga bibliotek i Svenska katalogiseringsregler 1980 (SKR)"
 # https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c361608/1601918851828/Grekiska%20alfabetet.pdf
-# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman#h-Gammalgrekiska
+# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/libris-romaniseringspraxis#h-Gammalgrekiska
 
 :: NFC (NFD);
 

--- a/whelk-core/src/main/resources/romanizer/kk-iso.txt
+++ b/whelk-core/src/main/resources/romanizer/kk-iso.txt
@@ -4,7 +4,7 @@
 # "Kyrillisk skrift för icke slaviska språk enligt ISO 9:1995"
 # "Table for Cyrillic characters of non-Slavic languages"
 # https://metadatabyran.kb.se/download/18.4810e090180d0919bf4609/1653052278416/Table%20for%20Cyrillic%20characters%20of%20non-Slavic%20languages.pdf
-# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman#h-Kazakiska
+# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/libris-romaniseringspraxis#h-Kazakiska
 
 # TODO: Some of these have multiple options in the spec. Review and pick the most likely one?
 

--- a/whelk-core/src/main/resources/romanizer/mn-lessing.txt
+++ b/whelk-core/src/main/resources/romanizer/mn-lessing.txt
@@ -3,7 +3,7 @@
 # Mongolian
 # "Ferdinand Lessings schema för Mongoliska"
 # https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c361600/1601917488493/Mongoliska,%20Lessings%20transkription.pdf
-# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman
+# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/libris-romaniseringspraxis
 # "Extratecknen Ө, ө romaniseras som svenskt Ö, ö och extratecknen Ү, ү som svenskt Ü, ü."
 
 # Note about 'е' and 'ю'

--- a/whelk-core/src/main/resources/romanizer/slavic-iso.txt
+++ b/whelk-core/src/main/resources/romanizer/slavic-iso.txt
@@ -1,9 +1,9 @@
 # ICU transform rules
 
 # Common base for slavic languages in cyrillic script.
-# "Kyrillisk skrift för slaviska språk enligt ISO 9:1995"
+# "Kyrillisk skrift för slaviska språk enligt ISO/R 9:1968"
 # https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c3615fe/1601917435290/Kyrilliska%20alfabetet.pdf
-# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman#h-Kyrilliskskrift
+# https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/libris-romaniseringspraxis#h-Kyrilliskskrift
 
 # А а a
 \u0410 <> A ;

--- a/whelk-core/src/test/groovy/whelk/util/RomanizerSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/RomanizerSpec.groovy
@@ -86,7 +86,7 @@ class RomanizerSpec extends Specification {
 
     def "Russian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'ru')['ru-Latn-t-ru-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'ru')['ru-Latn-t-ru-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/dtmgzm6wb09mh1vl#it
@@ -118,7 +118,7 @@ class RomanizerSpec extends Specification {
 
     def "Belarusian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'be')['be-Latn-t-be-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'be')['be-Latn-t-be-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/p408wtcjm06kz192#it
@@ -134,7 +134,7 @@ class RomanizerSpec extends Specification {
 
     def "Bosnian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'bs')['bs-Latn-t-bs-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'bs')['bs-Latn-t-bs-Cyrl-m0-iso-1968'] == target
         where:
         source           || target
         // https://libris.kb.se/5m0smjhb3d66cj4c#it
@@ -143,7 +143,7 @@ class RomanizerSpec extends Specification {
     
     def "Bulgarian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'bg')['bg-Latn-t-bg-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'bg')['bg-Latn-t-bg-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/fzr6pkkr2vnc152#it
@@ -156,7 +156,7 @@ class RomanizerSpec extends Specification {
 
     def "Macedonian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'mk')['mk-Latn-t-mk-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'mk')['mk-Latn-t-mk-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/wbxc6926tctq1kz6#it
@@ -168,7 +168,7 @@ class RomanizerSpec extends Specification {
 
     def "Serbian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'sr')['sr-Latn-t-sr-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'sr')['sr-Latn-t-sr-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/2dbbcc810dxjnk9l#it
@@ -179,7 +179,7 @@ class RomanizerSpec extends Specification {
 
     def "Ukrainian with ISO"() {
         expect:
-        new Romanizer().romanize(source, 'uk')['uk-Latn-t-uk-Cyrl-m0-iso-1995'] == target
+        new Romanizer().romanize(source, 'uk')['uk-Latn-t-uk-Cyrl-m0-iso-1968'] == target
         where:
         source || target
         // https://libris.kb.se/n2wmnf2hll6cn6vg#it 	

--- a/whelktool/scripts/cleanups/2023/05/lxl-4166-iso-1995-iso-1968.groovy
+++ b/whelktool/scripts/cleanups/2023/05/lxl-4166-iso-1995-iso-1968.groovy
@@ -1,0 +1,23 @@
+import whelk.util.DocumentUtil
+
+def where = """
+    (collection = 'bib' OR collection = 'hold' OR collection = 'auth')
+    AND deleted = false
+    AND modified > '2023-01-01'
+"""
+
+selectBySqlWhere(where) { doc ->
+    DocumentUtil.traverse(doc.graph) { value, path ->
+        if (path && ((String) path.last()).endsWith('ByLang') && value instanceof Map) {
+            var iso1995 = value.keySet().findAll { it.contains('iso-1995') && !it.contains('kk-Latn-t-kk-Cyrl') }
+
+            iso1995.each { String langTag ->
+                incrementStats('Replaced', langTag)
+                value.put(langTag.replace('1995', '1968'), value[langTag])
+                value.remove(langTag)
+                doc.scheduleSave()
+            }
+            return DocumentUtil.NOP
+        }
+    }
+}


### PR DESCRIPTION
The romanization table used in Libris is and has always been ISO/R 9:1968.
But it was incorrectly labeled as ISO 9:1995.

ISO 9:1995 is used for Kazakh (kk) only.

Depends on https://github.com/libris/definitions/pull/438