### PR TITLE
Experimental/manifest technical note

### DIFF
--- a/whelk-core/src/main/groovy/se/kb/libris/SignificantChangeCalculator.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/SignificantChangeCalculator.groovy
@@ -1,0 +1,44 @@
+package se.kb.libris
+
+import whelk.Document
+import whelk.JsonLd
+
+class SignificantChangeCalculator {
+
+    /**
+     * Compares two versions of a document, and mutates postupdateDoc with added
+     * ChangeNotes where applicable.
+     */
+    public static boolean markSignificantChanges(Document preUpdateDoc, Document postUpdateDoc, Date modTime, JsonLd jsonld) {
+        List<String> markersToAdd = []
+
+        if (significallyChangedAgent(preUpdateDoc, postUpdateDoc, jsonld))
+            markersToAdd.add("https://libris.kb.se/change/agent")
+
+        // Add additional rules..
+
+        if (!postUpdateDoc.data["technicalNote"] || ! postUpdateDoc.data["technicalNote"] instanceof List)
+            postUpdateDoc.data["technicalNote"] = []
+        for (String marker : markersToAdd) {
+            List techNotes = postUpdateDoc.data["technicalNote"]
+            techNotes.add(
+                    [
+                            "@type": "ChangeNote",
+                            "category": ["@id": marker],
+                            "date": modTime.toInstant().toString()
+                    ]
+            )
+        }
+    }
+
+    private static boolean significallyChangedAgent(Document preUpdateDoc, Document postUpdateDoc, JsonLd jsonld) {
+        if ( ! jsonld.isSubClassOf( preUpdateDoc.getThingType(), "Agent") ||
+             ! jsonld.isSubClassOf( postUpdateDoc.getThingType(), "Agent"))
+            return false
+
+        return preUpdateDoc.data["@graph"][1]["name"] != postUpdateDoc.data["@graph"][1]["name"] ||
+               preUpdateDoc.data["@graph"][1]["givenName"] != postUpdateDoc.data["@graph"][1]["givenName"] ||
+               preUpdateDoc.data["@graph"][1]["familyName"] != postUpdateDoc.data["@graph"][1]["familyName"] ||
+               preUpdateDoc.data["@graph"][1]["lifeSpan"] != postUpdateDoc.data["@graph"][1]["lifeSpan"]
+    }
+}

--- a/whelk-core/src/main/groovy/se/kb/libris/SignificantChangeCalculator.groovy
+++ b/whelk-core/src/main/groovy/se/kb/libris/SignificantChangeCalculator.groovy
@@ -5,6 +5,28 @@ import whelk.JsonLd
 
 class SignificantChangeCalculator {
 
+    public static Map getImpliedTechnicalNote(Map note, List typedPath, JsonLd jsonld) {
+
+        // Are conditions met for an implied primary-contribution marker?
+        // In other words: Is this (change-) 'note' a '/change/agent' placed on a primaryContribution (or derivative) path?
+        if ( typedPathEndsWith(typedPath, ["contribution", "@type=PrimaryContribution", "agent", "@type=Agent", "technicalNote", "@type=ChangeNote"], jsonld) ) {
+            if (note["category"] && note["category"] instanceof Map && note["category"]["@id"] && note["category"]["@id"] instanceof String) {
+                if (note["category"]["@id"] == "https://libris.kb.se/change/agent") {
+                    return [
+                            "@type"   : "ChangeNote",
+                            "category": ["@id": "https://libris.kb.se/change/primarycontribution"],
+                            "date"    : note["date"]
+                    ]
+                }
+            }
+        }
+
+        // Check for additional implied markers..
+
+        // Default: Return the original note
+        return note
+    }
+
     /**
      * Compares two versions of a document, and mutates postupdateDoc with added
      * ChangeNotes where applicable.
@@ -37,6 +59,32 @@ class SignificantChangeCalculator {
                 postUpdateDoc.data["@graph"][1]["technicalNote"] = newTechNotes
             }
         }
+    }
+
+    /**
+     * Types in 'full' are allowed to inherit types in 'end' and still be considered equal-ending.
+     *
+     * For example, full = ["instanceOf", "@type=NotatedMusic"] and end = ["instanceOf", "@type=Work"] is considered
+     * equal-ending, but if 'full' and 'end' switch places, they are not.
+     */
+    private static boolean typedPathEndsWith(List<String> full, List<String> end, JsonLd jsonLd) {
+        if (end.size() > full.size())
+            return false
+        List fullEnd = full.subList(full.size() - end.size(), full.size())
+
+        for (int i = 0; i < end.size(); ++i) {
+            if (fullEnd[i].startsWith("@type=") && end[i].startsWith("@type=")) {
+                String t1 = fullEnd[i].substring("@type=".length())
+                String t2 = end[i].substring("@type=".length())
+                if (! jsonLd.isSubClassOf(t1, t2) ) {
+                    return false
+                }
+            }
+            else if (fullEnd[i] != end[i]) {
+                return false
+            }
+        }
+        return true
     }
 
     private static boolean significantlyChangedAgent(Document preUpdateDoc, Document postUpdateDoc, JsonLd jsonld) {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1156,6 +1156,8 @@ class JsonLd {
 
     private static boolean shouldAlwaysKeep(String key) {
         return key == RECORD_KEY || key == THING_KEY || key == JSONLD_ALT_ID_KEY || key.startsWith("@")
+                // Temporary hack to make technical notes actually inherit/be embellishable
+                || key == "technicalNote" || key == "category" || key == "date" || key == "givenName" || key == "familyName"
     }
 
 

--- a/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
@@ -200,6 +200,11 @@ class JsonLdValidator {
     }
 
     private void verifyVocabTerm(String key, value, validation) {
+
+        // Temporary, until "ChangeNote" can be added to vocab
+        if (key == "@type" && value == "ChangeNote")
+            return
+
         if ((key == jsonLd.TYPE_KEY || isVocabTerm(key))
                 && !jsonLd.vocabIndex.containsKey(value?.toString())) {
             handleError(new Error(Error.Type.UNKNOWN_VOCAB_VALUE, key, value), validation)

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -307,9 +307,104 @@ class ElasticSearch {
         }
     }
 
+    /**
+     * Types in 'full' are allowed to inherit types in 'end' and still be considered equal-ending.
+     *
+     * For example, full = ["instanceOf", "@type=NotatedMusic"] and end = ["instanceOf", "@type=Work"] is considered
+     * equal-ending, but if 'full' and 'end' switch places, they are not.
+     */
+    boolean typedPathEndsWith(List<String> full, List<String> end, JsonLd jsonLd) {
+        if (end.size() > full.size())
+            return false
+        List fullEnd = full.subList(full.size() - end.size(), full.size())
+
+        for (int i = 0; i < end.size(); ++i) {
+            if (fullEnd[i].startsWith("@type=") && end[i].startsWith("@type=")) {
+                String t1 = fullEnd[i].substring("@type=".length())
+                String t2 = end[i].substring("@type=".length())
+                if (! jsonLd.isSubClassOf(t1, t2) ) {
+                    return false
+                }
+            }
+            else if (fullEnd[i] != end[i]) {
+                return false
+            }
+        }
+        return true
+    }
+
+    Map getImpliedTechnicalNote(Map note, List typedPath, JsonLd jsonld) {
+
+        //System.err.println("\ttesting "+ typedPath)
+
+        // Are conditions met for an implied primary-contribution marker?
+        if ( typedPathEndsWith(typedPath, ["contribution", "@type=PrimaryContribution", "agent", "@type=Agent", "technicalNote", "@type=ChangeNote"], jsonld) ) {
+            System.err.println("\tFound an inherited note: " + note)
+            if (note["category"] && note["category"] instanceof Map && note["category"]["@id"] && note["category"]["@id"] instanceof String) {
+                if (note["category"]["@id"] == "https://libris.kb.se/change/agent") {
+                    System.err.println("\t\tpc implied!")
+                    return [
+                            "@type"   : "ChangeNote",
+                            "category": ["@id": "https://libris.kb.se/change/primarycontribution"],
+                            "date"    : note["date"]
+                    ]
+                }
+            }
+        }
+
+        // Default: Return the original note
+        return note
+    }
+
+    Set collectTechnicalNotes(Object data, List typedPath, JsonLd jsonld) {
+        Set results = []
+        if (data instanceof Map) {
+
+            if ("ChangeNote" == data["@type"]) {
+                results.add( getImpliedTechnicalNote(data, typedPath, jsonld) )
+                results.add( data )
+            }
+
+            data.keySet().each {
+                List<String> nextPath = new ArrayList<>(typedPath)
+                nextPath.add(it)
+                if (data[it] instanceof Map && data[it]["@type"])
+                    nextPath.add("@type=" + data[it]["@type"])
+                results.addAll(collectTechnicalNotes(data[it], nextPath, jsonld))
+            }
+        } else if (data instanceof List) {
+            data.each { it ->
+                List<String> nextPath = new ArrayList<>(typedPath)
+                if (it instanceof Map && it["@type"])
+                    nextPath.add("@type=" + it["@type"])
+                results.addAll(collectTechnicalNotes(it, nextPath, jsonld))
+            }
+        }
+        return results
+    }
+
+    void compileTechnicalNotes(Map framed, JsonLd jsonld) {
+
+        //System.err.println("\n\nWill now get tech notes on: " + mapper.writeValueAsString(framed) + "\n\n")
+
+        Set<Map> compiledNotes = collectTechnicalNotes(framed, [], jsonld)
+
+        System.err.println(" Final new implied notes for " + framed["@id"] + " : " + compiledNotes)
+
+        if ( framed["technicalNote"] ) {
+            if ( framed["technicalNote"] instanceof List )
+                compiledNotes.addAll(framed["technicalNote"])
+            else
+                compiledNotes.add(framed["technicalNote"])
+        }
+        framed["technicalNote"] = compiledNotes.toList()
+    }
+
     String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
-        
+
+        System.err.println("********** Reindexing " + copy.getShortId())
+
         whelk.embellish(copy, ['search-chips'])
 
         if (log.isDebugEnabled()) {
@@ -338,6 +433,8 @@ class ElasticSearch {
                 whelk.jsonld.locales as Set,
                 REMOVABLE_BASE_URIS,
                 document.getThingInScheme() ? ['tokens', 'chips'] : ['chips'])
+
+        compileTechnicalNotes(framed, whelk.getJsonld())
 
         DocumentUtil.traverse(framed) { value, path ->
             if (path && JsonLd.SEARCH_KEY == path.last() && !Unicode.isNormalizedForSearch(value)) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -903,9 +903,7 @@ class PostgreSQLComponent {
                     ? new Date(resultSet.getTimestamp("modified").getTime())
                     : new Date()
 
-            // EXPERIMENTALLY: Create "interesting changes"-markers if certain significant parts of the record were changed.
             SignificantChangeCalculator.markSignificantChanges(preUpdateDoc, doc, modTime, getJsonld())
-            //
 
             if (!writeIdenticalVersions && preUpdateDoc.getChecksum(jsonld).equals(doc.getChecksum(jsonld))) {
                 throw new CancelUpdateException()


### PR DESCRIPTION
This draft implements a rough version of *one* CXZ rule (primary contribution) and creates an implied marker for it in the indexed version of the record. The stored (in pg) version does not have this implied marker. The (possibly broken out) agent-record where the actual change was made, however, has a "changed agent" marker both in the stored and indexed versions (uggh inconsistent).

It's black magic and sacrificed cats all the way, and there are some side effects of all this:

1. ChangeNotes have to go under mainEntity, and cannot sit (where they perhaps should) in metadata (@graph,0). Because otherwise we cannot (without rebuilding the world) bring them with us when embellishing, which we must.

2. TechnicalNotes and everything they contain must be part of the "card" or "search-card"-definition, because all of the data in these notes must be kept when embellishing, or else we won't have the necessary info from which to imply second order markers. This may have bad knock on-effects, such as for example these notes possibly showing up in the GUI (or otherwise requiring more dead cats to filter them out). For the moment being this was avoided by temporarily hacking the embellish-process, but that won't be good enough in the real world.

Also, this (if/when all the rules are implemented) obviously also only delivers ~1/3 of the CXZ-feature, as the actual stream this is supposed to result in, and all handling of the actual notifications aren't here, and will have to be built in the front end instead.

I consider all this a Very Bad Idea (tm), but there it is.