### PR TITLE
Fix an export bug causing missed exports.

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -262,7 +262,7 @@ public class ProfileExport
             usingCollectionRules = "bib";
         }
         
-        if (collection.equals("auth") && !hasCardChanged(id)) {
+        if (collection.equals("auth") && !hasCardChanged(id, from, until)) {
             return false;
         }
 
@@ -312,9 +312,9 @@ public class ProfileExport
         return true;
     }
 
-    private boolean hasCardChanged(String id) {
-        Document currentVersion = m_whelk.getStorage().load(id);
-        Document previousVersion = m_whelk.getStorage().load(id, "-1");
+    private boolean hasCardChanged(String id, Timestamp from, Timestamp until) {
+        Document currentVersion = m_whelk.getStorage().loadAsOf(id, until);
+        Document previousVersion = m_whelk.getStorage().loadAsOf(id, from);
         if (previousVersion == null) {
             return true;
         }


### PR DESCRIPTION
The issue here is that hasCardChanged() compared the latest version, with the second latest version, which is not the correct behaviour when generating exports for an interval of time.

One reason for this is that the selected interval can (and often will) be far back in time, where other (older) versions than the latest and second latest must be used to determine if there was any change to the card.

The other (slightly more sinister) reason is that exports are not generated infinitely often. Instead they are often generated once every few minutes for example, which means that when multiple edits of the same record occurs within those few minutes only the *last* of those edits was being looked at to determine if the card was changed or not. So say, for example that you make a change (which changed the card), saved, and then saved *again* within a few minutes, but this second time without changing the card. Your changes will now be lost to the export.

The second scenario occurring but over a rather large period of time of "inactive" webbsök-updates being caught up at a later time is what got this reported.

The loadAsOf() and changes to bulkLoad were taken from the feature/cxz branch as they already existed there.