### PR TITLE
Don't limit MARC export trigger from works to changes in card

### DIFF
--- a/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
+++ b/marc_export/src/main/java/whelk/export/marc/ProfileExport.java
@@ -262,7 +262,7 @@ public class ProfileExport
             usingCollectionRules = "bib";
         }
         
-        if (collection.equals("auth") && !hasCardChanged(id, from, until)) {
+        if (usingCollectionRules.equals("auth") && !hasCardChanged(id, from, until)) {
             return false;
         }
 


### PR DESCRIPTION
Since :instanceOf is an :integral relation, parts of the linked work description outside the card might theoretically be included in the instance description.