### PR TITLE
Elastic: Add missing outer layer of retries when deleting from index

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -307,10 +307,10 @@ class ElasticSearch {
                 log.warn("Failed to delete $identifier from index: $e", e)
             }
             else if (isNotFound(e)) {
-                log.warn("Tried to remove $identifier from index, but it was not there: $e", e)
+                log.warn("Tried to delete $identifier from index, but it was not there: $e", e)
             }
             else {
-                log.warn("Failed to $identifier from index: $e, placing in retry queue.", e)
+                log.warn("Failed to delete $identifier from index: $e, placing in retry queue.", e)
                 indexingRetryQueue.add({ -> remove(identifier) })
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -303,7 +303,16 @@ class ElasticSearch {
             }
         }
         catch(Exception e) {
-            log.warn("Record with id $identifier was not deleted from the Elasticsearch index: $e")
+            if (isBadRequest(e)) {
+                log.warn("Failed to delete $identifier from index: $e", e)
+            }
+            else if (isNotFound(e)) {
+                log.warn("Tried to remove $identifier from index, but it was not there: $e", e)
+            }
+            else {
+                log.warn("Failed to $identifier from index: $e, placing in retry queue.", e)
+                indexingRetryQueue.add({ -> remove(identifier) })
+            }
         }
     }
 


### PR DESCRIPTION
These were only retried by the resilience4j layer. Handle in the same way as other requests.