### PR TITLE
Use .localhost instead of .kblocalhost.kb.se

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ cp secret.properties.in secret.properties
 # In secret.properties, set:
 # - elasticCluster to whatever you set cluster.name to in the Elasticsearch configuration above.
 vim secret.properties
-# Make sure kblocalhost.kb.se points to 127.0.0.1
-echo '127.0.0.1 kblocalhost.kb.se' | sudo tee -a /etc/hosts
+# Make sure libris.localhost points to 127.0.0.1
+echo '127.0.0.1 libris.localhost' | sudo tee -a /etc/hosts
 ```
 
 ### Importing test data
@@ -242,7 +242,7 @@ and the id.kb.se app running on port 3000, but they won't work yet. Next, edit
 
 ```
 <VirtualHost *:5000>
-    ServerName kblocalhost.kb.se
+    ServerName libris.localhost
     ProxyRequests Off
     ProxyPreserveHost On
 
@@ -252,12 +252,12 @@ and the id.kb.se app running on port 3000, but they won't work yet. Next, edit
         ProxyPreserveHost Off
         RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml|\*/\*|^$)
         RewriteCond %{REQUEST_METHOD} GET
-        RewriteRule ([^/]+)$ http://id.kblocalhost.kb.se:5000/$1 [P]
+        RewriteRule ([^/]+)$ http://id.localhost:5000/$1 [P]
     </LocationMatch>
 
     <Location /_nuxt>
         ProxyPreserveHost Off
-        ProxyPass http://id.kblocalhost.kb.se:5000/_nuxt
+        ProxyPass http://id.localhost:5000/_nuxt
     </Location>
     
     ProxyPass        /katalogisering     http://localhost:8080/katalogisering                   
@@ -278,7 +278,7 @@ and the id.kb.se app running on port 3000, but they won't work yet. Next, edit
 </VirtualHost>
 
 <VirtualHost *:5000>
-    ServerName id.kblocalhost.kb.se
+    ServerName id.localhost
     ProxyRequests Off
     ProxyPreserveHost On
 
@@ -326,8 +326,8 @@ Listen 5000
 Add these lines to `/etc/hosts`:
 
 ```
-127.0.0.1 kblocalhost.kb.se
-127.0.0.1 id.kblocalhost.kb.se
+127.0.0.1 libris.localhost
+127.0.0.1 id.localhost
 ```
 
 Make sure some necessary Apache modules are enabled:
@@ -342,9 +342,9 @@ Now (re)start Apache:
 systemctl restart apache2
 ```
 
-You should now be able to visit http://id.kblocalhost.kb.se:5000, and use the cataloging client
-on http://kblocalhost.kb.se:5000/katalogisering/. The XL API itself is available on
-http://kblocalhost.kb.se:5000 (proxied via Apache), or directly on http://localhost:8180.
+You should now be able to visit http://id.localhost:5000, and use the cataloging client
+on http://libris.localhost:5000/katalogisering/. The XL API itself is available on
+http://libris.localhost:5000 (proxied via Apache), or directly on http://localhost:8180.
 
 ## Maintenance
 

--- a/gui-whelktool/cli_run_local.sh
+++ b/gui-whelktool/cli_run_local.sh
@@ -4,4 +4,4 @@ set -uex
 
 username=$(whoami)
 
-java -DsecretBaseUri=http://kblocalhost.kb.se:5000/ -DsecretSqlUrl=jdbc:postgresql://$username:_XL_PASSWORD_@localhost/whelk_dev -DsecretElasticHost=localhost -DsecretElasticCluster=elasticsearch_$username -DsecretElasticIndex=whelk_dev -DsecretApplicationId=https://libris.kb.se/ -DsecretSystemContextUri=https://id.kb.se/sys/context/kbv -DsecretLocales=sv,en -DsecretTimezone=Europe/Stockholm -jar build/libs/gui-whelktool.jar
+java -DsecretBaseUri=http://libris.localhost:5000/ -DsecretSqlUrl=jdbc:postgresql://$username:_XL_PASSWORD_@localhost/whelk_dev -DsecretElasticHost=localhost -DsecretElasticCluster=elasticsearch_$username -DsecretElasticIndex=whelk_dev -DsecretApplicationId=https://libris.kb.se/ -DsecretSystemContextUri=https://id.kb.se/sys/context/kbv -DsecretLocales=sv,en -DsecretTimezone=Europe/Stockholm -jar build/libs/gui-whelktool.jar

--- a/marc_export/integtest/test.py
+++ b/marc_export/integtest/test.py
@@ -5,7 +5,7 @@ import os
 import json
 import xml.etree.ElementTree as ET
 
-base_uri = 'http://kblocalhost.kb.se:5000/'
+base_uri = 'http://libris.localhost:5000/'
 export_url = 'http://localhost:8580/marc_export/'
     
 ## Util-stuff

--- a/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
+++ b/rest/src/main/groovy/se/kb/libris/digi/DigitalReproductionAPI.groovy
@@ -53,11 +53,11 @@ TOKEN=$(curl -s -X POST -d 'client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&gr
 curl -v -XPOST 'http://localhost:8180/_reproduction' -H 'Content-Type: application/ld+json' -H "Authorization: Bearer $TOKEN" -H 'XL-Active-Sigel: S' --data-binary @- << EOF
 {
   "@type": "Electronic",
-  "reproductionOf": { "@id": "http://kblocalhost.kb.se:5000/q822pht24j3ljjr#it" },
+  "reproductionOf": { "@id": "http://libris.localhost:5000/q822pht24j3ljjr#it" },
   "production": [ 
     {
       "@type": "Reproduction",
-      "agent": { "@id": "http://kblocalhost.kb.se:5000/jgvxv7m23l9rxd3#it" },
+      "agent": { "@id": "http://libris.localhost:5000/jgvxv7m23l9rxd3#it" },
       "place": { "@type": "Place", "label": "Stockholm" },
       "date": "2021"
     }

--- a/whelk-core/src/test/resources/preserve-paths/context.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/context.jsonld
@@ -1,7 +1,7 @@
 {
   "@graph": [
     {
-      "@id": "http://kblocalhost.kb.se:5000/00nj5pg324pd3kjp",
+      "@id": "http://libris.localhost:5000/00nj5pg324pd3kjp",
       "sameAs": [
         {
           "@id": "https://id.kb.se/vocab/context"

--- a/whelk-core/src/test/resources/preserve-paths/display-data.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/display-data.jsonld
@@ -1,7 +1,7 @@
 {
   "@graph": [
     {
-      "@id": "http://kblocalhost.kb.se:5000/00nj5pg324f356g2",
+      "@id": "http://libris.localhost:5000/00nj5pg324f356g2",
       "sameAs": [
         {
           "@id": "https://id.kb.se/vocab/display.jsonld"

--- a/whelk-core/src/test/resources/preserve-paths/molecular-aspects-cards-cards.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/molecular-aspects-cards-cards.jsonld
@@ -1,5 +1,5 @@
 {
-  "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#it",
+  "@id": "http://libris.localhost:5000/n602lbw018zh88k#it",
   "@type": "Electronic",
   "extent": [
     {
@@ -19,7 +19,7 @@
     }
   ],
   "instanceOf": {
-    "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#work",
+    "@id": "http://libris.localhost:5000/n602lbw018zh88k#work",
     "@type": "Text",
     "subject": [
       {

--- a/whelk-core/src/test/resources/preserve-paths/molecular-aspects-cards-chips.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/molecular-aspects-cards-chips.jsonld
@@ -1,5 +1,5 @@
 {
-  "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#it",
+  "@id": "http://libris.localhost:5000/n602lbw018zh88k#it",
   "@type": "Electronic",
   "extent": [
     {
@@ -19,7 +19,7 @@
     }
   ],
   "instanceOf": {
-    "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#work",
+    "@id": "http://libris.localhost:5000/n602lbw018zh88k#work",
     "@type": "Text",
     "language": [
       {

--- a/whelk-core/src/test/resources/preserve-paths/molecular-aspects-chips.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/molecular-aspects-chips.jsonld
@@ -1,5 +1,5 @@
 {
-  "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#it",
+  "@id": "http://libris.localhost:5000/n602lbw018zh88k#it",
   "@type": "Electronic",
   "sameAs": [
     {
@@ -13,7 +13,7 @@
     }
   ],
   "instanceOf": {
-    "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#work",
+    "@id": "http://libris.localhost:5000/n602lbw018zh88k#work",
     "@type": "Text",
     "language": [
       {

--- a/whelk-core/src/test/resources/preserve-paths/molecular-aspects.jsonld
+++ b/whelk-core/src/test/resources/preserve-paths/molecular-aspects.jsonld
@@ -1,5 +1,5 @@
 {
-  "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#it",
+  "@id": "http://libris.localhost:5000/n602lbw018zh88k#it",
   "@type": "Electronic",
   "extent": [
     {
@@ -26,7 +26,7 @@
     }
   ],
   "instanceOf": {
-    "@id": "http://kblocalhost.kb.se:5000/n602lbw018zh88k#work",
+    "@id": "http://libris.localhost:5000/n602lbw018zh88k#work",
     "@type": "Text",
     "hasPart": [
       {

--- a/whelktool/README.md
+++ b/whelktool/README.md
@@ -205,7 +205,7 @@ def data =
                         "@id": "TEMPID#it",
                         "@type": "Item",
                         "heldBy": ["@id": "https://libris.kb.se/library/Utb1"],
-                        "itemOf": ["@id": "http://kblocalhost.kb.se:5000/wf7mw1h74fkt88r#it"]
+                        "itemOf": ["@id": "http://libris.localhost:5000/wf7mw1h74fkt88r#it"]
                 ]
         ]]
 

--- a/whelktool/scripts/examples/create.groovy
+++ b/whelktool/scripts/examples/create.groovy
@@ -8,7 +8,7 @@ def data =
                         "@id": "TEMPID#it",
                         "@type": "Item",
                         "heldBy": ["@id": "https://libris.kb.se/library/Utb1"],
-                        "itemOf": ["@id": "http://kblocalhost.kb.se:5000/wf7mw1h74fkt88r#it"]
+                        "itemOf": ["@id": "http://libris.localhost:5000/wf7mw1h74fkt88r#it"]
                 ]
         ]]
 


### PR DESCRIPTION
Using kblocalhost.kb.se and id.kblocalhost.kb.se as domains for local development is an (increasingly) bad idea because in modern browsers an increasing number of features are only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) -- essentially https://, http://127.0.0.1, http://localhost and http://*.localhost.

Among [restricted features](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts) is, for example, the Web Crypto API, so we have a [workaround](https://github.com/libris/lxlviewer/blob/70cb543a0b067e14318c81957bd752e0bd030ee9/lxljs/string.js#L14-L27) for local development.

Let's just switch to .localhost. (Later on we might _also_ want to use local self-signed certificates.)

To "migrate" from an old setup:

* Stop the REST API, nuxt-app, vue-client
* Use the corresponding branches in lxlviewer and devops unless they've already been merged
* Change `id.kblocalhost.kb.se` => `id.localhost` and `kblocalhost.kb.se` => `libris.localhost`  in the following files:
    * `/etc/hosts` 
    * `librisxl/secret.properties`
    * `lxlviewer/nuxt-app/.env`
    * `lxlviewer/vue-client/.env.development`
    * `/etc/apache2/sites-enabled/something.conf` (or equivalent)
* Import everything again: `fab xl_local app.whelk.import_work_example_data`
* Restart Apache
* In `lxlviewer/vue-client/.end.development`, change `VUE_APP_CLIENT_ID` (see chat or ask for new one)
* Start REST API, nuxt-app, vue-client