### PR TITLE
Clean up manage-whelk-storage.sh

### DIFF
--- a/librisxl-tools/scripts/manage-whelk-storage.sh
+++ b/librisxl-tools/scripts/manage-whelk-storage.sh
@@ -10,19 +10,13 @@ usage () {
     cat <<EOF
 
 Usage: ./manage-whelk-storage.sh -n <NAME> [-h <POSTGRES HOST>]
-           [-e <ELASTICSEARCH HOST>] [-D <POSTGRES USER>]
-           [-C <CREATEDB USER>] [-R] [-N]
+           [-D <POSTGRES USER>] [-C <CREATEDB USER>] [-R] [-N]
 
     -n, --whelk-name
-        Instance name. Used as database name and ElasticSearch index.
+        Instance name. Used as database name.
 
     -h, --db-host
         PostgreSQL host to connect to.
-
-        Defaults to localhost.
-
-    -e, --es-host
-        ElasticSearch host to connect to.
 
         Defaults to localhost.
 
@@ -39,8 +33,8 @@ Usage: ./manage-whelk-storage.sh -n <NAME> [-h <POSTGRES HOST>]
         If unset, runs 'createdb' without 'sudo'.
 
     -R, --recreate-db
-        If set, will drop and recreate PostgreSQL and ElasticSearch
-        databases indicated by -n/--whelk-name, and reload schema.
+        If set, will drop and recreate PostgreSQL database indicated
+        by -n/--whelk-name, and reload schema.
 
         Unset by default.
 
@@ -63,14 +57,6 @@ do
             ;;
         -h|--db-host)
             DBHOST="$2"
-            shift
-            ;;
-        -e|--es-host)
-            ESHOST="$2"
-            shift
-            ;;
-        -E|--es-index)
-            ESINDEX="$2"
             shift
             ;;
         -D|--db-user)
@@ -100,14 +86,6 @@ if [ -z "$DBHOST" ]; then
     DBHOST="localhost"
 fi
 
-if [ -z "$ESHOST" ]; then
-    ESHOST="localhost"
-fi
-
-if [ -z "$ESINDEX" ]; then
-    ESINDEX="${WHELKNAME}"
-fi
-
 if [ "$DBUSER" ]; then
     DBUSER_ARG="-U ${DBUSER}"
 fi
@@ -127,21 +105,6 @@ if [ "$RECREATE_DB" = true ]; then
     do
       psql -h $DBHOST $DBUSER_ARG $WHELKNAME < $MIGRATIONFILE
     done
-
-    echo ""
-    echo "(Re)creating ElasticSearch database..."
-    echo ""
-
-    curl -XDELETE http://$ESHOST:9200/$ESINDEX
-
-    echo ""
-    echo ""
-    curl -XPUT http://$ESHOST:9200/$ESINDEX \
-         -d@$TOOLDIR/elasticsearch/libris_config.json \
-         --header "Content-Type: application/json"
-    echo ""
-    echo ""
-
 fi
 
 if [ "$RUN_MIGRATIONS" = true ]; then

--- a/librisxl-tools/scripts/manage-whelk-storage.sh
+++ b/librisxl-tools/scripts/manage-whelk-storage.sh
@@ -4,7 +4,6 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
 TOOLDIR=$(dirname $SCRIPT_DIR)
 
 RECREATE_DB=false
-NUKE_DEFINITIONS=false
 RUN_MIGRATIONS=false
 
 usage () {
@@ -50,26 +49,7 @@ Usage: ./manage-whelk-storage.sh -n <NAME> [-h <POSTGRES HOST>]
         indicated by -n/--whelk-name
 
         Unset by default.
-
-    -N, --nuke-definitions
-        If set, will delete all definitions data from PostgreSQL and
-        ElasticSearch.
-
-        Unset by default.
 EOF
-}
-
-delete_definitions() {
-    psql -h $DBHOST $DBUSER_ARG $WHELKNAME -c \
-         "DELETE FROM lddb__identifiers WHERE id in (SELECT id from lddb where ( data#>'{@graph,0,inDataset}' @> '[{\"@id\":\"https://id.kb.se/dataset/definitions\"}]' OR data#>>'{@graph,1,@id}' in ('https://id.kb.se/vocab/', 'https://id.kb.se/vocab/context', 'https://id.kb.se/vocab/display')) and collection = 'definitions');"
-    psql -h $DBHOST $DBUSER_ARG $WHELKNAME -c \
-         "DELETE FROM lddb where ( data#>'{@graph,0,inDataset}' @> '[{\"@id\":\"https://id.kb.se/dataset/definitions\"}]' OR data#>>'{@graph,1,@id}' in ('https://id.kb.se/vocab/', 'https://id.kb.se/vocab/context', 'https://id.kb.se/vocab/display')) and collection = 'definitions';"
-    psql -h $DBHOST $DBUSER_ARG $WHELKNAME -c \
-         "DELETE FROM lddb__versions where ( data#>'{@graph,0,inDataset}' @> '[{\"@id\":\"https://id.kb.se/dataset/definitions\"}]' OR data#>>'{@graph,1,@id}' in ('https://id.kb.se/vocab/', 'https://id.kb.se/vocab/context', 'https://id.kb.se/vocab/display')) and collection = 'definitions' ;"
-
-    curl -XPOST http://$ESHOST:9200/$ESINDEX/_delete_by_query \
-          -H 'Content-Type: application/json' \
-          -d '{ "query": { "match": { "meta.inDataset.@id": "https://id.kb.se/dataset/definitions" } } }'
 }
 
 while [[ $# -gt 0 ]]
@@ -103,9 +83,6 @@ do
             ;;
         -R|--recreate-db)
             RECREATE_DB=true
-            ;;
-        -N|--nuke-definitions)
-            NUKE_DEFINITIONS=true
             ;;
         -M|--run-migrations)
             RUN_MIGRATIONS=true
@@ -181,15 +158,4 @@ if [ "$RUN_MIGRATIONS" = true ]; then
 
     echo ""
     echo "Version after: $(psql -qtA -h $DBHOST $DBUSER_ARG $WHELKNAME -c "SELECT version FROM lddb__schema")"
-fi
-
-if [ "$NUKE_DEFINITIONS" = true ]; then
-    echo ""
-    echo "Nuking definitions data..."
-    echo ""
-
-    delete_definitions
-
-    echo ""
-    echo ""
 fi


### PR DESCRIPTION
* [Remove obsolete --nuke-definitions](https://github.com/libris/librisxl/commit/3fcf971d551b6972384c34a709efda4abeb6ae26)
* [Don't create elasticsearch index](https://github.com/libris/librisxl/pull/1285/commits/7f1f14488609e5cf47294e0c959355a000e5712e)
    * Because fab tasks always use numbered indices + aliases now. This caused the initial docker-compose setup to fail after copying data.