### PR TITLE
Fix intellij autocomplete etc inside whelktool scripts

### DIFF
--- a/whelktool/build.gradle
+++ b/whelktool/build.gradle
@@ -24,6 +24,18 @@ sourceSets {
     test {
         groovy { srcDir 'src/test/groovy/' }
     }
+    // This is just so that intellij will understand whelk-core and whelktool classes 
+    // inside whelktool scripts. So that autocomplete and navigation etc works.
+    //
+    // After importing the gradle project the 'scripts' directory needs to be manually 
+    // unmarked as "source root" for whelktool classes to work. And so that 'scripts' 
+    // is displayed as directories instead of as packages. Autocomplete etc. still works.
+    //
+    // Right-click on the 'scripts' directory and select 
+    // "Mark directory as" > "Unmark as Sources root"
+    whelktoolScripts {
+        groovy { srcDir 'scripts' }
+    }
 }
 
 mainClassName = "whelk.datatool.WhelkTool"
@@ -54,6 +66,8 @@ dependencies {
     implementation "org.codehaus.groovy:groovy:${groovyVersion}"
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
     implementation group: 'xml-apis', name: 'xml-apis', version: '1.4.01'
+    whelktoolScriptsCompileOnly sourceSets.main.output
+    whelktoolScriptsCompileOnly project(':whelk-core')
 }
 
 jar {


### PR DESCRIPTION
This makes intellij recognize whelktool and whelk-core classes in whelktool scripts.
It does not make the "scripts" directory part of whelktool.jar.
Stuff made available to the scripts through `javax.script.Bindings` like `selectBySqlWhere` is not recognized.

After importing the gradle project a manual step has to be performed for it to work 100%. Se comment.