### PR TITLE
Feature/lxl 4042 update more shelfmark sequences

### DIFF
--- a/whelktool/scripts/syslib/bump-year-based-shelfmarksequences.groovy
+++ b/whelktool/scripts/syslib/bump-year-based-shelfmarksequences.groovy
@@ -1,8 +1,8 @@
 /**
  * This script bumps the year for "year based" ShelfMarkSequences
  * 
- * Any ShelfMarkSequence with YY or YYYY in the label (e.g. "Sv2021") will be replacedBy
- * a new sequence starting at 1 and with the new year in the label (e.g. "Sv2022").
+ * Any ShelfMarkSequence with YY or YYYY in the label/qualifier (e.g. "Sv2021") will be replacedBy
+ * a new sequence starting at 1 and with the new year in the label/qualifier (e.g. "Sv2022").
  * 
  * To be scheduled at New Year's Eve 🎆
  */


### PR DESCRIPTION
Include shelfmarkSequences with year based sequence codes in `qualifier` instead of `label` in the yearly bump. 

Tested locally on copies of https://libris.kb.se/katalogisering/1hcqjgvwzfpfjcxh and https://libris.kb.se/katalogisering/0fklzxfzxgvfcj23. 