### PR TITLE
Only set context in JsonLD2RdfXml unless present

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/JsonLD2RdfXml.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLD2RdfXml.groovy
@@ -26,7 +26,7 @@ class JsonLD2RdfXml implements FormatConverter {
     Map convert(Map originaldata, String id) {
         var srcData = [:]
         srcData.putAll(originaldata)
-        if (context) {
+        if (context && JsonLd.CONTEXT_KEY !in srcData) {
             srcData[JsonLd.CONTEXT_KEY] = context
         }
 


### PR DESCRIPTION
Fixes removal of namespace declarations when serializing as RDF/XML.