### PR TITLE
Do not use PrimaryContribution on instances

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
@@ -58,14 +58,16 @@ class ContributionByRoleStep extends MarcFramePostProcStepBase {
                     workRoles << it
                 }
             }
-            def contrib = it.clone()
+
             if (instanceRoles) {
+              def contrib = it.clone()
                 contrib.role = instanceRoles
+                setToPlainContribution(contrib)
                 instanceContribs << contrib
-            } else {
-                if (workRoles) {
-                    contrib.role = workRoles
-                }
+            }
+            if (workRoles) {
+                def contrib = it.clone()
+                contrib.role = workRoles
                 workContribs << contrib
             }
         }
@@ -76,10 +78,12 @@ class ContributionByRoleStep extends MarcFramePostProcStepBase {
             } else {
                 work.contribution = workContribs
             }
+
             if (!instance.contribution) {
                 instance.contribution = []
             }
             instance.contribution += instanceContribs
+
             return true
         } else {
             return false
@@ -101,7 +105,14 @@ class ContributionByRoleStep extends MarcFramePostProcStepBase {
         } else if (work.contribution !instanceof List) {
             work.contribution = [work.contribution]
         }
-        work.contribution += asList(instance.contribution)
-        instance.remove('contribution')
+        var instanceContribs = asList(instance.remove('contribution'))
+        instanceContribs.each { setToPlainContribution(it) }
+        work.contribution += instanceContribs
+    }
+
+    void setToPlainContribution(contrib) {
+      if (contrib[TYPE] != 'Contribution') {
+        contrib[TYPE] = 'Contribution'
+      }
     }
 }

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
@@ -79,6 +79,77 @@
         }
       },
       "back": "source"
+    },
+    {
+      "name": "Split publisher from author and move",
+      "source": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/author"},
+                  {"@id": "https://id.kb.se/relator/publisher"}
+                ],
+                "@type": "PrimaryContribution",
+                "agent": {"@id": "x"}
+              }
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/author"}
+                ],
+                "@type": "PrimaryContribution",
+                "agent": {"@id": "x"}
+              }
+            ]
+          },
+          "contribution": [
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/publisher"}
+                ],
+                "@type": "Contribution",
+                "agent": {"@id": "x"}
+              }
+          ]
+        }
+      },
+      "back": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/author"}
+                ],
+                "@type": "PrimaryContribution",
+                "agent": {"@id": "x"}
+              },
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/publisher"}
+                ],
+                "@type": "Contribution",
+                "agent": {"@id": "x"}
+              }
+            ]
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
When moving contributions to the instance, set them to type Contribution, to avoid there being multiple primary (100) fields when reverting to MARC.