### PR TITLE
Feature/lxl 4183 correct illustrators vs translators

### DIFF
--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -138,6 +138,20 @@ selectByIds(clusters.flatten()) { bib ->
     // if still no match, add constructed local Contribution with agent + roles extracted from responsibilityStatement
     modified |= addRemainingContributionsFromRespStatement(contribution, contributionsInRespStatement, normalizedNameToName, respStatement, id)
 
+    if (modified) {
+        bib.scheduleSave()
+    }
+}
+
+selectByIds(clusters.flatten()) { bib ->
+    def id = bib.doc.shortId
+    def work = bib.graph[1].instanceOf
+    def contribution = work?.contribution
+
+    if (!contribution) return
+
+    def modified = false
+
     contribution.each { Map c ->
         // add roles from contributions in same cluster with matching agent
         modified |= tryAddRole(c, id)

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -399,7 +399,7 @@ boolean tryAddRole(Map contribution, String id) {
         def inClusterWithRole = ids.intersect(idToCluster[id])
         return inClusterWithRole
                 && !noRole([r])
-                && (inClusterWithRole.size() >= inCluster.size()
+                && (inClusterWithRole.size() >= inCluster.size() / 2
                 || noRole(currentRoles)
                 || r == [(ID_KEY): Relator.PRIMARY_RIGHTS_HOLDER.iri]
                 || (r in adapterEditor && currentRoles.intersect(adapterEditor)))

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -519,7 +519,7 @@ static Map<String, List<Relator>> parseSwedishFictionContribution(String contrib
             [
                     (Relator.TRANSLATOR)         : ~/(bemynd(\w+|\.)? )?öf?v(\.|ers(\.|\p{L}+)?)( (till|från) \p{L}+)?|(till svenskan?|från \p{L}+)|svensk text/,
                     (Relator.AUTHOR)             : ~/^(text(e[nr])?|skriven|written)/,
-                    (Relator.ILLUSTRATOR)        : ~/\bbild(erStrin)?|ill(\.|ustr(\.|\w+)?)|\bvi(gn|nj)ett(er|ill)?|ritad/,
+                    (Relator.ILLUSTRATOR)        : ~/\bbild(er)?|ill(\.|ustr(\.|\w+)?)|\bvi(gn|nj)ett(er|ill)?|ritad|\bteckn(ad|ingar)/,
                     (Relator.AUTHOR_OF_INTRO)    : ~/förord|inl(edn(\.|ing)|edd)/,
                     (Relator.COVER_DESIGNER)     : ~/omslag/,
                     (Relator.AUTHOR_OF_AFTERWORD): ~/efter(ord|skrift)/,

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -507,7 +507,7 @@ static Map<String, List<Relator>> parseSwedishFictionContribution(String contrib
     def namePattern = ~/\p{Lu}:?\p{Ll}+('\p{Ll})?(,? [Jj](r|unior))?/
     def betweenNamesPattern = ~/-| |\. ?| ([Dd]e(l| la)?|von|van( de[nr])?|v\.|le|af|du|dos) | [ODdLl]'/
     def fullNamePattern = ~/(($initialPattern|$namePattern)($betweenNamesPattern)?)*$namePattern/
-    def conjPattern = ~/ (och|&|and) /
+    def conjPattern = ~/(,| och| &| and) /
     def roleAfterNamePattern = ~/( ?\(($rolePattern$conjPattern)?$rolePattern\))/
     def fullContributionPattern = ~/(($rolePattern($conjPattern|\/))*$rolePattern$followsRolePattern)?$fullNamePattern($conjPattern$fullNamePattern)*$roleAfterNamePattern?/
 

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -66,6 +66,13 @@ selectByIds(clusters.flatten()) { bib ->
                 String agentName = name(a)
                 if (agentName) {
                     nameToAgents.computeIfAbsent(agentName, f -> new ConcurrentHashMap().newKeySet()).add(agentStr)
+                    def acronym = agentName.split(' ').findAll().with { parts ->
+                        (0..<parts.size() - 1).each {
+                            parts[it] = parts[it][0]
+                        }
+                        parts.join(' ')
+                    }
+                    nameToAgents.computeIfAbsent(acronym, f -> new ConcurrentHashMap().newKeySet()).add(agentStr)
                 }
             }
             def roleToIds = agentToRolesToIds.computeIfAbsent(agentStr, f -> new ConcurrentHashMap())
@@ -634,7 +641,7 @@ static List<Character> initials(List nameParts) {
 }
 
 static List<String> nameParts(String s) {
-    s.split(' ') as List
+    s.split(' ').findAll()
 }
 
 static String findIncorrectIllVsTrl(List currentRoles, List rolesInRespStatement) {

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -424,6 +424,12 @@ boolean tryAddRole(Map contribution, String id) {
                 || (r in adapterEditor && currentRoles.intersect(adapterEditor)))
     }.collect { it.key }
 
+    def illAndTrl = [[(ID_KEY): Relator.TRANSLATOR.iri], [(ID_KEY): Relator.ILLUSTRATOR.iri]]
+
+    if ((currentRoles + rolesInCluster).containsAll(illAndTrl)) {
+        rolesInCluster -= illAndTrl
+    }
+
     def newRoles = rolesInCluster - currentRoles
     if (newRoles) {
         contribution['role'] = noRole(currentRoles) ? newRoles : currentRoles + newRoles

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -237,10 +237,15 @@ boolean tryAddRolesFromRespStatement(Map contribution, Map contributionsInRespSt
                 ? null
                 : [(ID_KEY): relator.iri]
     }
+
+    def modified = false
+
     def incorrectIllOrTrl = findIncorrectIllVsTrl(currentRoles, rolesOfInterest)
     if (incorrectIllOrTrl) {
         currentRoles.remove([(ID_KEY): incorrectIllOrTrl])
+        contribution['role'] = currentRoles
         illVsTrl.println([id, roleShort(incorrectIllOrTrl), name, respStatement].join('\t'))
+        modified = true
     }
     def newRoles = rolesOfInterest - currentRoles
     if (newRoles) {
@@ -254,10 +259,10 @@ boolean tryAddRolesFromRespStatement(Map contribution, Map contributionsInRespSt
         newRoles.each { r ->
             roleToIds.computeIfAbsent(r, f -> new ConcurrentHashMap().newKeySet()).add(id)
         }
-        return true
+        modified = true
     }
 
-    return false
+    return modified
 }
 
 boolean tryAddLinkedAgentContributionsFromRespStatement(List<Map> contribution, Map contributionsInRespStatement, String respStatement, String id) {

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -258,6 +258,7 @@ boolean tryAddRolesFromRespStatement(Map contribution, Map contributionsInRespSt
     if (incorrectIllOrTrl) {
         currentRoles.remove([(ID_KEY): incorrectIllOrTrl])
         contribution['role'] = currentRoles
+        roleToIds[[(ID_KEY): incorrectIllOrTrl]].remove(id)
         illVsTrl.println([id, roleShort(incorrectIllOrTrl), name, respStatement].join('\t'))
         modified = true
     }

--- a/librisworks/scripts/add-missing-contribution-data.groovy
+++ b/librisworks/scripts/add-missing-contribution-data.groovy
@@ -634,7 +634,7 @@ static List<Character> initials(List nameParts) {
 }
 
 static List<String> nameParts(String s) {
-    s.split(/\s+|-/) as List
+    s.split(' ') as List
 }
 
 static String findIncorrectIllVsTrl(List currentRoles, List rolesInRespStatement) {

--- a/librisworks/src/main/groovy/se/kb/libris/mergeworks/Util.groovy
+++ b/librisworks/src/main/groovy/se/kb/libris/mergeworks/Util.groovy
@@ -293,16 +293,6 @@ class Util {
 
     static def isTitle = { it.'@type' == 'Title' }
 
-    static boolean nameMatch(Object local, Map agent) {
-        def variants = [agent] + asList(agent.hasVariant)
-
-        def localName = local instanceof Map ? name(local) : normalize(local)
-
-        localName && variants.any {
-            name(it) && localName == name(it)
-        }
-    }
-
     static String name(Map agent) {
         (agent.givenName && agent.familyName)
                 ? normalize("${agent.givenName} ${agent.familyName}")


### PR DESCRIPTION
- When an agent X is stated as either illustrator or translator in responsibilityStatement, remove the other from the Contribution holding agent X since it's likely to be incorrect (of course nothing is removed should both illustrator and translator be stated in responsibilityStatement). All these removals are reported in ill-vs-trl.tsv for manual verification.
- Never add translator/illustrator role from another work in same cluster when either is already present.
- Match agents on acronym, e.g. match Anne-Marie Constant with A.M. Constant.
 
Plus some more minor improvements.

Don't expect a thorough review since the whole script is very messy due to new details being added continually. This is more of an FYI :)