### PR TITLE
Don't try to bulk index empty body

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -207,9 +207,13 @@ class ElasticSearch {
                 }
             }.join('')
 
-            String response = bulkClient.performRequest('POST', '/_bulk', bulkString, BULK_CONTENT_TYPE)
-            Map responseMap = mapper.readValue(response, Map)
-            log.info("Bulk indexed ${docs.count{it}} docs in ${responseMap.took} ms")
+            if (bulkString) {
+                String response = bulkClient.performRequest('POST', '/_bulk', bulkString, BULK_CONTENT_TYPE)
+                Map responseMap = mapper.readValue(response, Map)
+                log.info("Bulk indexed ${docs.count{it}} docs in ${responseMap.took} ms")
+            } else {
+                log.warn("Refused bulk indexing ${docs.count{it}} docs because body was empty")
+            }
         }
     }
 


### PR DESCRIPTION
Reindexing QA failed:
```
Reindex failed with:
whelk.exception.WhelkRuntimeException: Task threw exception: whelk.exception.UnexpectedHttpStatusException: 400: {"error":{"root_cause":[{"type":"parse_exception","reason":"request body is required"}],"t
ype":"parse_exception","reason":"request body is required"},"status":400}
callstack:
null
PANIC ABORT, unhandled exception:
whelk.exception.WhelkRuntimeException: Task threw exception: whelk.exception.UnexpectedHttpStatusException: 400: {"error":{"root_cause":[{"type":"parse_exception","reason":"request body is required"}],"t
ype":"parse_exception","reason":"request body is required"},"status":400}
whelk.exception.WhelkRuntimeException: Task threw exception: whelk.exception.UnexpectedHttpStatusException: 400: {"error":{"root_cause":[{"type":"parse_exception","reason":"request body is required"}],"t
ype":"parse_exception","reason":"request body is required"},"status":400}
        at whelk.util.BlockingThreadPool$Queue.checkResult(BlockingThreadPool.java:109)
        at whelk.util.BlockingThreadPool$Queue.awaitAll(BlockingThreadPool.java:96)
        at whelk.util.BlockingThreadPool$SimplePool.awaitAllAndShutdown(BlockingThreadPool.java:143)
        at whelk.util.BlockingThreadPool$SimplePool$awaitAllAndShutdown$0.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:130)
        at whelk.reindexer.ElasticReindexer.reindex(ElasticReindexer.groovy:99)
        at whelk.reindexer.ElasticReindexer$reindex.call(Unknown Source)
```
Because a bunch of docs (~11k) had `null` as the value of `descriptionLastModifiers.@id`:
```
2023-09-09T09:01:37,503 [SimplePool-14] ERROR whelk.component.ElasticSearch - Failed to index brgstdh08j6l9jkn in elastic: java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "id" is null
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "id" is null
        at whelk.JsonLd.getReferencedBNodes(JsonLd.groovy:1395) ~[xlimporter.jar:?]
        at whelk.JsonLd.getReferencedBNodes(JsonLd.groovy:1404) ~[xlimporter.jar:?]
        at whelk.JsonLd.getReferencedBNodes(JsonLd.groovy:1404) ~[xlimporter.jar:?]
        at whelk.JsonLd.cleanUp(JsonLd.groovy:1381) ~[xlimporter.jar:?]
        at whelk.JsonLd.frame(JsonLd.groovy:1263) ~[xlimporter.jar:?]
```
So, don't send a bulk index request to Elasticsearch if the the request body is empty; warn instead. We'll have to look at the offending records separately.