### PR TITLE
Fix revert for DDC broadMatch and narrowMatch

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe-auth.json
+++ b/whelk-core/src/main/resources/ext/marcframe-auth.json
@@ -867,6 +867,7 @@
   },
   "065": {
     "onRevertPrefer": "083",
+    "NOTE:local": "onRevertPrefer makes sure ClassificationDDC with broadMatch not get converted to 065",
     "inherit": "bib:084",
     "aboutEntity": "?thing",
     "addLink": "broadMatch",

--- a/whelk-core/src/main/resources/ext/marcframe-auth.json
+++ b/whelk-core/src/main/resources/ext/marcframe-auth.json
@@ -866,11 +866,13 @@
     "NOTE:record-count": 0
   },
   "065": {
+    "onRevertPrefer": "083",
     "inherit": "bib:084",
     "aboutEntity": "?thing",
     "addLink": "broadMatch",
     "$c": {"property": "marc:explanatoryTerm"},
-    "_spec": [{
+    "_spec": [
+      {
         "source": {
           "065": {"ind1": " ", "ind2": " ", "subfields": [
             {"a": "Ykk"},
@@ -939,6 +941,7 @@
   "083" : {
     "aboutEntity": "?thing",
     "addLink": "closeMatch",
+    "allowLinkOnRevert": ["broadMatch", "narrowMatch"],
     "resourceType": "ClassificationDdc",
     "TODO:match": [
       {
@@ -950,10 +953,6 @@
         "aboutType": "Concept"
       }
     ],
-    "TODO:computeLinks": {
-      "use": "$c",
-      "mapping": {"BroadMatch": "broadMatch", "NarrowMatch": "narrowMatch", "*": "closeMatch"}
-    },
     "i1": {"marcDefault": "0"},
     "i2": {"marcDefault": "4"},
     "$a": {"property": "code", "required": true},
@@ -1007,6 +1006,40 @@
           "mainEntity": {
             "@type": "Identity",
             "closeMatch": [{
+              "@type": "ClassificationDdc",
+              "code":  "617.66",
+              "edition":  "23/swe"
+            }]
+          }
+        }
+      },
+      {
+        "normalized": {
+          "083": {"ind1": "0", "ind2": "4", "subfields": [
+            {"a": "617.66"},
+            {"2": "23/swe"}
+          ]}},
+        "result": {
+          "mainEntity": {
+            "@type": "Identity",
+            "broadMatch": [{
+              "@type": "ClassificationDdc",
+              "code":  "617.66",
+              "edition":  "23/swe"
+            }]
+          }
+        }
+      },
+      {
+        "normalized": {
+          "083": {"ind1": "0", "ind2": "4", "subfields": [
+            {"a": "617.66"},
+            {"2": "23/swe"}
+          ]}},
+        "result": {
+          "mainEntity": {
+            "@type": "Identity",
+            "narrowMatch": [{
               "@type": "ClassificationDdc",
               "code":  "617.66",
               "edition":  "23/swe"


### PR DESCRIPTION
When adding DDC classification with broadMatch these should also revert to 083 instead of 065. Added bonus: narrowMatch can also be used removing an old TODO.

See LXL-3533 for details.