### PR TITLE
Use Elasticsearch 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Related external repositories:
 
 ## Dependencies
 
-The instructions below assume an Ubuntu 20.04 system (Debian should be identical), but should work
+The instructions below assume an Ubuntu 22.04 system (Debian should be identical), but should work
 for e.g. Fedora/CentOS/RHEL with minor adjustments.
 
 1. [Gradle](http://gradle.org/)
@@ -55,15 +55,10 @@ for e.g. Fedora/CentOS/RHEL with minor adjustments.
     [gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html)
     to automatically get the specified version of Gradle and Groovy.
 
-2. [Elasticsearch](http://elasticsearch.org/) (version 7.x)
+2. [Elasticsearch](http://elasticsearch.org/) (version 8.x)
 
-    [Download Elasticsearch](https://www.elastic.co/downloads/elasticsearch-oss)
-    (for Ubuntu/Debian, select "Install with apt-get"; before importing the Elasticsearch
-    PGP key you might have to do `sudo apt install gnupg` if you're running a minimal distribution.)
-
-    **NOTE:**
-    * We use the elasticsearch-oss version.
-    * The [ICU Analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/7.12/analysis-icu.html) (`icu-analysis`) must be installed; see "Setting up Elasticsearch" below.
+    [Download Elasticsearch](https://www.elastic.co/downloads/elasticsearch)
+    For Ubuntu/Debian, select "apt-get" and follow the instructions.
 
 3. [PostgreSQL](https://www.postgresql.org/) (version 14.2 or later)
 
@@ -159,8 +154,11 @@ whelk_dev=> \q
 
 ### Setting up Elasticsearch
 
-Edit `/etc/elasticsearch/elasticsearch.yml`. Uncomment `cluster.name` and set it to something unique
-on the network. This name is later specified when you configure the XL system.
+Assuming Elasticsearch is already running, first set the password of the `elastic` user:
+
+```
+printf "elastic\nelastic" | sudo /usr/share/elasticsearch/bin/elasticsearch-reset-password -b -i -u elastic
+```
 
 Next, install the ICU Analysis plugin:
 
@@ -174,8 +172,14 @@ Finally, (re)start Elasticsearch:
 sudo systemctl restart elasticsearch
 ```
 
-(To adjust the JVM heap size for Elasticsearch, edit `/etc/elasticsearch/jvm.options` and then restart
-Elasticsearch.)
+To adjust the JVM heap size for Elasticsearch, edit `/etc/elasticsearch/jvm.options`
+and then restart Elasticsearch. In a local development environment, you might want to
+add the following to prevent Elasticsearch from hogging memory:
+
+```
+-Xms2g
+-Xmx2g
+```
 
 ### Configuring secrets
 
@@ -184,9 +188,6 @@ Use `librisxl/secret.properties.in` as a starting point:
 ```
 cd librisxl
 cp secret.properties.in secret.properties
-# In secret.properties, set:
-# - elasticCluster to whatever you set cluster.name to in the Elasticsearch configuration above.
-vim secret.properties
 # Make sure libris.kb.se.localhost points to 127.0.0.1
 echo '127.0.0.1 libris.kb.se.localhost' | sudo tee -a /etc/hosts
 ```

--- a/gui-whelktool/cli_run_local.sh
+++ b/gui-whelktool/cli_run_local.sh
@@ -3,5 +3,4 @@
 set -uex
 
 username=$(whoami)
-
-java -DsecretBaseUri=http://libris.kb.se.localhost:5000/ -DsecretSqlUrl=jdbc:postgresql://$username:_XL_PASSWORD_@localhost/whelk_dev -DsecretElasticHost=localhost -DsecretElasticCluster=elasticsearch_$username -DsecretElasticIndex=whelk_dev -DsecretApplicationId=https://libris.kb.se/ -DsecretSystemContextUri=https://id.kb.se/sys/context/kbv -DsecretLocales=sv,en -DsecretTimezone=Europe/Stockholm -jar build/libs/gui-whelktool.jar
+java -DsecretBaseUri=http://libris.kb.se.localhost:5000/ -DsecretSqlUrl=jdbc:postgresql://$username:_XL_PASSWORD_@localhost/whelk_dev -DsecretElasticHost=localhost -DsecretElasticCluster=elasticsearch_$username -DsecretElasticIndex=libris_local -DsecretApplicationId=https://libris.kb.se/ -DsecretSystemContextUri=https://id.kb.se/sys/context/kbv -DsecretLocales=sv,en -DsecretTimezone=Europe/Stockholm -jar build/libs/gui-whelktool.jar

--- a/gui-whelktool/src/main/java/whelk/gui/RunPanel.java
+++ b/gui-whelktool/src/main/java/whelk/gui/RunPanel.java
@@ -90,8 +90,6 @@ public class RunPanel extends WizardCard implements ActionListener
                                     System.getProperty("secretBaseUri") + "\n" +
                                     "elasticHost = " +
                                     System.getProperty("secretElasticHost") + "\n" +
-                                    "elasticCluster = " +
-                                    System.getProperty("secretElasticCluster") + "\n" +
                                     "elasticIndex = " +
                                     System.getProperty("secretElasticIndex") + "\n" +
                                     "applicationId = " +

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -310,6 +310,9 @@
                 "type": "text",
                 "store": false,
                 "analyzer": "softmatcher"
+            },
+            "_es_id": {
+                "type": "keyword"
             }
         },
         "date_detection": false,

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -7,8 +7,8 @@
                     "limit": 100000
                 }
             },
-            "number_of_shards": 6,
-            "number_of_replicas": 1
+            "number_of_shards": 15,
+            "number_of_replicas": 2
         },
         "index.query.default_field": "_all",
         "analysis": {

--- a/oaipmh/secret_dev_test.properties
+++ b/oaipmh/secret_dev_test.properties
@@ -1,6 +1,5 @@
 baseUri = https://libris-dev.kb.se/
 sqlUrl = jdbc:postgresql://whelk:whelk@pgsql01-dev.libris.kb.se/whelk
 elasticHost = es01-dev.libris.kb.se
-elasticCluster = lxdev_elasticsearch
 elasticIndex = libris
 oauth2verifyurl = https://bibdb-stg.libris.kb.se/api/o/verify

--- a/secret.properties.in
+++ b/secret.properties.in
@@ -12,7 +12,7 @@ sqlUrl = jdbc:postgresql://whelk:whelk@localhost/whelk_dev
 sqlMaxPoolSize = 4
 
 elasticHost = localhost:9200
-elasticIndex = whelk_dev
+elasticIndex = libris_local
 elasticUser = elastic
 elasticPassword = elastic
 

--- a/secret.properties.in
+++ b/secret.properties.in
@@ -15,6 +15,8 @@ elasticHost = localhost:9200
 # elasticCluster should match the value of cluster.name in elasticsearch.yml
 elasticCluster = <something unique>
 elasticIndex = whelk_dev
+elasticUser = elastic
+elasticPassword = elastic
 
 oauth2verifyurl = https://login-dev.libris.kb.se/oauth/verify
 

--- a/secret.properties.in
+++ b/secret.properties.in
@@ -12,8 +12,6 @@ sqlUrl = jdbc:postgresql://whelk:whelk@localhost/whelk_dev
 sqlMaxPoolSize = 4
 
 elasticHost = localhost:9200
-# elasticCluster should match the value of cluster.name in elasticsearch.yml
-elasticCluster = <something unique>
 elasticIndex = whelk_dev
 elasticUser = elastic
 elasticPassword = elastic

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -46,7 +46,6 @@ class ElasticSearch {
     
     String defaultIndex = null
     private List<String> elasticHosts
-    private String elasticCluster
     private String elasticUser
     private String elasticPassword
     private ElasticClient client
@@ -58,16 +57,14 @@ class ElasticSearch {
     ElasticSearch(Properties props) {
         this(
                 props.getProperty("elasticHost"),
-                props.getProperty("elasticCluster"),
                 props.getProperty("elasticIndex"),
                 props.getProperty("elasticUser"),
                 props.getProperty("elasticPassword")
         )
     }
 
-    ElasticSearch(String elasticHost, String elasticCluster, String elasticIndex, String elasticUser, String elasticPassword) {
+    ElasticSearch(String elasticHost, String elasticIndex, String elasticUser, String elasticPassword) {
         this.elasticHosts = getElasticHosts(elasticHost)
-        this.elasticCluster = elasticCluster
         this.defaultIndex = elasticIndex
         this.elasticUser = elasticUser
         this.elasticPassword = elasticPassword

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -396,6 +396,10 @@ class ElasticSearch {
             }
         }
 
+        // In ES up until 7.8 we could use the _id field for aggregations and sorting, but it was discouraged
+        // for performance reasons. In 7.9 such use was deprecated, and since 8.x it's no longer supported, so
+        // we follow the advice and use a separate field.
+        // (https://www.elastic.co/guide/en/elasticsearch/reference/8.8/mapping-id-field.html).
         framed["_es_id"] =  toElasticId(copy.getShortId())
 
         if (log.isTraceEnabled()) {

--- a/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ElasticFind.groovy
@@ -96,7 +96,7 @@ class ElasticFind {
         p.put("_offset", [Integer.toString(offset)] as String[])
         p.put("_limit", [Integer.toString(PAGE_SIZE)] as String[])
 
-        p.putIfAbsent("_sort", ["_id"] as String[])
+        p.putIfAbsent("_sort", ["_es_id"] as String[])
 
         return p
     }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -663,7 +663,6 @@ class WhelkTool {
         if (whelk.elastic) {
             log "  ElasticSearch:"
             log "    hosts:   ${whelk.elastic.elasticHosts}"
-            log "    cluster: ${whelk.elastic.elasticCluster}"
             log "    index:   ${whelk.elastic.defaultIndex}"
         }
         log "Using script: $scriptFile"


### PR DESCRIPTION
Changes necessary for XL to work with Elasticsearch 8. Main change is that ES 8 has security (and TLS) enabled by default, so we now have to user+pass over HTTPS when talking to the ES cluster.

The devops part has already been merged.

How to tune things for search speed is a separate issue that we can look at more once we have QA running in the new ES cluster. The increased `number_of_shards` / `number_of_replicas` is just a starting point based on our current usage in the main cluster and current recommendations (and anyway we should make `number_of_shards` and `number_of_replicas` configurable, but that's a devops thing).