### PR TITLE
Only log successful ES queries if they took more than a certain amount of time

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -51,6 +51,7 @@ class ElasticSearch {
     private ElasticClient client
     private ElasticClient bulkClient
     private boolean isPitApiAvailable = false
+    private static final int ES_LOG_MIN_DURATION = 2000 // Only log queries taking at least this amount of milliseconds
 
     private final Queue<Runnable> indexingRetryQueue = new LinkedBlockingQueue<>()
 
@@ -566,7 +567,9 @@ class ElasticSearch {
             def duration = System.currentTimeMillis() - start
             Map responseMap = mapper.readValue(responseBody, Map)
 
-            log.info("ES query took ${duration} (${responseMap.took} server-side)")
+            if (duration >= ES_LOG_MIN_DURATION) {
+                log.info("ES query took ${duration} (${responseMap.took} server-side)")
+            }
 
             def results = [:]
 


### PR DESCRIPTION
Currently the API whelk log in production has few million lines like this every day:
```
INFO whelk.component.ElasticSearch - ES query took 48 (46 server-side)
```
This is a) not particularly useful and b) makes it more annoying to find other things in the log. Let's write a log entry only if the query exceeded a certain amount of time.