### PR TITLE
Check exclude list also when actually about to remove doc

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2585,7 +2585,7 @@ class PostgreSQLComponent {
 
     void remove(String identifier, String changedIn, String changedBy, boolean force=false) {
         if (versioning) {
-            if(!force && !followDependers(identifier).isEmpty())
+            if(!force && !followDependers(identifier, JsonLd.ALLOW_LINK_TO_DELETED).isEmpty())
                 throw new RuntimeException("Deleting depended upon records is not allowed.")
 
             log.debug("Marking document with ID ${identifier} as deleted.")


### PR DESCRIPTION
Follow up on https://github.com/libris/librisxl/pull/1315 which allows the document we wish to delete to pass the dependency check at CRUD level, however it still got stopped at the next dependency check, before actually deleting from postgres.