### PR TITLE
Terminate script immediately (with explicit exit code) on error

### DIFF
--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -693,7 +693,7 @@ class WhelkTool {
         }
         if (errorDetected) {
             log "Script terminated due to an error, see $reportsDir/ERRORS.txt for more info"
-            System.exit(2)
+            System.exit(1)
         }
         log "Done!"
     }

--- a/whelktool/src/main/groovy/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/datatool/WhelkTool.groovy
@@ -281,12 +281,7 @@ class WhelkTool {
     }
 
     private void select(Iterable<Document> selection, Closure process,
-                        int batchSize = DEFAULT_BATCH_SIZE, boolean newItems = false) {
-        if (errorDetected) {
-            log "Error detected, refusing further processing."
-            return
-        }
-
+                        int batchSize = DEFAULT_BATCH_SIZE, boolean newItems = false) throws Exception {
         int batchCount = 0
         Batch batch = new Batch(number: ++batchCount)
 
@@ -303,6 +298,7 @@ class WhelkTool {
                     err.printStackTrace errorLog
                     errorLog.println "-" * 20
                     errorLog.flush()
+                    errorDetected = err
             }
         }
 
@@ -351,6 +347,11 @@ class WhelkTool {
             log()
         }
         loggerFuture?.cancel(true)
+
+        if (errorDetected) {
+            log "Error detected, refusing further processing."
+            throw new Exception()
+        }
     }
 
     private def createExecutorService() {
@@ -676,9 +677,12 @@ class WhelkTool {
         log()
 
         bindings = createMainBindings()
-        script.eval(bindings)
 
-        finish()
+        try {
+            script.eval(bindings)
+        } finally {
+            finish()
+        }
     }
 
     private void finish() {
@@ -686,6 +690,10 @@ class WhelkTool {
         logWriters.each {
             it.flush()
             it.close()
+        }
+        if (errorDetected) {
+            log "Script terminated due to an error, see $reportsDir/ERRORS.txt for more info"
+            System.exit(2)
         }
         log "Done!"
     }


### PR DESCRIPTION
- Before, if a script contained several calls to `select` and one failed, the subsequent ones would still be run.
- The exit code is useful e.g. for controlling the course of events when running Whelktool scripts from within a shell script.