### PR TITLE
Guarantee meaningful closeMatch links by matching primary contributors

### DIFF
--- a/librisworks/src/main/groovy/se/kb/libris/mergeworks/Doc.groovy
+++ b/librisworks/src/main/groovy/se/kb/libris/mergeworks/Doc.groovy
@@ -178,6 +178,10 @@ class Doc {
         asList(instanceData?.reproductionOf)
     }
 
+    Map primaryContributor() {
+        contribution().findResult { it['@type'] == 'PrimaryContribution' ? asList(it.agent).find() : null }
+    }
+
     String editionStatement() {
         instanceData?.editionStatement
     }


### PR DESCRIPTION
As per earlier discussion, add `closeMatch` link to another work from same cluster only if the other work has the same agent in `PrimaryContribution`.