### PR TITLE
Include sameAs URIs when loading instance relators

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
@@ -31,10 +31,10 @@ class ContributionByRoleStep extends MarcFramePostProcStepBase {
             if (domainRef) {
               def domain = ld.toTermKey(domainRef)
               if (ld.isSubClassOf(domain, 'Embodiment')) {
-                return it[ID]
+                return [it[ID]] + it['sameAs'].collect { it[ID] }
               }
             }
-        } as Set
+        }.flatten() as Set
         log.debug "Using as instance relations: $instanceRelators"
     }
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
@@ -113,8 +113,8 @@
             "contribution": [
               {
                 "role": [
-                  {"@id": "https://id.kb.se/relator/author"},
-                  {"@id": "https://id.kb.se/relator/publisher"}
+                  {"@id": "https://id.kb.se/relator/aut"},
+                  {"@id": "https://id.kb.se/relator/pbl"}
                 ],
                 "@type": "PrimaryContribution",
                 "agent": {"@id": "x"}
@@ -131,7 +131,7 @@
             "contribution": [
               {
                 "role": [
-                  {"@id": "https://id.kb.se/relator/author"}
+                  {"@id": "https://id.kb.se/relator/aut"}
                 ],
                 "@type": "PrimaryContribution",
                 "agent": {"@id": "x"}
@@ -141,7 +141,7 @@
           "contribution": [
               {
                 "role": [
-                  {"@id": "https://id.kb.se/relator/publisher"}
+                  {"@id": "https://id.kb.se/relator/pbl"}
                 ],
                 "@type": "Contribution",
                 "agent": {"@id": "x"}
@@ -157,14 +157,14 @@
             "contribution": [
               {
                 "role": [
-                  {"@id": "https://id.kb.se/relator/author"}
+                  {"@id": "https://id.kb.se/relator/aut"}
                 ],
                 "@type": "PrimaryContribution",
                 "agent": {"@id": "x"}
               },
               {
                 "role": [
-                  {"@id": "https://id.kb.se/relator/publisher"}
+                  {"@id": "https://id.kb.se/relator/pbl"}
                 ],
                 "@type": "Contribution",
                 "agent": {"@id": "x"}


### PR DESCRIPTION
...because that's the given URI form in the batch import.