### PR TITLE
Use equals method instead of ==

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -100,7 +100,7 @@ class DocumentUtil {
 
         for (int i = 0; i < path.size(); i++) {
             def p = path[i]
-            if (p == '*') {
+            if (p.equals('*')) {
                 if (item instanceof Collection) {
                     return item.collect { getAtPath(it, path.drop(i + 1), []) }.flatten()
                 } else {


### PR DESCRIPTION
Apparently e.g. `42 == '*'` evaluates to `true` in groovy since 42 is the asterisk's ASCII decimal value. This led to `getAtPath()` incorrectly returning a `List` when the input path contained index 42 and this in turn caused:
``` 
ERROR whelk.converter.marc.RomanizationStep - Failed to convert 880 for record https://libris-qa.kb.se/r82xwts31z7hrv8: groovy.lang.MissingMethodException: No signature of method: java.util.ArrayList.keySet() is applicable for argument types: () values: []
Nov 21 15:29:13 export-repl01-qa.libris.kb.se server[10527]: Possible solutions: toSet(), toSet(), set(int, java.lang.Object), set(int, java.lang.Object), get(int), get(int)
```
when trying to call `keySet()` here:
https://github.com/libris/librisxl/blob/91bcf6d3aab9063848419b434dfa72833944b305/whelk-core/src/main/groovy/whelk/converter/marc/RomanizationStep.groovy#L524

We probably need to replace `==` elsewhere too but let's start here where we know that it causes problem. 