### PR TITLE
Do linkFinder.normalizeIdentifiers in RemoteSearchAPI

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.groovy
@@ -12,6 +12,7 @@ import whelk.IdGenerator
 import whelk.Whelk
 import whelk.converter.MarcJSONConverter
 import whelk.converter.marc.MarcFrameConverter
+import whelk.filter.LinkFinder
 import whelk.util.LegacyIntegrationTools
 import whelk.util.PropertyLoader
 import whelk.util.WhelkFactory
@@ -39,6 +40,7 @@ class RemoteSearchAPI extends HttpServlet {
     final String DEFAULT_DATABASE = "LC"
 
     private Whelk whelk
+    private LinkFinder linkFinder
 
     private Set<String> m_undesirableFields
     private Set<String> m_undesirableFieldsAuth
@@ -54,6 +56,7 @@ class RemoteSearchAPI extends HttpServlet {
             whelk = WhelkFactory.getSingletonWhelk()
         }
         marcFrameConverter = whelk.getMarcFrameConverter()
+        linkFinder = new LinkFinder(whelk.storage)
 
         m_undesirableFields = new HashSet<>()
 
@@ -346,6 +349,7 @@ class RemoteSearchAPI extends HttpServlet {
                         log.trace("Marcframeconverter done")
 
                         Document doc = new Document(jsonDoc)
+                        linkFinder.normalizeIdentifiers(doc);
                         whelk.normalize(doc)
                         whelk.embellish(doc)
                         results.addHit(doc)


### PR DESCRIPTION
After conversion from MARC the documents might contain entities with both `@id` and data

```
"language": { "@id": "https://id.kb.se/language/eng", "code": "eng" }
```

This trips up Embellisher which doesn't see it as a link (`@id` and size == 1). 
So https://id.kb.se/language/eng is not added to embellish data.

The same thing then happens in the cataloging interface, so the definition for English is not fetched there by `addMissingLinksToQuoted` either. This leads to a chip with the URI instead of the label in the form for the imported record.

![bild](https://github.com/libris/librisxl/assets/51744858/99d7908a-4063-4b2a-a161-4f73b723ed30)


`linkFinder.normalizeIdentifiers` runs `clearReferenceAmbiguities` which clears out `code` in this example.
I guess we could use a cheaper version which doesn't do any id checks against the DB in this case.