### PR TITLE
Search: Fix sorting on hasTitle.mainTitle

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -480,9 +480,13 @@ class ESQuery {
         def (String field, String sortOrder) = getFieldAndSortOrder(sortParam)
         String termPath = getInferredTermPath(field)
         Map clause = [(termPath): ['order': sortOrder]]
+        // FIXME: this should be based on if the path is inside nested, not hardcoded to hasTitle.mainTitle
+        // what about the filter condition then?
         if (field == 'hasTitle.mainTitle' || field == 'hasTitle.mainTitle.keyword') {
-            clause[termPath]['nested_path'] = 'hasTitle'
-            clause[termPath]['nested_filter'] = ['term': ['hasTitle.@type': 'Title']]
+            clause[termPath]['nested'] = [
+                'path': 'hasTitle',
+                'filter': ['term': ['hasTitle.@type': 'Title']]
+            ]
         }
         return clause
     }


### PR DESCRIPTION
Broke since the the way to specify sorting on nested docs in ES has changed.

nested_path och nested_filter were deprecated in ES6 and removed in ES8. 
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/sort-search-results.html#nested-sorting