### PR TITLE
Feature/speed up merge works

### DIFF
--- a/librisworks/run.sh
+++ b/librisworks/run.sh
@@ -9,7 +9,7 @@ count_lines() {
   fi
 }
 
-if ! [[ "$1" =~ ^(local|dev|dev2|qa|stg|prod)$ ]]; then
+if ! [[ "$1" =~ ^(local|dev|dev2|qa|stg|prod|edu)$ ]]; then
   echo "Missing or invalid environment"
   exit 1
 fi
@@ -126,6 +126,6 @@ fi
 # Merge
 echo
 echo "Merging..."
-time java -Dxl.secret.properties=$HOME/secret.properties-$ENV -Dclusters=$NO_ANONYMOUS_TRANSLATIONS/$CLUSTER_TSV -jar $JAR_FILE \
+time java -Xmx4G -Dxl.secret.properties=$HOME/secret.properties-$ENV -Dclusters=$NO_ANONYMOUS_TRANSLATIONS/$CLUSTER_TSV -jar $JAR_FILE \
   $ARGS --report $MERGED_WORKS_DIR $SCRIPTS_DIR/merge-works.groovy 2>/dev/null
 echo "Done! See reports in $MERGED_WORKS_DIR"

--- a/librisworks/src/main/groovy/se/kb/libris/mergeworks/DisplayDoc.groovy
+++ b/librisworks/src/main/groovy/se/kb/libris/mergeworks/DisplayDoc.groovy
@@ -6,7 +6,6 @@ import whelk.util.DocumentUtil
 
 class DisplayDoc {
     Doc doc
-    Map framed
 
     DisplayDoc(Doc doc) {
         this.doc = doc
@@ -21,11 +20,11 @@ class DisplayDoc {
     }
 
     // TODO...
-    String getDisplayText(String field) {
+    String getDisplayText(String field, Map framed) {
         if (field == 'contribution') {
-            return contributorStrings().join("<br>")
+            return contributorStrings(framed).join("<br>")
         } else if (field == 'classification') {
-            return classificationStrings().join("<br>")
+            return classificationStrings(framed).join("<br>")
         } else if (field == 'instance title') {
             return doc.instanceTitle() ?: ''
         } else if (field == 'instance type') {
@@ -74,9 +73,9 @@ class DisplayDoc {
         return base + kat + id
     }
 
-    private List contributorStrings() {
+    private List contributorStrings(Map framed) {
         List path = doc.instanceData ? ['instanceOf', 'contribution'] : ['contribution']
-        List contribution = DocumentUtil.getAtPath(getFramed(), path, [])
+        List contribution = DocumentUtil.getAtPath(framed, path, [])
 
         return contribution.collect { Map c ->
             contributionStr(c)
@@ -100,9 +99,9 @@ class DisplayDoc {
         return s.toString()
     }
 
-    List classificationStrings() {
+    List classificationStrings(Map framed) {
         List path = doc.instanceData ? ['instanceOf', 'classification'] : ['classification']
-        List classification = DocumentUtil.getAtPath(getFramed(), path, [])
+        List classification = DocumentUtil.getAtPath(framed, path, [])
 
         classification.collect { c ->
             StringBuilder s = new StringBuilder()
@@ -146,12 +145,8 @@ class DisplayDoc {
     }
 
     Map getFramed() {
-        if (!framed) {
-            Document copy = doc.document.clone()
-            doc.whelk.embellish(copy)
-            framed = JsonLd.frame(doc.thingIri(), copy.data)
-        }
-
-        return framed
+        Document copy = doc.document.clone()
+        doc.whelk.embellish(copy)
+        return JsonLd.frame(doc.thingIri(), copy.data)
     }
 }

--- a/librisworks/src/main/groovy/se/kb/libris/mergeworks/Html.groovy
+++ b/librisworks/src/main/groovy/se/kb/libris/mergeworks/Html.groovy
@@ -100,11 +100,12 @@ class Html {
     }
 
     private static def fieldRows(Collection<Doc> cluster, String cls) {
-        { field ->
+        cluster = cluster.collect { [it, it.view.getFramed()] }
+        return { field ->
             """
             <tr class="${cls}">
                 <td>${field}</td>
-                ${cluster.collect { "<td>${it.view.getDisplayText(field)}</td>" }.join('\n')}   
+                ${ cluster.collect { doc, framed -> "<td>${ doc.view.getDisplayText(field, framed) }</td>" }.join('\n') }
             </tr> """.stripIndent()
         }
     }


### PR DESCRIPTION
Not doing a selectBy for each document individually did the trick. Comes with a slight cost though as we instead need to keep lots of data in memory. So had to make some adjustments to compensate for the higher memory usage.

Tested in dev2 where the merging and linking part took only a couple hours. Reporting is slower but that's not important.

Planning to rehearse the whole thing one last time in QA on Monday. See https://jira.kb.se/browse/FMT-205 for more info.