### PR TITLE
Do not drop contributions without roles

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy
@@ -71,16 +71,23 @@ class ContributionByRoleStep extends MarcFramePostProcStepBase {
                 }
             }
 
+            Map contrib = null
+
             if (instanceRoles) {
-              def contrib = it.clone()
+                contrib = it.clone()
                 contrib.role = instanceRoles
                 setToPlainContribution(contrib)
                 instanceContribs << contrib
             }
+
             if (workRoles) {
-                def contrib = it.clone()
+                contrib = it.clone()
                 contrib.role = workRoles
                 workContribs << contrib
+            }
+
+            if (contrib == null) {
+                workContribs << it
             }
         }
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-contribution.json
@@ -27,6 +27,114 @@
       }
     },
     {
+      "name": "Keep role-less agents 1",
+      "source": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "@type": "Contribution",
+                "agent": {"@id": "x"}
+              },
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/publisher"}
+                ],
+                "@type": "Contribution",
+                "agent": {"@id": "y"}
+              }
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "contribution": [
+            {
+              "role": [
+                {"@id": "https://id.kb.se/relator/publisher"}
+              ],
+              "@type": "Contribution",
+              "agent": {"@id": "y"}
+            }
+          ],
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "@type": "Contribution",
+                "agent": {"@id": "x"}
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "Keep role-less agents 2",
+      "source": {
+        "mainEntity": {
+          "@type": "Instance",
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "@type": "PrimaryContribution",
+                "role": [
+                  {"@id": "https://id.kb.se/relator/author"}
+                ],
+                "agent": {"@id": "x"}
+              },
+              {
+                "role": [
+                  {"@id": "https://id.kb.se/relator/publisher"}
+                ],
+                "@type": "Contribution",
+                "agent": {"@id": "y"}
+              },
+              {
+                "@type": "Contribution",
+                "agent": {"@id": "z"}
+              }
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@type": "Instance",
+          "contribution": [
+            {
+              "role": [
+                {"@id": "https://id.kb.se/relator/publisher"}
+              ],
+              "@type": "Contribution",
+              "agent": {"@id": "y"}
+            }
+          ],
+          "instanceOf": {
+            "@type": "Text",
+            "contribution": [
+              {
+                "@type": "PrimaryContribution",
+                "role": [
+                  {"@id": "https://id.kb.se/relator/author"}
+                ],
+                "agent": {"@id": "x"}
+              },
+              {
+                "@type": "Contribution",
+                "agent": {"@id": "z"}
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "name": "Move publisher",
       "source": {
         "mainEntity": {


### PR DESCRIPTION
Fixes bug in ContributionByRoleStep, which dropped contributions without roles if there was at least one contribution with an instance-level role. The reason was that if some contributions where moved,  only those with explicit work-level roles where kept in the set of work contributions.

**CAUTION:** Only approve on github but do not merge this here; use `git flow hotfix finish` (I'll do that once approved unless :bus: ).