### PR TITLE
Fix sorting on fields with numeric_extractor, e.g. publication.year

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -774,7 +774,7 @@ class ESQuery {
                     boolean isSimple = isSimple(val)
                     clauses.add([(isSimple ? 'simple_query_string' : 'query_string'): [
                             'query'           : isSimple ? val : escapeNonSimpleQueryString(val),
-                            'fields'          : [expandLangMapKeys(field)],
+                            'fields'          : [getInferredTermPath(expandLangMapKeys(field))],
                             'default_operator': 'AND'
                     ]])
                 }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -480,7 +480,7 @@ class ESQuery {
     @CompileStatic(TypeCheckingMode.SKIP)
     private Map getSortClause(String sortParam) {
         def (String field, String sortOrder) = getFieldAndSortOrder(sortParam)
-        String termPath = getInferredTermPath(field)
+        String termPath = getInferredSortTermPath(field)
         Map clause = [(termPath): ['order': sortOrder]]
         // FIXME: this should be based on if the path is inside nested, not hardcoded to hasTitle.mainTitle
         // what about the filter condition then?
@@ -502,6 +502,15 @@ class ESQuery {
     }
 
     private String getInferredTermPath(String termPath) {
+        termPath = expandLangMapKeys(termPath)
+        if (termPath in keywordFields) {
+            return "${termPath}.keyword"
+        } else {
+            return termPath
+        }
+    }
+
+    private String getInferredSortTermPath(String termPath) {
         termPath = expandLangMapKeys(termPath)
         if (termPath in keywordFields && termPath !in numericExtractorFields) {
             return "${termPath}.keyword"

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -27,7 +27,8 @@ class ESQuery {
     private Set keywordFields
     private Set dateFields
     private Set nestedFields
-    
+    private Set numericExtractorFields
+
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
         'q', 'o', '_limit', '_offset', '_sort', '_statsrepr', '_site_base_uri', '_debug', '_boost', '_lens', '_stats', '_suggest', '_site'
@@ -74,7 +75,8 @@ class ESQuery {
             this.keywordFields =  getKeywordFields(mappings)
             this.dateFields = getFieldsOfType('date', mappings)
             this.nestedFields = getFieldsOfType('nested', mappings)
-            
+            this.numericExtractorFields = getFieldsWithAnalyzer('numeric_extractor', mappings)
+
             if (mappings['properties']['__prefLabel']) {
                 whelk.elastic.ENABLE_SMUSH_LANG_TAGGED_PROPS = true
                 log.info("ENABLE_SMUSH_LANG_TAGGED_PROPS = true")
@@ -501,7 +503,7 @@ class ESQuery {
 
     private String getInferredTermPath(String termPath) {
         termPath = expandLangMapKeys(termPath)
-        if (termPath in keywordFields) {
+        if (termPath in keywordFields && termPath !in numericExtractorFields) {
             return "${termPath}.keyword"
         } else {
             return termPath
@@ -929,9 +931,17 @@ class ESQuery {
     }
 
     static Set getFieldsOfType(String type, Map mappings) {
+        getFieldsWithSetting('type', type, mappings)
+    }
+
+    static Set getFieldsWithAnalyzer(String analyzer, Map mappings) {
+        getFieldsWithSetting('analyzer', analyzer, mappings)
+    }
+
+    static Set getFieldsWithSetting(String setting, String value, Map mappings) {
         Set fields = [] as Set
-        DocumentUtil.findKey(mappings['properties'], 'type') { value, path ->
-            if (value == type) {
+        DocumentUtil.findKey(mappings['properties'], setting) { v, path ->
+            if (v == value) {
                 fields.add(path.dropRight(1).findAll{ it != 'properties'}.join('.'))
             }
             DocumentUtil.NOP


### PR DESCRIPTION
Some fields are indexed as text with the "numeric_extractor" analyzer. See [libris_config.json](https://github.com/libris/librisxl/blob/develop/librisxl-tools/elasticsearch/libris_config.json). This keeps four-digit years and throws away everything else. For example "℗2006" -> "2006", "uuuu" -> null. They are also indexed as keyword fields under <property>.keyword which preserves the raw value.

For sorting we want to use the analyzed value, i.e the four-digit year. By default elastic puts missing values last so this works both ascending and descending.

Fixes sorting on publication.year, publication.startYear, publication.endYear.


This also fixes filtering on years like "nnnn". Before they showed up in facets but didn't work.
https://libris-qa.kb.se/katalogisering/search/libris?q=*&@type=Instance&_limit=20&and-publication.year=nnnn