### PR TITLE
Allow dead links at certain paths when saving doc

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1190,8 +1190,8 @@ class PostgreSQLComponent {
             }
 
         getSystemIds(linksByIri.keySet(), connection) { String iri, String systemId, boolean deleted ->
-            if (deleted) // doc refers to a deleted document which is not ok.
-                throw new LinkValidationException("Record supposedly depends on deleted record: ${systemId}, which is not allowed.")
+            if (deleted && !JsonLd.ALLOW_LINK_TO_DELETED.containsAll(linksByIri[iri]*.relation))
+                throw new LinkValidationException("Forbidden link(s) to deleted resource ${systemId} found in ${linksByIri[iri]*.relation}")
 
             if (systemId != doc.getShortId()) // Exclude A -> A (self-references)
                 dependencies.addAll(linksByIri[iri].collect { [it.relation, systemId] as String[] })


### PR DESCRIPTION
See [LXL-4450](https://jira.kb.se/browse/LXL-4450) and previously [LXL-4209](https://jira.kb.se/browse/LXL-4209) (which only made deleting possible, not resaving apparently). 