### PR TITLE
Embellish: Add support for integral inverse relations

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -67,8 +67,8 @@ class Embellisher {
 
         // TODO? reach doc from same doc via integral and non-integral
         // TODO reach doc vn non-integral and inverse integral
-        // TODO: don't hardcode 'full' as start? could be 'cards' for ES index
-        def docs = fetchIntegral('full', integral(getAllLinks(start)), visitedIris).collect()
+        // TODO: don't hardcode 'full'? could be 'cards' for index
+        def docs = fetchIntegral('full', start, integral(getAllLinks(start)), visitedIris).collect()
 
         List result = docs.collect()
         Set<Link> links = getAllLinks(start + docs)
@@ -79,7 +79,7 @@ class Embellisher {
             docs = fetchNonVisited(lens, uniqueIris(links), visitedIris)
             links = getAllLinks(docs)
 
-            def integralDocs = fetchIntegral(lens, integral(links), visitedIris)
+            def integralDocs = fetchIntegral(lens, docs, integral(links), visitedIris)
             docs += integralDocs
             links += getAllLinks(integralDocs)
 
@@ -136,9 +136,8 @@ class Embellisher {
         return data
     }
 
-    private Iterable<Map> fetchIntegral(String lens, Set<Link> integralLinks, Set<String> visitedIris) {
+    private Iterable<Map> fetchIntegral(String lens, Iterable<Map> docs, Set<Link> integralLinks, Set<String> visitedIris) {
         List<Map> result = []
-        Iterable<Map> docs
         while(true) {
             docs = fetchNonVisited(lens, uniqueIris(integralLinks), visitedIris)
             integralLinks = integral(getAllLinks(docs))

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -216,7 +216,12 @@ class Embellisher {
 
             theThing[JsonLd.REVERSE_KEY][relation] = irisLinkingHere.collect { [(JsonLd.ID_KEY): it] }
             if (applyLens) {
-                cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
+                if (relation in inverseIntegralRelations) {
+                    cards.addAll(fetchNonVisited(forLens, irisLinkingHere, visitedIris))
+                } else {
+                    cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
+                }
+                //cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
             }
         }
         return cards

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -139,7 +139,11 @@ class Embellisher {
     private Iterable<Map> fetchIntegral(String lens, Iterable<Map> docs, Set<Link> integralLinks, Set<String> visitedIris) {
         List<Map> result = []
         while(true) {
+            var previousDocs = docs
             docs = fetchNonVisited(lens, uniqueIris(integralLinks), visitedIris)
+            for (Map doc in previousDocs) {
+                docs += insertInverseIntegral(lens, doc, lens, visitedIris)
+            }
             integralLinks = integral(getAllLinks(docs))
 
             if (docs.isEmpty()) {
@@ -186,7 +190,20 @@ class Embellisher {
     }
 
     private Iterable<Map> insertInverse(String forLens, Map thing, String applyLens, Set<String> visitedIris) {
+        _insertInverse(forLens, thing, applyLens, visitedIris, false)
+    }
+
+    private Iterable<Map> insertInverseIntegral(String forLens, Map thing, String applyLens, Set<String> visitedIris) {
+        _insertInverse(forLens, thing, applyLens, visitedIris, true)
+    }
+
+    private Iterable<Map> _insertInverse(String forLens, Map thing, String applyLens, Set<String> visitedIris, boolean onlyIntegral) {
         Set<String> inverseRelations = jsonld.getInverseProperties(thing, forLens)
+        if (onlyIntegral) {
+            inverseRelations = inverseIntegralRelations.intersect(inverseRelations) as Set
+        } else {
+            inverseRelations -= inverseIntegralRelations // they should already have been handled
+        }
         if (inverseRelations.isEmpty()) {
             return Collections.EMPTY_LIST
         }

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -65,9 +65,7 @@ class Embellisher {
         Set<String> visitedIris = new HashSet<>()
         visitedIris.addAll(plusWithoutHash(document.getThingIdentifiers()))
 
-        // TODO? reach doc from same doc via integral and non-integral
-        // TODO reach doc vn non-integral and inverse integral
-        // TODO: don't hardcode 'full'? could be 'cards' for index
+        // TODO? don't hardcode 'full'? could be 'cards' for index
         def docs = fetchIntegral('full', start, integral(getAllLinks(start)), visitedIris).collect()
 
         List result = docs.collect()

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -212,12 +212,7 @@ class Embellisher {
 
             theThing[JsonLd.REVERSE_KEY][relation] = irisLinkingHere.collect { [(JsonLd.ID_KEY): it] }
             if (applyLens) {
-                if (relation in inverseIntegralRelations) {
-                    cards.addAll(fetchNonVisited(forLens, irisLinkingHere, visitedIris))
-                } else {
-                    cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
-                }
-                //cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
+                cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
             }
         }
         return cards

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -37,7 +37,8 @@ class Embellisher {
         
         def integral = jsonld.getCategoryMembers('integral')
         if (integral) {
-            setIntegralRelations(integral)
+            this.integralRelations = integral
+            this.inverseIntegralRelations = integralRelations.collect{ jsonld.getInverseProperty(it) }.grep()
         }
     }
 
@@ -48,11 +49,6 @@ class Embellisher {
 
     void setEmbellishLevels(List<String> embellishLevels) {
         this.embellishLevels = embellishLevels.collect()
-    }
-
-    void setIntegralRelations(Collection<String> integralRelations) {
-        this.integralRelations = integralRelations.collect()
-        this.inverseIntegralRelations = integralRelations.collect{ jsonld.getInverseProperty(it) }.grep()
     }
 
     void setFollowInverse(boolean followInverse) {

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -67,8 +67,8 @@ class Embellisher {
 
         // TODO? reach doc from same doc via integral and non-integral
         // TODO reach doc vn non-integral and inverse integral
-        // TODO: don't hardcode 'full'? could be 'cards' for index
-        def docs = fetchIntegral('full', start, integral(getAllLinks(start)), visitedIris).collect()
+        // TODO: don't hardcode 'full' as start? could be 'cards' for ES index
+        def docs = fetchIntegral('full', integral(getAllLinks(start)), visitedIris).collect()
 
         List result = docs.collect()
         Set<Link> links = getAllLinks(start + docs)
@@ -79,7 +79,7 @@ class Embellisher {
             docs = fetchNonVisited(lens, uniqueIris(links), visitedIris)
             links = getAllLinks(docs)
 
-            def integralDocs = fetchIntegral(lens, docs, integral(links), visitedIris)
+            def integralDocs = fetchIntegral(lens, integral(links), visitedIris)
             docs += integralDocs
             links += getAllLinks(integralDocs)
 
@@ -136,8 +136,9 @@ class Embellisher {
         return data
     }
 
-    private Iterable<Map> fetchIntegral(String lens, Iterable<Map> docs, Set<Link> integralLinks, Set<String> visitedIris) {
+    private Iterable<Map> fetchIntegral(String lens, Set<Link> integralLinks, Set<String> visitedIris) {
         List<Map> result = []
+        Iterable<Map> docs
         while(true) {
             docs = fetchNonVisited(lens, uniqueIris(integralLinks), visitedIris)
             integralLinks = integral(getAllLinks(docs))

--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -69,6 +69,8 @@ class Embellisher {
         Set<String> visitedIris = new HashSet<>()
         visitedIris.addAll(plusWithoutHash(document.getThingIdentifiers()))
 
+        // TODO? reach doc from same doc via integral and non-integral
+        // TODO reach doc vn non-integral and inverse integral
         // TODO: don't hardcode 'full'? could be 'cards' for index
         def docs = fetchIntegral('full', start, integral(getAllLinks(start)), visitedIris).collect()
 
@@ -214,11 +216,7 @@ class Embellisher {
 
             theThing[JsonLd.REVERSE_KEY][relation] = irisLinkingHere.collect { [(JsonLd.ID_KEY): it] }
             if (applyLens) {
-                if (relation in inverseIntegralRelations) {
-                    cards.addAll(fetchNonVisited(forLens, irisLinkingHere, visitedIris))
-                } else {
-                    cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
-                }
+                cards.addAll(fetchNonVisited(applyLens, irisLinkingHere, visitedIris))
             }
         }
         return cards

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -10,6 +10,7 @@ import whelk.exception.FramingException
 import whelk.exception.WhelkRuntimeException
 import whelk.util.DocumentUtil
 
+import javax.annotation.Nullable
 import java.util.regex.Matcher
 
 @CompileStatic
@@ -566,8 +567,12 @@ class JsonLd {
         }
     }
 
+    @Nullable
     String getInverseProperty(String propertyName) {
         Map relDescription = vocabIndex[propertyName]
+        if (!relDescription) {
+            return null
+        }
         // NOTE: resilient in case we add inverseOf as a direct term
         def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
         List revIds = asList(inverseOf)?.collect {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -553,14 +553,8 @@ class JsonLd {
 
     @TypeChecked(TypeCheckingMode.SKIP)
     void applyInverses(Map thing) {
-        thing[REVERSE_KEY]?.each { rel, subjects ->
-            Map relDescription = vocabIndex[rel]
-            // NOTE: resilient in case we add inverseOf as a direct term
-            def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
-            List revIds = asList(inverseOf)?.collect {
-                toTermKey((String) it[ID_KEY])
-            }
-            String rev = revIds.find { it in vocabIndex }
+        thing[REVERSE_KEY]?.each { String rel, subjects ->
+            String rev = getInverseProperty(rel)
             if (rev) {
                 thing[rev] = asList(thing.get(rev, []))
                 thing[rev].addAll(asList(subjects))
@@ -570,6 +564,16 @@ class JsonLd {
                 }
             }
         }
+    }
+
+    String getInverseProperty(String propertyName) {
+        Map relDescription = vocabIndex[propertyName]
+        // NOTE: resilient in case we add inverseOf as a direct term
+        def inverseOf = relDescription['owl:inverseOf'] ?: relDescription.inverseOf
+        List revIds = asList(inverseOf)?.collect {
+            toTermKey((String) it[ID_KEY])
+        }
+        return revIds.find { it in vocabIndex }
     }
 
     static List asList(o) {

--- a/whelk-core/src/test/groovy/EmbellishSpec.groovy
+++ b/whelk-core/src/test/groovy/EmbellishSpec.groovy
@@ -8,6 +8,27 @@ import whelk.Link
 import whelk.util.JsonLdSpec
 
 class EmbellishSpec extends Specification {
+    static final Map CONTEXT_DATA = [
+            "@context": [
+                    "@vocab": "https://example.org/ns/",
+                    "pfx": "https://example.org/pfx/"
+            ]
+    ]
+    
+    static final Map VOCAB_DATA = [
+            "@graph": [
+                    ["@id": "https://example.org/ns/R"],
+                    ["@id": "https://example.org/ns/X"],
+                    ["@id": "https://example.org/ns/Y"],
+                    ["@id": "https://example.org/ns/pr1"],
+                    ["@id": "https://example.org/ns/px1"],
+                    ["@id": "https://example.org/ns/px2"],
+                    ["@id": "https://example.org/ns/py1"],
+                    ["@id": "https://example.org/ns/CR", "category": ["@id": "integral"]],
+                    ["@id": "https://example.org/ns/CR2", "category": ["@id": "integral"]],
+            ]
+    ]
+
     static final Map DISPLAY_DATA = [
             'lensGroups':
                     ['chips':
@@ -128,7 +149,7 @@ digraph {
 
     def "should by default embellish recursively, two levels, using cards, chips"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing', 'px1': ['@id': '/thingX1']]
@@ -264,7 +285,7 @@ digraph {
 
     def "should handle integral relations"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing', 'CR': ['@id': '/thingX0'], 'px1': ['@id': '/thingX1']]
@@ -314,7 +335,6 @@ digraph {
         docs.each(storage.&add)
 
         def embellisher = new Embellisher(ld, storage.&getFull, storage.&getCards, storage.&getReverseLinks)
-        embellisher.setIntegralRelations(['CR'])
 
         Document document = new Document(doc)
 
@@ -409,7 +429,7 @@ digraph {
 
     def "should handle multi-level integral relations"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing', 'CR': ['@id': '/thingX0'], 'px1': ['@id': '/thingX1']]
@@ -467,7 +487,6 @@ digraph {
         docs.each(storage.&add)
 
         def embellisher = new Embellisher(ld, storage.&getFull, storage.&getCards, storage.&getReverseLinks)
-        embellisher.setIntegralRelations(['CR', 'CR2'])
 
         Document document = new Document(doc)
 
@@ -532,7 +551,7 @@ digraph {
 
     def "should follow integral relations before other relations"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing', 'CR': ['@id': '/thingX0'], 'px1': ['@id': '/thingX0']]
@@ -550,7 +569,6 @@ digraph {
         docs.each(storage.&add)
 
         def embellisher = new Embellisher(ld, storage.&getFull, storage.&getCards, storage.&getReverseLinks)
-        embellisher.setIntegralRelations(['CR', 'CR2'])
 
         Document document = new Document(doc)
 
@@ -602,7 +620,7 @@ digraph {
 
     def "should follow integral relations before other relations (also when shorter path exists)"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [
                 ['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
@@ -629,7 +647,6 @@ digraph {
         docs.each(storage.&add)
 
         def embellisher = new Embellisher(ld, storage.&getFull, storage.&getCards, storage.&getReverseLinks)
-        embellisher.setIntegralRelations(['CR', 'CR2'])
 
         Document document = new Document(doc)
 
@@ -728,7 +745,7 @@ digraph {
 
     def "should embellish recursively, three levels, using cards, chips, chips"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing', 'px1': ['@id': '/thingX1']]
@@ -807,7 +824,7 @@ digraph {
 
     def "should understand sameAs when avoiding loops in embellish graph"() {
         given:
-        def ld = new JsonLd(JsonLdSpec.CONTEXT_DATA, DISPLAY_DATA, JsonLdSpec.VOCAB_DATA)
+        def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
         def doc = ['@graph': [['@type' : 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type' : 'X',

--- a/whelk-core/src/test/groovy/EmbellishSpec.groovy
+++ b/whelk-core/src/test/groovy/EmbellishSpec.groovy
@@ -871,7 +871,7 @@ digraph {
         given:
         def ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
 
-        def doc = ['@graph': [['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
+        def doc = ['@graph': [
                               ['@type': 'R', '@id': '/record', 'mainEntity': ['@id': '/thing']],
                               ['@type': 'X', '@id': '/thing',
                                'px1' : ['@id': '/thingX0']]


### PR DESCRIPTION
If for example `hasInstance` is defined as `:category` `:integral`. Then `['inverseOf': 'instanceOf']` in a lens definition should be treated as `:integral`, i.e. following the link "is free" and embellish stays on the same level.

If only `instanceOf` is `:integral` then `['inverseOf': 'instanceOf']` is not `:integral`

Use case: Filter Works on publication.year of their Instances. 
`@reverse.instanceOf.publication.year=2024`

We will need a mechanism to limit the amount of data pulled in when following the inverse of a relation that has already been "traversed in the forward direction". But this is a separate issue.
For example `Instance instanceOf Work @reverse.instanceOf Instance2`
This is already a problem with Instances showing up as search hits for a ISBN of another Instance linking to the same Work. 

