### PR TITLE
Index all year/startYear/endYear as keyword with numeric_extractor

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -191,49 +191,6 @@
                     }
                 }
             },
-            "publication": {
-                "properties": {
-                    "year": {
-                        "fields": {
-                            "keyword": {
-                                "index": true,
-                                "type": "keyword"
-                            }
-                        },
-                        "analyzer": "numeric_extractor",
-                        "index": true,
-                        "type": "text",
-                        "fielddata": true,
-                        "copy_to": "_all"
-                    },
-                    "startYear": {
-                        "fields": {
-                            "keyword": {
-                                "index": true,
-                                "type": "keyword"
-                            }
-                        },
-                        "analyzer": "numeric_extractor",
-                        "index": true,
-                        "type": "text",
-                        "fielddata": true,
-                        "copy_to": "_all"
-                    },
-                    "endYear": {
-                        "fields": {
-                            "keyword": {
-                                "index": true,
-                                "type": "keyword"
-                            }
-                        },
-                        "analyzer": "numeric_extractor",
-                        "index": true,
-                        "type": "text",
-                        "fielddata": true,
-                        "copy_to": "_all"
-                    }
-                }
-            },
             "hasTitle": {
                 "type": "nested",
                 "include_in_parent": true,
@@ -354,6 +311,24 @@
                     "mapping": {
                         "index": true,
                         "type": "text",
+                        "copy_to": "_all"
+                    }
+                }
+            },
+            {
+                "year_template": {
+                    "match": ["year", "startYear", "endYear"],
+                    "mapping": {
+                        "fields": {
+                            "keyword": {
+                                "index": true,
+                                "type": "keyword"
+                            }
+                        },
+                        "analyzer": "numeric_extractor",
+                        "index": true,
+                        "type": "text",
+                        "fielddata": true,
                         "copy_to": "_all"
                     }
                 }


### PR DESCRIPTION
...regardless of where in the document they appear. Not only inside `publication`.

So that we can have facets on e.g.
* `@reverse.instanceOf.publication.year`
* `production.year` 

and so on.