### PR TITLE
Feature/lws 41 xlql filtering

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -158,6 +158,8 @@ class Crud extends HttpServlet {
         } catch (InvalidQueryException e) {
             log.warn("Invalid query: ${queryParameters}")
             throw new BadRequestException("Invalid query, please check the documentation. ${e.getMessage()}")
+        } catch (RedirectException e) {
+            sendRedirect(request, response, e.getMessage())
         }
     }
 
@@ -900,6 +902,12 @@ class Crud extends HttpServlet {
         
         protected NoStackTraceException(String msg, Throwable cause) {
             super(msg, cause, true, false)
+        }
+    }
+
+    static class RedirectException extends NoStackTraceException {
+        RedirectException(String msg) {
+            super(msg)
         }
     }
 }

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -67,7 +67,7 @@ public class SearchUtils2 {
         private final Map<String, Object> esQueryDsl;
 
         Query(Map<String, String[]> queryParameters) throws InvalidQueryException, IOException {
-            this.sortBy = getOptionalSingle("_sort", queryParameters).orElse(null);
+            this.sortBy = getOptionalSingleFilterEmpty("_sort", queryParameters).orElse(null);
             this.debug = queryParameters.containsKey("_debug"); // Different debug modes needed?
             this.limit = getLimit(queryParameters);
             this.offset = getOffset(queryParameters);
@@ -79,7 +79,7 @@ public class SearchUtils2 {
 
             if (q.isPresent() && i.isPresent()) {
                 var iSqt = xlqlQuery.getSimpleQueryTree(i.get());
-                if (iSqt.isFreeText()) {
+                if (iSqt.isEmpty() || iSqt.isFreeText()) {
                     var qSqt = xlqlQuery.getSimpleQueryTree(q.get());
                     if (i.get().equals(qSqt.getFreeTextPart())) {
                         // The acceptable case
@@ -211,14 +211,17 @@ public class SearchUtils2 {
             ));
         }
 
+        private static Optional<String> getOptionalSingleFilterEmpty(String name, Map<String, String[]> queryParameters) {
+            return getOptionalSingle(name, queryParameters).filter(String::isEmpty);
+        }
+
         private static Optional<String> getOptionalSingle(String name, Map<String, String[]> queryParameters) {
             return Optional.ofNullable(queryParameters.get(name))
-                    .map(x -> x[0])
-                    .filter(x -> !x.isEmpty());
+                    .map(x -> x[0]);
         }
 
         private int getLimit(Map<String, String[]> queryParameters) throws InvalidQueryException {
-            int limit = getOptionalSingle("_limit", queryParameters)
+            int limit = getOptionalSingleFilterEmpty("_limit", queryParameters)
                     .map(x -> parseInt(x, DEFAULT_LIMIT))
                     .orElse(DEFAULT_LIMIT);
 
@@ -235,7 +238,7 @@ public class SearchUtils2 {
         }
 
         private int getOffset(Map<String, String[]> queryParameters) throws InvalidQueryException {
-            int offset = getOptionalSingle("_offset", queryParameters)
+            int offset = getOptionalSingleFilterEmpty("_offset", queryParameters)
                     .map(x -> parseInt(x, DEFAULT_OFFSET))
                     .orElse(DEFAULT_OFFSET);
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -24,7 +24,7 @@ public class SearchUtils2 {
     final static int DEFAULT_OFFSET = 0;
 
     private static final Escaper QUERY_ESCAPER = UrlEscapers.urlFormParameterEscaper();
-
+    private static final List<SimpleQueryTree.PropertyValue> DEFAULT_FILTERS = List.of(SimpleQueryTree.pvEquals("rdf:type", "Work"));
 
     Whelk whelk;
     XLQLQuery xlqlQuery;
@@ -78,7 +78,7 @@ public class SearchUtils2 {
             this.statsRepr = getStatsRepr(queryParameters);
             this.simpleQueryTree = xlqlQuery.getSimpleQueryTree(queryString);
             this.outsetType = xlqlQuery.getOutsetType(simpleQueryTree);
-            this.queryTree = xlqlQuery.getQueryTree(simpleQueryTree, outsetType);
+            this.queryTree = xlqlQuery.getQueryTree(xlqlQuery.addFilters(simpleQueryTree, DEFAULT_FILTERS), outsetType);
             this.esQueryDsl = getEsQueryDsl();
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -239,8 +239,6 @@ public class SearchUtils2 {
                     .map(x -> x[0])
                     .orElse("{}");
 
-
-            // TODO: Replace ESQuery.buildStatsReprFromSliceSpec() with something more fitting
             Map<?, ?> statsMap = mapper.readValue(statsJson, LinkedHashMap.class);
             for (var entry : statsMap.entrySet()) {
                 statsRepr.put((String) entry.getKey(), entry.getValue());

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -77,8 +77,9 @@ public class SearchUtils2 {
             this.offset = getOffset(queryParameters);
             this.statsRepr = getStatsRepr(queryParameters);
             this.simpleQueryTree = xlqlQuery.getSimpleQueryTree(queryString);
-            this.outsetType = xlqlQuery.getOutsetType(simpleQueryTree);
-            this.queryTree = xlqlQuery.getQueryTree(xlqlQuery.addFilters(simpleQueryTree, DEFAULT_FILTERS), outsetType);
+            SimpleQueryTree filteredTree = xlqlQuery.addFilters(simpleQueryTree, DEFAULT_FILTERS);
+            this.outsetType = xlqlQuery.getOutsetType(filteredTree);
+            this.queryTree = xlqlQuery.getQueryTree(filteredTree, outsetType);
             this.esQueryDsl = getEsQueryDsl();
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -10,8 +10,6 @@ import whelk.xlql.QueryTree;
 import whelk.xlql.SimpleQueryTree;
 
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static whelk.util.Jackson.mapper;
@@ -73,7 +71,6 @@ public class SearchUtils2 {
             this.offset = getOffset(queryParameters);
             this.statsRepr = getStatsRepr(queryParameters);
 
-            // TODO: Distinguish between empty param and no param
             var q = getOptionalSingle("_q", queryParameters);
             var i = getOptionalSingle("_i", queryParameters);
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -13,7 +13,6 @@ import whelk.xlql.SimpleQueryTree;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static whelk.util.Jackson.mapper;
 
@@ -40,6 +39,19 @@ public class SearchUtils2 {
         @SuppressWarnings("unchecked")
         var esResponse = (Map<String, Object>) whelk.elastic.query(query.getEsQueryDsl());
         return query.getPartialCollectionView(esResponse);
+    }
+
+    public Map<String, Object> buildStatsReprFromSliceSpec(List<Map<String,Object>> sliceList) {
+        Map<String,Object> statsfind = new LinkedHashMap<>();
+        for (Map<String, Object> slice : sliceList) {
+            String key = (String) ((List<?>) slice.get("dimensionChain")).getFirst();
+            int limit = (Integer) slice.get("itemLimit");
+            var m = Map.of("sort", "value",
+                    "sortOrder", "desc",
+                    "size", limit);
+            statsfind.put(key, m);
+        }
+        return statsfind;
     }
 
     class Query {

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -25,6 +25,7 @@ public class SearchUtils2 {
 
     private static final Escaper QUERY_ESCAPER = UrlEscapers.urlFormParameterEscaper();
 
+
     Whelk whelk;
     XLQLQuery xlqlQuery;
 
@@ -43,8 +44,8 @@ public class SearchUtils2 {
         return query.getPartialCollectionView(esResponse);
     }
 
-    public Map<String, Object> buildStatsReprFromSliceSpec(List<Map<String,Object>> sliceList) {
-        Map<String,Object> statsfind = new LinkedHashMap<>();
+    public Map<String, Object> buildStatsReprFromSliceSpec(List<Map<String, Object>> sliceList) {
+        Map<String, Object> statsfind = new LinkedHashMap<>();
         for (Map<String, Object> slice : sliceList) {
             String key = (String) ((List<?>) slice.get("dimensionChain")).getFirst();
             int limit = (Integer) slice.get("itemLimit");
@@ -159,6 +160,7 @@ public class SearchUtils2 {
                 params.add(makeParam("_offset", offset));
             }
             params.add(makeParam("_limit", limit));
+            params.add(makeParam("_i", XLQLQuery.quoteSpecialSymbolsWithinFreeTextString(simpleQueryTree.getFreeTextPart().orElse("*"))));
             return params;
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -161,7 +161,7 @@ public class SearchUtils2 {
                 params.add(makeParam("_offset", offset));
             }
             params.add(makeParam("_limit", limit));
-            params.add(makeParam("_i", XLQLQuery.quoteSpecialSymbolsWithinFreeTextString(simpleQueryTree.getFreeTextPart().orElse("*"))));
+            params.add(makeParam("_i", simpleQueryTree.getFreeTextPart().orElse("*")));
             return params;
         }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -12,6 +12,8 @@ import whelk.xlql.QueryTree;
 import whelk.xlql.SimpleQueryTree;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static whelk.util.Jackson.mapper;
@@ -67,7 +69,7 @@ public class SearchUtils2 {
         private final Map<String, Object> esQueryDsl;
 
         Query(Map<String, String[]> queryParameters) throws InvalidQueryException, IOException {
-            this.queryString = queryParameters.get("_q")[0];
+            this.queryString = URLDecoder.decode(queryParameters.get("_q")[0], StandardCharsets.UTF_8); //TODO: Decoding shouldn't be necessary here, make sure the query string decoded already
             this.sortBy = getOptionalSingle("_sort", queryParameters);
             this.debug = queryParameters.containsKey("_debug"); // Different debug modes needed?
             this.limit = getLimit(queryParameters);

--- a/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
@@ -127,7 +127,7 @@ class SiteSearch {
                 queryParameters.put('_statsrepr', [mapper.writeValueAsString(searchSettings['statsindex'])] as String[])
             }
             return toDataIndexDescription(appsIndex["${activeSite}data" as String], queryParameters)
-        } else if ("_q" in queryParameters) {
+        } else if ("_q" in queryParameters || "_i" in queryParameters) {
             searchSettings = searchStatsReprs2["https://beta.libris.kb.se/"]
             if (!queryParameters['_statsrepr'] && searchSettings['statsfind']) {
                 queryParameters.put('_statsrepr', [mapper.writeValueAsString(searchSettings['statsfind'])] as String[])

--- a/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
@@ -52,8 +52,8 @@ class SiteSearch {
                 var dataDesc = getAndIndexDescription("${appId}data")
                 searchStatsReprs[appId] = [
                     (JsonLd.ID_KEY): appId,
-                    'statsfind': buildStatsReprFromSliceSpec(findDesc),
-                    'statsindex': buildStatsReprFromSliceSpec(dataDesc),
+                    'statsfind': buildStatsReprFromSliceSpec(findDesc, appId),
+                    'statsindex': buildStatsReprFromSliceSpec(dataDesc, appId),
                     'domain': appId.replaceAll('^https?://([^/]+)/', '$1')
                 ]
             }
@@ -140,9 +140,15 @@ class SiteSearch {
         return results
     }
 
-    protected Map buildStatsReprFromSliceSpec(Map desc) {
+    protected Map buildStatsReprFromSliceSpec(Map desc, String appId) {
         var stats = (Map) desc.get('statistics')
         var sliceList = (List) stats?.get('sliceList')
-        return sliceList ? search.buildStatsReprFromSliceSpec(sliceList) : null
+        if (sliceList) {
+            if (appId == "https://beta.libris.kb.se/") {
+                return search2.buildStatsReprFromSliceSpec(sliceList)
+            }
+            return search.buildStatsReprFromSliceSpec(sliceList)
+        }
+        return null
     }
 }

--- a/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SiteSearch.groovy
@@ -42,7 +42,7 @@ class SiteSearch {
             }
         }
 
-        var appIds = [whelk.applicationId]
+        var appIds = [whelk.applicationId, "https://beta.libris.kb.se/"]
         appIds += whelk.namedApplications.keySet() as List<String>
 
         appIds.each { appId ->
@@ -111,6 +111,7 @@ class SiteSearch {
             }
             return toDataIndexDescription(appsIndex["${activeSite}data" as String], queryParameters)
         } else if ("_q" in queryParameters) {
+            searchSettings = searchStatsReprs["https://beta.libris.kb.se/"]
             if (!queryParameters['_statsrepr'] && searchSettings['statsfind']) {
                 queryParameters.put('_statsrepr', [mapper.writeValueAsString(searchSettings['statsfind'])] as String[])
             }

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -11,8 +11,6 @@ import whelk.xlql.*;
 
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static whelk.util.DocumentUtil.findKey;
@@ -28,7 +26,7 @@ public class XLQLQuery {
 
     private static final String FILTERED_AGG = "a";
     private static final int DEFAULT_BUCKET_SIZE = 10;
-    private static final Escaper QUERY_ESCAPER = UrlEscapers.urlFormParameterEscaper();
+    public static final Escaper QUERY_ESCAPER = UrlEscapers.urlFormParameterEscaper();
 
 
     public XLQLQuery(Whelk whelk) {

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -50,6 +50,14 @@ public class XLQLQuery {
         return new SimpleQueryTree(flattened, disambiguate);
     }
 
+    public SimpleQueryTree addFilters(SimpleQueryTree sqt, List<SimpleQueryTree.PropertyValue> filters) {
+        SimpleQueryTree.Node tree = sqt.tree;
+        for (SimpleQueryTree.Node pv : filters) {
+            tree = SimpleQueryTree.andExtend(tree, pv);
+        }
+        return new SimpleQueryTree(tree);
+    }
+
     public Map<String, Object> getEsQuery(QueryTree queryTree) {
         return buildEsQuery(queryTree.tree, new HashMap<>());
     }

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -52,8 +52,10 @@ public class XLQLQuery {
 
     public SimpleQueryTree addFilters(SimpleQueryTree sqt, List<SimpleQueryTree.PropertyValue> filters) {
         SimpleQueryTree.Node tree = sqt.tree;
-        for (SimpleQueryTree.Node pv : filters) {
-            tree = SimpleQueryTree.andExtend(tree, pv);
+        for (SimpleQueryTree.PropertyValue pv : filters) {
+            if (sqt.getTopLevelPvNodes().stream().noneMatch(n -> n.property().equals(pv.property()))) {
+                tree = SimpleQueryTree.andExtend(tree, pv);
+            }
         }
         return new SimpleQueryTree(tree);
     }

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -47,6 +47,9 @@ public class XLQLQuery {
     }
 
     public SimpleQueryTree getSimpleQueryTree(String queryString) throws InvalidQueryException {
+        if (queryString.isEmpty()) {
+            return new SimpleQueryTree(null);
+        }
         LinkedList<Lex.Symbol> lexedSymbols = Lex.lexQuery(queryString);
         Parse.OrComb parseTree = Parse.parseQuery(lexedSymbols);
         Ast ast = new Ast(parseTree);

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -322,7 +322,7 @@ public class XLQLQuery {
                 String andClause = and.conjuncts()
                         .stream()
                         .map(this::buildQueryString)
-                        .collect(Collectors.joining(" AND "));
+                        .collect(Collectors.joining(" "));
                 return topLevel ? andClause : "(" + andClause + ")";
             }
             case SimpleQueryTree.Or or -> {

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -346,7 +346,7 @@ public class XLQLQuery {
     }
 
     private String freeTextToString(SimpleQueryTree.FreeText ft) {
-        String s = quoteSpecialSymbolsWithinFreeTextString(ft.value());
+        String s = ft.value();
         if (ft.operator() == Operator.NOT_EQUALS) {
             s = "NOT " + s;
         }
@@ -419,34 +419,8 @@ public class XLQLQuery {
         return s.matches(".*\\s.*") ? "\"" + s + "\"" : s;
     }
 
-    private static String quoteIfPhraseOrContainsSpecialSymbol(String s) {
+    public static String quoteIfPhraseOrContainsSpecialSymbol(String s) {
         return s.matches(".*(>=|<=|[=!~<>(): ]).*") ? "\"" + s + "\"" : s;
-    }
-
-    public static String quoteSpecialSymbolsWithinFreeTextString(String s) {
-        Matcher quotedMatcher = Pattern.compile("\".*?\"").matcher(s);
-        List<List<Integer>> quotedIntervals = new ArrayList<>();
-        while (quotedMatcher.find()) {
-            quotedIntervals.add(List.of(quotedMatcher.start(), quotedMatcher.end()));
-        }
-
-        List<Integer> insertQuoteAtIdx = new ArrayList<>();
-        Matcher specialSymbolMatcher = Pattern.compile("[^ \"]*(>=|<=|[=!~<>():])[^ \"]*").matcher(s);
-        while (specialSymbolMatcher.find()) {
-            boolean isAlreadyQuoted = quotedIntervals.stream().anyMatch(interval ->
-                    interval.getFirst() < specialSymbolMatcher.start() && interval.getLast() > specialSymbolMatcher.end()
-            );
-            if (!isAlreadyQuoted) {
-                insertQuoteAtIdx.addFirst(specialSymbolMatcher.start());
-                insertQuoteAtIdx.addFirst(specialSymbolMatcher.end());
-            }
-        }
-
-        for (int i : insertQuoteAtIdx) {
-            s = s.substring(0, i) + "\"" + s.substring(i);
-        }
-
-        return s;
     }
 
     private Set<String> getEsNestedFields(Whelk whelk) {

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -619,11 +619,11 @@ public class XLQLQuery {
 
         buckets.forEach((value, count) -> {
             Map<String, Object> observation = new LinkedHashMap<>();
-            SimpleQueryTree.PropertyValue pvNode = new SimpleQueryTree.PropertyValue(property, List.of(property), Operator.EQUALS, value);
+            var pvNode = new SimpleQueryTree.PropertyValue(property, List.of(property), Operator.EQUALS, value);
             boolean queried = sqt.getTopLevelPvNodes().contains(pvNode);
             if (!queried) {
                 observation.put("totalItems", count);
-                String url = "/find?_q=" + treeToQueryString(new SimpleQueryTree.And(List.of(sqt.tree, pvNode))) + urlTail;
+                String url = "/find?_q=" + treeToQueryString(addFilterToTree(sqt, pvNode)) + urlTail;
                 observation.put("view", Map.of(JsonLd.ID_KEY, url));
                 observation.put("object", lookUp(value).orElse(value));
                 observations.add(observation);
@@ -631,6 +631,19 @@ public class XLQLQuery {
         });
 
         return observations;
+    }
+
+    SimpleQueryTree.And addFilterToTree(SimpleQueryTree sqt, SimpleQueryTree.PropertyValue pvNode) {
+        var conjuncts = switch (sqt.tree) {
+            case SimpleQueryTree.And and -> {
+                var copy  = new ArrayList<>(and.conjuncts());
+                copy.add(pvNode);
+                yield copy;
+            }
+            default -> List.of(sqt.tree, pvNode);
+        };
+
+        return new SimpleQueryTree.And(conjuncts);
     }
 
     public Disambiguate.OutsetType getOutsetType(SimpleQueryTree sqt) {

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -90,7 +90,7 @@ public class Disambiguate {
         return outset.size() == 1 ? outset.stream().findFirst().get() : Disambiguate.OutsetType.RESOURCE;
     }
 
-    private OutsetType getOutsetType(String type) {
+    public OutsetType getOutsetType(String type) {
         if (workTypes.contains(type)) {
             return OutsetType.WORK;
         }

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -80,17 +80,17 @@ public class Disambiguate {
         return domainByProperty.getOrDefault(property, UNKNOWN_DOMAIN);
     }
 
-    public Disambiguate.OutsetType decideOutset(SimpleQueryTree sqt) {
-        Set<Disambiguate.OutsetType> outset = sqt.collectGivenTypes()
+    public OutsetType decideOutset(SimpleQueryTree sqt) {
+        Set<OutsetType> outset = sqt.collectGivenTypes()
                 .stream()
                 .map(this::getOutsetType)
                 .collect(Collectors.toSet());
 
         // TODO: Review this (for now default to Resource)
-        return outset.size() == 1 ? outset.stream().findFirst().get() : Disambiguate.OutsetType.RESOURCE;
+        return outset.size() == 1 ? outset.stream().findFirst().get() : OutsetType.RESOURCE;
     }
 
-    public OutsetType getOutsetType(String type) {
+    private OutsetType getOutsetType(String type) {
         if (workTypes.contains(type)) {
             return OutsetType.WORK;
         }

--- a/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
@@ -1,5 +1,7 @@
 package whelk.xlql;
 
+import whelk.search.XLQLQuery;
+
 import java.util.*;
 
 public class FlattenedAst {
@@ -43,7 +45,7 @@ public class FlattenedAst {
                 List<String> leafValues = new ArrayList<>();
                 for (Node node : and.operands()) {
                     switch (node) {
-                        case Leaf l -> leafValues.add(quoteIfPhrase(l.value()));
+                        case Leaf l -> leafValues.add(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(l.value()));
                         default -> newOperands.add(mergeLeaves(node));
                     }
                 }
@@ -59,9 +61,9 @@ public class FlattenedAst {
                         .toList();
                 yield new Or(newOperands);
             }
-            case Not not -> new Not(quoteIfPhrase(not.value()));
+            case Not not -> new Not(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(not.value()));
             case Code code -> code;
-            case Leaf leaf -> new Leaf(quoteIfPhrase(leaf.value()));
+            case Leaf leaf -> new Leaf(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(leaf.value()));
         };
     }
 
@@ -202,9 +204,5 @@ public class FlattenedAst {
                 Operator.GREATER_THAN_OR_EQUALS, Operator.LESS_THAN,
                 Operator.GREATER_THAN, Operator.LESS_THAN_OR_EQUALS
         );
-    }
-
-    private static String quoteIfPhrase(String s) {
-        return s.matches(".*\\s.*") ? "\"" + s + "\"" : s;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
@@ -44,17 +44,11 @@ public class FlattenedAst {
                 for (Node node : and.operands()) {
                     switch (node) {
                         case Leaf l -> leafValues.add(quoteIfPhrase(l.value()));
-                        default -> {
-                            if (!leafValues.isEmpty()) {
-                                newOperands.add(new Leaf(String.join(" ", leafValues)));
-                                leafValues.clear();
-                            }
-                            newOperands.add(node);
-                        }
+                        default -> newOperands.add(mergeLeaves(node));
                     }
                 }
                 if (!leafValues.isEmpty()) {
-                    newOperands.add(new Leaf(String.join(" ", leafValues)));
+                    newOperands.addFirst(new Leaf(String.join(" ", leafValues)));
                 }
                 yield newOperands.size() > 1 ? new And(newOperands) : newOperands.getFirst();
             }

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -27,22 +27,11 @@ public class QueryTree {
     public Node tree;
 
     public QueryTree(SimpleQueryTree sqt, Disambiguate disambiguate) {
-        this.tree = sqtToQt(sqt.tree, disambiguate);
+        this.tree = sqtToQt(sqt.tree, disambiguate, Disambiguate.OutsetType.RESOURCE);
     }
 
-    private static Node sqtToQt(SimpleQueryTree.Node sqt, Disambiguate disambiguate) {
-        Disambiguate.OutsetType outset = decideOutset(sqt, disambiguate);
-        return sqtToQt(sqt, disambiguate, outset);
-    }
-
-    private static Disambiguate.OutsetType decideOutset(SimpleQueryTree.Node sqtNode, Disambiguate disambiguate) {
-        Set<String> givenTypes = collectGivenTypes(sqtNode);
-        Set<Disambiguate.OutsetType> outset = givenTypes.stream()
-                .map(disambiguate::getOutsetType)
-                .collect(Collectors.toSet());
-
-        // TODO: Review this (for now default to Resource)
-        return outset.size() == 1 ? outset.stream().findFirst().get() : Disambiguate.OutsetType.RESOURCE;
+    public QueryTree(SimpleQueryTree sqt, Disambiguate disambiguate, Disambiguate.OutsetType outsetType) {
+        this.tree = sqtToQt(sqt.tree, disambiguate, outsetType);
     }
 
     private static Node sqtToQt(SimpleQueryTree.Node sqtNode, Disambiguate disambiguate, Disambiguate.OutsetType outset) {
@@ -109,60 +98,18 @@ public class QueryTree {
             return new Field(path, operator, value);
         }
 
-        path.expandChainAxiom(disambiguate);
+        List<Path> altPaths = path.expand(pv.property(), disambiguate, outset);
 
-        String domain = disambiguate.getDomain(pv.property());
-
-        Disambiguate.DomainCategory domainCategory = disambiguate.getDomainCategory(domain);
-        if (domainCategory == Disambiguate.DomainCategory.ADMIN_METADATA) {
-            path.prependMeta();
+        List<Node> altFields = new ArrayList<>();
+        for (Path p : altPaths) {
+            altFields.add(newFields(p, operator, value, disambiguate));
         }
 
-        return switch (outset) {
-            case WORK -> {
-                switch (domainCategory) {
-                    case INSTANCE, EMBODIMENT -> {
-                        // The property p appears only on instance, modify path to @reverse.instanceOf.p...
-                        path.setWorkToInstancePath();
-                        yield newFields(path, operator, value, disambiguate);
-                    }
-                    case CREATION_SUPER, UNKNOWN -> {
-                        // The property p may appear on instance, add alternative path @reverse.instanceOf.p...
-                        List<Node> altFields = new ArrayList<>();
-                        Path copy = path.copy();
-                        copy.setWorkToInstancePath();
-                        altFields.add(newFields(path, operator, value, disambiguate));
-                        altFields.add(newFields(copy, operator, value, disambiguate));
-                        yield operator == Operator.NOT_EQUALS ? new And(altFields) : new Or(altFields);
-                    }
-                    default -> {
-                        yield newFields(path, operator, value, disambiguate);
-                    }
-                }
-            }
-            case INSTANCE -> {
-                switch (domainCategory) {
-                    case WORK -> {
-                        // The property p appears only work, modify path to instanceOf.p...
-                        path.setInstanceToWorkPath();
-                        yield newFields(path, operator, value, disambiguate);
-                    }
-                    case CREATION_SUPER, UNKNOWN -> {
-                        // The property p may appear on work, add alternative path instanceOf.p...
-                        List<Node> altFields = new ArrayList<>();
-                        Path copy = path.copy();
-                        copy.setInstanceToWorkPath();
-                        altFields.add(newFields(path, operator, value, disambiguate));
-                        altFields.add(newFields(copy, operator, value, disambiguate));
-                        yield operator == Operator.NOT_EQUALS ? new And(altFields) : new Or(altFields);
-                    }
-                    default -> {
-                        yield newFields(path, operator, value, disambiguate);
-                    }
-                }
-            }
-            case RESOURCE -> newFields(path, operator, value, disambiguate);
-        };
+        if (altFields.size() == 1) {
+            return altFields.getFirst();
+        }
+
+        return operator == Operator.NOT_EQUALS ? new And(altFields) : new Or(altFields);
     }
 
     static Node newFields(Path path, Operator operator, String value, Disambiguate disambiguate) {
@@ -201,26 +148,5 @@ public class QueryTree {
                 .toList();
 
         return pv.operator() == Operator.NOT_EQUALS ? new And(altFields) : new Or(altFields);
-    }
-
-    public static Set<String> collectGivenTypes(SimpleQueryTree.Node sqt) {
-        return collectGivenTypes(sqt, new HashSet<>());
-    }
-
-    private static Set<String> collectGivenTypes(SimpleQueryTree.Node sqtNode, Set<String> types) {
-        switch (sqtNode) {
-            case SimpleQueryTree.And and -> and.conjuncts().forEach(c -> collectGivenTypes(c, types));
-            case SimpleQueryTree.Or or -> or.disjuncts().forEach(d -> collectGivenTypes(d, types));
-            case SimpleQueryTree.PropertyValue pv -> {
-                if (List.of("rdf:type").equals(pv.propertyPath())) {
-                    types.add(pv.value());
-                }
-            }
-            case SimpleQueryTree.FreeText ignored -> {
-                // Nothing to do here
-            }
-        }
-
-        return types;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -85,10 +85,8 @@ public class QueryTree {
              If "vocab term" interpret the value as is, e.g. issuanceType: "Serial" or encodingLevel: "marc:FullLevel".
              Otherwise, when object property, append either @id or _str to the path.
              */
-            String expanded = Disambiguate.expandPrefixed(pv.value());
-            if (JsonLd.looksLikeIri(expanded)) {
+            if (JsonLd.looksLikeIri(value)) {
                 path.appendId();
-                value = expanded;
             } else {
                 path.appendUnderscoreStr();
             }
@@ -98,12 +96,10 @@ public class QueryTree {
             return new Field(path, operator, value);
         }
 
-        List<Path> altPaths = path.expand(pv.property(), disambiguate, outset);
-
-        List<Node> altFields = new ArrayList<>();
-        for (Path p : altPaths) {
-            altFields.add(newFields(p, operator, value, disambiguate));
-        }
+        List<Node> altFields = path.expand(pv.property(), disambiguate, outset)
+                .stream()
+                .map(p -> newFields(p, operator, value, disambiguate))
+                .collect(Collectors.toList());
 
         if (altFields.size() == 1) {
             return altFields.getFirst();

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -34,6 +34,10 @@ public class SimpleQueryTree {
         this.tree = buildTree(ast.tree, disambiguate);
     }
 
+    public SimpleQueryTree(SimpleQueryTree.Node tree) {
+        this.tree = tree;
+    }
+
     public static Node andExtend(Node tree, Node node) {
         var conjuncts = switch (tree) {
             case And and -> {

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -4,8 +4,6 @@ import whelk.JsonLd;
 import whelk.exception.InvalidQueryException;
 import whelk.search.XLQLQuery;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -101,12 +99,10 @@ public class SimpleQueryTree {
                 // Expand and encode URIs, e.g. sao:Hästar -> https://id.kb.se/term/sao/H%C3%A4star
                 if (disambiguate.isObjectProperty(property)) {
                     String expanded = Disambiguate.expandPrefixed(value);
-                    if (JsonLd.looksLikeIri(expanded)) {
-                        value = URLEncoder.encode(value, StandardCharsets.UTF_8)
-                                .replaceAll("\\+", "%20")
-                                .replaceAll("%2F", "/")
-                                .replaceAll("%3A", ":");
-                    }
+                    int lastSlashIdx = expanded.lastIndexOf("/");
+                    String slug = value.substring(lastSlashIdx + 1);
+                    String ns = value.substring(0, lastSlashIdx + 1);
+                    value = ns + XLQLQuery.QUERY_ESCAPER.escape(slug).replace("%23", "#");
                 }
 
                 return new PropertyValue(property, propertyPath, c.operator(), value);

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -296,7 +296,7 @@ public class SimpleQueryTree {
         } else if (tree instanceof And) {
             List<Node> newConjuncts = ((And) tree).conjuncts().stream()
                     .filter(Predicate.not(c -> c instanceof FreeText && ((FreeText) c).operator().equals(Operator.EQUALS)))
-                    .toList();
+                    .collect(Collectors.toList());
             newConjuncts.addFirst(new FreeText(Operator.EQUALS, replacement));
             this.tree = new And(newConjuncts);
         }

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -3,6 +3,8 @@ package whelk.xlql;
 import whelk.JsonLd;
 import whelk.exception.InvalidQueryException;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class SimpleQueryTree {
@@ -87,10 +89,16 @@ public class SimpleQueryTree {
                     }
                 }
 
-                //TODO: e.g. https://id.kb.se/term/barn/Hästar -> https://id.kb.se/term/barn/H%C3%A4star
-//                if (disambiguate.isObjectProperty(property) && JsonLd.looksLikeIri(value)) {
-//                    value = normalizeUri(value);
-//                }
+                // Expand and encode URIs, e.g. sao:Hästar -> https://id.kb.se/term/sao/H%C3%A4star
+                if (disambiguate.isObjectProperty(property)) {
+                    String expanded = Disambiguate.expandPrefixed(value);
+                    if (JsonLd.looksLikeIri(expanded)) {
+                        value = URLEncoder.encode(value, StandardCharsets.UTF_8)
+                                .replaceAll("\\+", "%20")
+                                .replaceAll("%2F", "/")
+                                .replaceAll("%3A", ":");
+                    }
+                }
 
                 return new PropertyValue(property, propertyPath, c.operator(), value);
             }

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -297,8 +297,10 @@ public class SimpleQueryTree {
             List<Node> newConjuncts = ((And) tree).conjuncts().stream()
                     .filter(Predicate.not(c -> c instanceof FreeText && ((FreeText) c).operator().equals(Operator.EQUALS)))
                     .collect(Collectors.toList());
-            newConjuncts.addFirst(new FreeText(Operator.EQUALS, replacement));
-            this.tree = new And(newConjuncts);
+            if (!replacement.isEmpty()) {
+                newConjuncts.addFirst(new FreeText(Operator.EQUALS, replacement));
+            }
+            this.tree = newConjuncts.size() == 1 ? newConjuncts.getFirst() : new And(newConjuncts);
         }
     }
 }

--- a/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
@@ -153,11 +153,9 @@ class FlattenedAstSpec extends Specification {
         expect:
         flattenedAst.tree == new FlattenedAst.And(
                 [
-                        new FlattenedAst.Leaf("x y z \"a b c\" d"),
+                        new FlattenedAst.Leaf("x y z \"a b c\" d e:f h i"),
                         new FlattenedAst.Code("p", Operator.EQUALS, "v"),
-                        new FlattenedAst.Leaf("e:f"),
-                        new FlattenedAst.Not("g"),
-                        new FlattenedAst.Leaf("h i")
+                        new FlattenedAst.Not("g")
                 ] as List<FlattenedAst.Node>
         )
     }

--- a/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
@@ -153,7 +153,7 @@ class FlattenedAstSpec extends Specification {
         expect:
         flattenedAst.tree == new FlattenedAst.And(
                 [
-                        new FlattenedAst.Leaf("x y z \"a b c\" d e:f h i"),
+                        new FlattenedAst.Leaf("x y z \"a b c\" d \"e:f\" h i"),
                         new FlattenedAst.Code("p", Operator.EQUALS, "v"),
                         new FlattenedAst.Not("g")
                 ] as List<FlattenedAst.Node>

--- a/whelk-core/src/test/groovy/whelk/xlql/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/QueryTreeSpec.groovy
@@ -17,16 +17,6 @@ class QueryTreeSpec extends Specification {
         return new SimpleQueryTree(flattened, disambiguate)
     }
 
-    def "collect given types from query"() {
-        given:
-        def input = "type: (Electronic OR Print) AND utgivning: aaa"
-        SimpleQueryTree sqt = getSimpleQueryTree(input)
-        Set<Object> givenTypes = QueryTree.collectGivenTypes(sqt.tree)
-
-        expect:
-        givenTypes == ["Electronic", "Print"] as Set
-    }
-
     def "free text tree"() {
         given:
         SimpleQueryTree sqt = getSimpleQueryTree("AAA BBB and (CCC or DDD)")
@@ -49,7 +39,8 @@ class QueryTreeSpec extends Specification {
     def "object property + datatype property + free text"() {
         given:
         SimpleQueryTree sqt = getSimpleQueryTree("subject: \"sao:Fysik\" AND tillkomsttid < 2023 AND \"svarta hål\"")
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Field subjectField = conjuncts[0]
@@ -72,7 +63,8 @@ class QueryTreeSpec extends Specification {
         given:
         String queryString = "typ:Tryck instanceOf.subject:\"sao:Fysik\" AND instanceOf.subject._str:rymd and tillkomsttid:2022"
         SimpleQueryTree sqt = getSimpleQueryTree(queryString)
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Field typeField = conjuncts[0]
@@ -102,7 +94,8 @@ class QueryTreeSpec extends Specification {
         given:
         String queryString = "typ:Text upphovsuppgift:Någon tillkomsttid<2020 language:\"https://id.kb.se/language/swe\""
         SimpleQueryTree sqt = getSimpleQueryTree(queryString)
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Field typeField = conjuncts[0]
@@ -138,7 +131,8 @@ class QueryTreeSpec extends Specification {
         given:
         String queryString = "typ:Instance upphovsuppgift:Någon tillkomsttid<2020 language:\"https://id.kb.se/language/swe\""
         SimpleQueryTree sqt = getSimpleQueryTree(queryString)
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Or typeFields = conjuncts[0]
@@ -172,7 +166,8 @@ class QueryTreeSpec extends Specification {
         given:
         String queryString = "author:x not isbn:y"
         SimpleQueryTree sqt = getSimpleQueryTree(queryString)
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Nested author = conjuncts[0]
@@ -196,7 +191,8 @@ class QueryTreeSpec extends Specification {
         given:
         String queryString = "type:Text author:x not isbn:y"
         SimpleQueryTree sqt = getSimpleQueryTree(queryString)
-        QueryTree qt = new QueryTree(sqt, disambiguate)
+        Disambiguate.OutsetType outsetType = disambiguate.decideOutset(sqt)
+        QueryTree qt = new QueryTree(sqt, disambiguate, outsetType)
         QueryTree.And topNode = qt.tree
         List conjuncts = topNode.conjuncts()
         QueryTree.Nested author = conjuncts[1]

--- a/whelk-core/src/test/groovy/whelk/xlql/SimpleQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/SimpleQueryTreeSpec.groovy
@@ -133,4 +133,14 @@ class SimpleQueryTreeSpec extends Specification {
         then:
         thrown(InvalidQueryException)
     }
+
+    def "collect given types from query"() {
+        given:
+        def input = "type: (Electronic OR Print) AND utgivning: aaa"
+        SimpleQueryTree sqt = getTree(input)
+        Set<Object> givenTypes = sqt.collectGivenTypes()
+
+        expect:
+        givenTypes == ["Electronic", "Print"] as Set
+    }
 }


### PR DESCRIPTION
Generate facets with selectable filters based on (requires!) https://github.com/libris/definitions/pull/472/files#diff-6696b36e4b8890f8ec4beba9b087927c296d79e1d41f894af4827fa00362f5b7 (More filters to be added, see https://jira.kb.se/browse/LWS-62)

~~Not yet tested with the new beta frontend, only the cataloguing.~~

 Some known problems/todos:
- Only works for "and filters" so far
- ~~Since we now put the whole query in the `_q` parameter, any added filter will also be visible in the input field as long as the input field is mapped to `_q` (as e.g. "textinput AND added:filter").~~
**UPDATE:** Put free text part in `_i` parameter. See https://jira.kb.se/browse/LWS-41 for more info. Update https://github.com/libris/lxlviewer/pull/984 accordingly.
- ~~Contributor filter does not work, it seems that the `#it` part of an id is interpreted as a comment, so e.g. `_q=contributor:"https://libris.kb.se/fcrtpljz1qp2bdv#it"` is received as `contributor:"https://libris.kb.se/fcrtpljz1qp2bdv` (missing `#it")` in the backend.~~ **SOLVED**
- The form for the "slices" in `PartialCollectionView.stats.sliceByDimension` should be reviewed, they are now unnecessarily verbose. (Marked as TODO in code)
- Each filter is now 1-to-1 mapped to a defined property, however some properties (e.g. `contributor`) may appear at both Work and Instance level. In these cases I've now included values from both levels in the filters. _If_ that's how we want it to work, we need to find a better solution for generating the "bucket count" because the current solution can generate inaccurate counts when merging fields from the "aggs" query result. It would probably be better if the merging was done already at runtime by Elastic when running the aggs query.
Not a big problem in practice but we should find a better a solution once we have a clearer picture of how filters "on different levels" should work.
