### PR TITLE
Change lddb__dependencies pk column to bigint (int no longer enough)

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000022-alter-dependencies-pk-to-bigint.plsql
+++ b/librisxl-tools/postgresql/migrations/00000022-alter-dependencies-pk-to-bigint.plsql
@@ -1,0 +1,30 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 21;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 22;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+
+   ALTER TABLE lddb__dependencies ALTER COLUMN pk TYPE BIGINT;
+
+END$$;
+
+COMMIT;


### PR DESCRIPTION
We've already done this change in QA/STG/PROD. Doing it again in those environments should be almost-but-not-quite-a-noop.