### PR TITLE
Don't lazy-load HouseKeeping servlet

### DIFF
--- a/housekeeping/src/main/groovy/whelk/HouseKeepingServer.java
+++ b/housekeeping/src/main/groovy/whelk/HouseKeepingServer.java
@@ -1,6 +1,7 @@
 package whelk;
 
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import whelk.housekeeping.WebInterface;
 
@@ -12,7 +13,9 @@ public class HouseKeepingServer extends XlServer {
 
         server.setHandler(context);
 
-        context.addServlet(WebInterface.class, "/");
+        ServletHolder holder = new ServletHolder(WebInterface.class);
+        holder.setInitOrder(0);
+        context.addServlet(holder, "/");
         serveStaticContent(context);
     }
 


### PR DESCRIPTION
After the transition to embedded Jetty, HouseKeeping was lazy-loaded and wouldn't start until one visited `<server>:/8181/housekeeping/`. But it needs to start immediately. This seems to do the trick.

https://eclipse.dev/jetty/javadoc/jetty-12/org/eclipse/jetty/ee10/servlet/ServletHolder.html#setInitOrder(int)