### PR TITLE
Adapt cleanEtag to nginx

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudUtils.groovy
@@ -276,7 +276,7 @@ class CrudUtils {
         }
 
         private static String cleanEtag(String str) {
-            return stripQuotes(str)?.replaceAll('-gzip', '')
+            return stripQuotes(str)?.replaceAll('W/', '')
         }
 
         private static String stripQuotes(String str) {


### PR DESCRIPTION
Apache added the suffix `-gzip`, nginx (which we now use everywhere) adds the prefix `W/`. Just like before we need to clean it. Oherwise, if compression is enabled in nginx, the comparison in XL will fail and it won't be possible to, well, update records (at least not when the client has compression enabled).

So with this change we can re-enable compression for application/ld+json from libris.kb.se in nginx (for a while it's only been enabled for id.kb.se).

Tested on dev2.

https://jira.kb.se/browse/LXL-4401