### PR TITLE
Index @reverse.itemOf as nested

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -339,6 +339,14 @@
                 }
             },
             {
+                "reverse_itemOf_template": {
+                    "path_match": ["@reverse.itemOf", "@reverse.instanceOf.@reverse.itemOf"],
+                    "mapping": {
+                        "type": "nested"
+                    }
+                }
+            },
+            {
                 "unknown_template": {
                     "path_match": "_marc*.*.subfields.*",
                     "mapping": {

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -629,7 +629,7 @@ class ESQuery {
     private static getPrefixGroup(String key, Set<String> nestedFields) {
         if (key.contains('.')) {
             (QUERY_PREFIXES.find{ key.startsWith(it) } ?: "").with { String prefix ->
-                String nested = nestedFields.find{ key.startsWith(prefix + it) }
+                String nested = nestedFields.find{ key.startsWith(prefix + it + '.') }
                 if (nested) {
                     return key.substring(prefix.length(), prefix.length() + nested.length())
                 }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -733,6 +733,10 @@ class ESQuery {
             Example
             prefix: "@reverse.itemOf"
             nestedQuery: ["and-@reverse.itemOf.heldBy.@id":[".../library/A", ".../library/A]]
+
+            Example
+            prefix: "@reverse.itemOf"
+            nestedQuery: ["@reverse.itemOf.heldBy.@id":[".../library/A"], "not-@reverse.itemOf.availability.@id": ["X"] ]
         */
         var ands = nestedQuery.findAll { it.key.startsWith(AND_PREFIX) }
         var nots = nestedQuery.findAll { it.key.startsWith(NOT_PREFIX) }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -728,12 +728,12 @@ class ESQuery {
         /*
             Example
             prefix: "identifiedBy"
-            nestedQuery: ["identifiedBy.@type":["ISBN","LCCN"], "identifiedBy.value":["1234","5678"]]
+            nestedQuery: ["and-identifiedBy.@type":["ISBN","LCCN"], "and-identifiedBy.value":["1234","5678"]]
 
             Example
-            prefix: "identifiedBy"
-            nestedQuery: ["and-@reverse.itemOf.heldBy.@id":["https://libris.kb.se/library/Mtm", "https://libris.kb.se/library/S]]
-         */
+            prefix: "@reverse.itemOf"
+            nestedQuery: ["and-@reverse.itemOf.heldBy.@id":[".../library/A", ".../library/A]]
+        */
         var ands = nestedQuery.findAll { it.key.startsWith(AND_PREFIX) }
         var nots = nestedQuery.findAll { it.key.startsWith(NOT_PREFIX) }
         var rest = nestedQuery.findAll { !(it.key in nots.keySet() || it.key in ands.keySet()) }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -26,8 +26,9 @@ class ESQuery {
     private JsonLd jsonld
     private Set keywordFields
     private Set dateFields
-    private Set nestedFields
-    private Set numericExtractorFields
+    private Set<String> nestedFields
+    private Set<String> nestedNotInParentFields
+    private Set<String> numericExtractorFields
 
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
@@ -39,7 +40,11 @@ class ESQuery {
     private static final String NOT_PREFIX = 'not-'
     private static final String EXISTS_PREFIX = 'exists-'
 
-    private static final String FILTERED_AGG = 'a'
+    private static final List<String> QUERY_PREFIXES = [AND_PREFIX, AND_MATCHES_PREFIX, OR_PREFIX,
+                                                        NOT_PREFIX, EXISTS_PREFIX]
+
+    private static final String FILTERED_AGG_NAME = 'a'
+    private static final String NESTED_AGG_NAME = 'n'
 
     private static final Map recordsOverCacheRecordsBoost = [
             'bool': ['should': [
@@ -75,6 +80,7 @@ class ESQuery {
             this.keywordFields =  getKeywordFields(mappings)
             this.dateFields = getFieldsOfType('date', mappings)
             this.nestedFields = getFieldsOfType('nested', mappings)
+            this.nestedNotInParentFields = nestedFields - getFieldsWithSetting('include_in_parent', true, mappings)
             this.numericExtractorFields = getFieldsWithAnalyzer('numeric_extractor', mappings)
 
             if (mappings['properties']['__prefLabel']) {
@@ -96,7 +102,7 @@ class ESQuery {
     @CompileStatic(TypeCheckingMode.SKIP)
     Map doQuery(Map<String, String[]> queryParameters, suggest = null) {
         Map esQuery = getESQuery(queryParameters, suggest)
-        Map esResponse = hideKeywordFields(moveFilteredAggregationsToTopLevel(whelk.elastic.query(esQuery)))
+        Map esResponse = hideKeywordFields(moveAggregationsToTopLevel(whelk.elastic.query(esQuery)))
         if ('esQuery' in queryParameters.get('_debug')) {
             esResponse._debug = [esQuery: esQuery]
         }
@@ -106,7 +112,7 @@ class ESQuery {
     @CompileStatic(TypeCheckingMode.SKIP)
     Map doQueryIds(Map<String, String[]> queryParameters) {
         Map esQuery = getESQuery(queryParameters)
-        Map esResponse = hideKeywordFields(moveFilteredAggregationsToTopLevel(whelk.elastic.queryIds(esQuery)))
+        Map esResponse = hideKeywordFields(moveAggregationsToTopLevel(whelk.elastic.queryIds(esQuery)))
         if ('esQuery' in queryParameters.get('_debug')) {
             esResponse._debug = [esQuery: esQuery]
         }
@@ -551,16 +557,33 @@ class ESQuery {
     Tuple2<List, Map> getFilters(Map<String, String[]> queryParameters) {
         def queryParametersCopy = new HashMap<>(queryParameters)
         List filters = []
-        List filtersForNot = []
         Map multiSelectFilters = [:]
 
         def (handledParameters, rangeFilters) = makeRangeFilters(queryParametersCopy)
         handledParameters.each {queryParametersCopy.remove(it)}
         filters.addAll(rangeFilters)
         
-        Map groups = queryParametersCopy.groupBy { p -> getPrefixIfExists(p.key) }
-        Map nested = getNestedParams(groups)
+        var groups = queryParametersCopy.groupBy { p -> getPrefixGroup(p.key, nestedFields) }
+        var nested = getNestedParams(groups)
         Map notNested = (groups - nested).collect { it.value }.sum([:])
+
+        // If both nested and notNested contains explicit OR they need to be moved to not nested
+        // If two different nested contains explicit or they need to be moved to not nested
+        // TODO handle not_in_parent
+        boolean explicitOrInDifferentNested = nested.values()
+                .findAll{ it.keySet().any{ k -> k.startsWith(OR_PREFIX)} }
+                .size() > 1
+
+        if (notNested.keySet().any { it.startsWith(OR_PREFIX) } || explicitOrInDifferentNested) {
+            // TODO
+            nested.values().each { n ->
+                n.keySet().findAll{ it.startsWith(OR_PREFIX) }.each {
+                    notNested.put(it, n.remove(it))
+                }
+            }
+            nested.removeAll { it.value.isEmpty() }
+        }
+
         nested.each { key, vals ->
             filters.addAll(createNestedBoolFilters(key, vals))
         }
@@ -587,22 +610,14 @@ class ESQuery {
                 multiSelectFilters[m.keySet().first()] = createBoolFilter(addMissingMatch(m, matchMissing))
             }
             else {
-                filters << createBoolFilter(addMissingMatch(m, matchMissing))
+                filters << wrapNestedNotInParent(createBoolFilter(addMissingMatch(m, matchMissing)))
             }
         }
-        notNestedGroupsForNot.each { m ->
-            filtersForNot << createBoolFilter(m)
-        }
 
-        Map allFilters = [:]
-        if (filters) {
-            allFilters['must'] = filters
-        }
-        if (filtersForNot) {
-            allFilters['must_not'] = filtersForNot
-        }
+        var mustNots = notNestedGroupsForNot.collect { createBoolFilter(it) }
+        var filter = Q.bool(filters, mustNots).with { it.bool ? [it] : null }
 
-        return new Tuple2(allFilters ? [['bool': allFilters]] : null, multiSelectFilters)
+        return new Tuple2(filter, multiSelectFilters)
     }
 
     private static Map addMissingMatch(Map m, Map matchMissing) {
@@ -613,12 +628,35 @@ class ESQuery {
         return m
     }
 
-    private getPrefixIfExists(String key) {
+    private static getPrefixGroup(String key, Set<String> nestedFields) {
         if (key.contains('.')) {
-            return key.substring(0, key.indexOf('.'))
+            (QUERY_PREFIXES.find{ key.startsWith(it) } ?: "").with { String prefix ->
+                String nested = nestedFields.find{ key.startsWith(prefix + it) }
+                if (nested) {
+                    return key.substring(prefix.length(), prefix.length() + nested.length())
+                }
+                else {
+                    return key.substring(0, key.indexOf('.'))
+                }
+            }
         } else {
             return key
         }
+    }
+
+    private Map wrapNestedNotInParent(Map boolFilter) {
+        var nested = { String f -> nestedNotInParentFields.find{ (f ?: '').startsWith(it + '.') } }
+
+        var fields = DocumentUtil.getAtPath(boolFilter, ['bool', 'should', '*', 'simple_query_string', 'fields', 0], [])
+
+        if (fields.any(nested)) {
+            boolFilter.bool['should'] = boolFilter.bool['should'].collect { Map q ->
+                String n = nested((String) DocumentUtil.getAtPath(q, ['simple_query_string', 'fields', 0]))
+                n ? Q.nested(n, q) : q
+            }
+        }
+
+        return boolFilter
     }
 
     /**
@@ -677,46 +715,92 @@ class ESQuery {
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)
-    private Map getNestedParams(Map<String, Map<String, String[]>> groups) {
+    private Map<String, Map<String, String[]>> getNestedParams(Map<String, Map<String, String[]>> groups) {
         Map nested = groups.findAll { g ->
-            // More than one property or more than one value for some property
-            g.key in nestedFields && (g.value.size() > 1 || g.value.values().any{ it.length > 1})
+            // If included in parent: More than one property or more than one value for some property
+            g.key in nestedNotInParentFields
+                    || (g.key in nestedFields && (g.value.size() > 1 || g.value.values().any{ it.length > 1 }))
         }
         return nested
     }
 
+    @PackageScope
     @CompileStatic(TypeCheckingMode.SKIP)
-    private List<Map> createNestedBoolFilters(String prefix, Map<String, String[]> nestedQuery) {
+    List<Map> createNestedBoolFilters(String prefix, Map<String, String[]> nestedQuery) {
         /*
             Example
             prefix: "identifiedBy"
             nestedQuery: ["identifiedBy.@type":["ISBN","LCCN"], "identifiedBy.value":["1234","5678"]]
+
+            Example
+            prefix: "identifiedBy"
+            nestedQuery: ["and-@reverse.itemOf.heldBy.@id":["https://libris.kb.se/library/Mtm", "https://libris.kb.se/library/S]]
          */
-        
-        int maxLen = nestedQuery.collect { it.value }.collect { it.length }.max()
-        
-        List result = []
-        for (int i = 0 ; i < maxLen ; i++) {
-            List<Map> musts = nestedQuery.findResults {
-                it.value.length > i 
-                    ? ['match': [(expandLangMapKeys(it.key)): it.value[i]]]
-                    : null
+        var ands = nestedQuery.findAll { it.key.startsWith(AND_PREFIX) }
+        var nots = nestedQuery.findAll { it.key.startsWith(NOT_PREFIX) }
+        var rest = nestedQuery.findAll { !(it.key in nots.keySet() || it.key in ands.keySet()) }
+
+        if (nots && !ands && !rest) {
+            return nots.collect {
+                String prop = stripPrefix(it.key, NOT_PREFIX)
+                Q.not([Q.nested(prefix, createBoolFilter([(prop): it.value]))])
             }
-            
-            result << [ 'nested': [
-                            'path': prefix, 
-                            'query': ['bool': ['must': musts]]]]
         }
 
-        // Implicit OR
-        // identifiedBy.value=A&identifiedBy.value=B is expected to work the same way as for non-nested docs 
-        if (nestedQuery.size() == 1 && nestedQuery[nestedQuery.keySet().first()].size() > 1) {
-            result = [['bool': ['should': result]]]
+        int numberOfReferencedDocs = ands.collect { it.value }.collect { it.length }?.max() ?: 1
+
+        List<Map> result = []
+        for (int i = 0 ; i < numberOfReferencedDocs ; i++) {
+            List<Map> musts = []
+            List<Map> mustNots = null
+
+            if (i == 0) {
+                getOrGroups(rest).each {
+                    musts.add(createBoolFilter(it))
+                }
+                mustNots = nots.collect {
+                    String prop = stripPrefix(it.key, NOT_PREFIX)
+                    createBoolFilter([(prop): it.value])
+                }
+            }
+
+            musts.addAll(ands.findResults {
+                it.value.length > i
+                        ? createBoolFilter([ (stripPrefix(it.key, AND_PREFIX)): [it.value[i]] ])
+                        : null
+            })
+            
+            result << Q.nested(prefix, Q.bool(musts, mustNots))
         }
 
         return result
     }
-    
+
+    private static String stripPrefix(String s, String prefix) {
+        s.startsWith(prefix) ? s.substring(prefix.length()) : s
+    }
+
+    private static class Q {
+        static Map not(List mustNots) {
+            return bool(null, mustNots)
+        }
+
+        static Map bool(List must, List mustNot) {
+            Map b = [:]
+            if (must) {
+                b['must'] = must
+            }
+            if (mustNot) {
+                b['must_not'] = mustNot
+            }
+            return ['bool': b]
+        }
+
+        static Map nested(String prefix, Map query) {
+            ['nested': ['path': prefix, 'query': query]]
+        }
+    }
+
     /**
      * Can this query string be handled by ES simple_query_string?
      */
@@ -781,6 +865,7 @@ class ESQuery {
             }
         }
 
+        // FIXME? "should" wrapper is not needed if values/clauses.size == 1
         return ['bool': ['should': clauses]]
     }
     
@@ -843,16 +928,27 @@ class ESQuery {
             def filters = multiSelectFilters.findAll { it.key != key }.values()
             String termPath = getInferredTermPath(key)
 
+            // Core agg query
+            query[termPath] = ['terms': [
+                    'field': termPath,
+                    'size' : tree[key]?.size ?: size,
+                    'order': [(sort): sortOrder]]
+            ]
+
+            // If field is nested, wrap agg query with nested
+            nestedFields.find{ key.startsWith(it) }?.with { nestedField ->
+                query[termPath] = [
+                        'nested': [ 'path': nestedField ],
+                        'aggs'  : [ (NESTED_AGG_NAME): query[termPath] ]
+                ]
+            }
+
+            // Wrap agg query with a filter so that we can get counts for multi select filters
             query[termPath] = [
-                'aggs' : [
-                    (FILTERED_AGG): ['terms': [
-                        'field': termPath,
-                        'size' : tree[key]?.size ?: size,
-                        'order': [(sort): sortOrder]]
-                    ]
-                ],
+                'aggs'  : [ (FILTERED_AGG_NAME): query[termPath] ],
                 'filter': ['bool': ['must': filters]]
             ]
+
             if (tree[key].subItems instanceof Map) {
                 query[termPath]['aggs'] = buildAggQuery(tree[key].subItems, multiSelectFilters, size)
             }
@@ -947,7 +1043,7 @@ class ESQuery {
         getFieldsWithSetting('analyzer', analyzer, mappings)
     }
 
-    static Set getFieldsWithSetting(String setting, String value, Map mappings) {
+    static Set getFieldsWithSetting(String setting, value, Map mappings) {
         Set fields = [] as Set
         DocumentUtil.findKey(mappings['properties'], setting) { v, path ->
             if (v == value) {
@@ -1007,15 +1103,18 @@ class ESQuery {
         return result
     }
 
-    static Map moveFilteredAggregationsToTopLevel(Map esResponse) {
+    static Map moveAggregationsToTopLevel(Map esResponse) {
         if (!esResponse['aggregations']) {
             return esResponse
         }
 
         Map aggregations = (Map) esResponse['aggregations']
         aggregations.keySet().each { k ->
-            if (aggregations[k][FILTERED_AGG]) {
-                aggregations[k] = aggregations[k][FILTERED_AGG]
+            if (aggregations[k][FILTERED_AGG_NAME]) {
+                aggregations[k] = aggregations[k][FILTERED_AGG_NAME]
+            }
+            if (aggregations[k][NESTED_AGG_NAME]) {
+                aggregations[k] = aggregations[k][NESTED_AGG_NAME]
             }
         }
 

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -569,13 +569,11 @@ class ESQuery {
 
         // If both nested and notNested contains explicit OR they need to be moved to not nested
         // If two different nested contains explicit or they need to be moved to not nested
-        // TODO handle not_in_parent
         boolean explicitOrInDifferentNested = nested.values()
                 .findAll{ it.keySet().any{ k -> k.startsWith(OR_PREFIX)} }
                 .size() > 1
 
         if (notNested.keySet().any { it.startsWith(OR_PREFIX) } || explicitOrInDifferentNested) {
-            // TODO
             nested.values().each { n ->
                 n.keySet().findAll{ it.startsWith(OR_PREFIX) }.each {
                     notNested.put(it, n.remove(it))

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -567,8 +567,8 @@ class ESQuery {
         var nested = getNestedParams(groups)
         Map notNested = (groups - nested).collect { it.value }.sum([:])
 
-        // If both nested and notNested contains explicit OR they need to be moved to not nested
-        // If two different nested contains explicit or they need to be moved to not nested
+        // If both nested and notNested contains explicit OR they should be moved to notNested
+        // If two different nested contains explicit OR they should be moved to not notNested
         boolean explicitOrInDifferentNested = nested.values()
                 .findAll{ it.keySet().any{ k -> k.startsWith(OR_PREFIX)} }
                 .size() > 1

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -1,6 +1,7 @@
 package whelk.search
 
 import groovy.json.JsonOutput
+import spock.lang.Ignore
 import spock.lang.Specification
 import whelk.JsonLd
 
@@ -14,6 +15,8 @@ class ESQuerySpec extends Specification {
         Map display = [:]
         Map vocab = [:]
         es.jsonld = new JsonLd(context, display, vocab)
+        es.nestedNotInParentFields = ['nested_not_in_parent_field', 'deeper.deeper_nested_not_in_parent_field'] as Set
+        es.nestedFields = ['nested_field', 'deeper.deeper_nested_field'] + es.nestedNotInParentFields as Set
     }
 
     def "should get query string"() {
@@ -69,7 +72,7 @@ class ESQuerySpec extends Specification {
 
     def "should get filters"(Map<String, String[]> params, List result) {
         given:
-        def (filters, postFilters) = es.getFilters(params)
+        def (filters, postFilters) = es.getFilters(params.collectEntries { k, v -> [(k), v as String[]] })
         expect:
         filters == result
         where:
@@ -153,6 +156,110 @@ class ESQuerySpec extends Specification {
                                                         ['simple_query_string' : ['query': 'baz',
                                                                                   'fields': ['__langAliased'],
                                                                                   'default_operator': 'AND']]]]]]]]]
+
+    }
+
+    def "should get filters for nested docs"(Map<String, String[]> params, List result) {
+        given:
+        def (filters, postFilters) = es.getFilters(params.collectEntries { k, v -> [(k), v as String[]] })
+        expect:
+        filters == result
+        where:
+        params                                          | result
+
+        // Matching two different nested objects - nested_field: [{ a: foo, b: baz }, { a: bar, b: qux }]
+        ['and-nested_field.a': ['foo', 'bar'],
+         'and-nested_field.b': ['baz', 'qux']] | [[bool:[must:[
+                [nested: [path:'nested_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'foo', fields:['nested_field.a'], default_operator:'AND']]]]],
+                        [bool:[should:[[simple_query_string:[query:'baz', fields:['nested_field.b'], default_operator:'AND']]]]]
+                ]]]]],
+                [nested: [path:'nested_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'bar', fields:['nested_field.a'], default_operator:'AND']]]]],
+                        [bool:[should:[[simple_query_string:[query:'qux', fields:['nested_field.b'], default_operator:'AND']]]]]
+                ]]]]]
+        ]]]]
+
+        ['and-deeper.deeper_nested_field.a': ['foo', 'bar'],
+         'and-deeper.deeper_nested_field.b': ['baz', 'qux']] | [[bool:[must:[
+                [nested:[path:'deeper.deeper_nested_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'baz', fields:['deeper.deeper_nested_field.b'], default_operator:'AND']]]]],
+                        [bool:[should:[[simple_query_string:[query:'foo', fields:['deeper.deeper_nested_field.a'], default_operator:'AND']]]]]
+                ]]]]],
+                [nested:[path:'deeper.deeper_nested_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'qux', fields:['deeper.deeper_nested_field.b'], default_operator:'AND']]]]],
+                        [bool:[should:[[simple_query_string:[query:'bar', fields:['deeper.deeper_nested_field.a'], default_operator:'AND']]]]]
+                ]]]]]
+        ]]]]
+
+        // Implicit OR
+        ['nested_field.a': ['foo', 'bar']] | [[bool:[must:[
+                [nested:[path:'nested_field', query:[bool:[must:[[bool:[should:[
+                        [simple_query_string:[query:'foo', fields:['nested_field.a'], default_operator:'AND']],
+                        [simple_query_string:[query:'bar', fields:['nested_field.a'], default_operator:'AND']]
+                ]]]]]]]]
+        ]]]]
+
+
+        // Single filter on nested doc doesn't need a nested query
+        ['nested_field.a': ['foo']] | [[bool:[must:[
+                [bool:[should:[[simple_query_string:[query:'foo', fields:['nested_field.a'], default_operator:'AND']]]]]
+        ]]]]
+
+        ['deeper.deeper_nested_field.a': ['foo']] | [[bool:[must:[
+                [bool:[should:[[simple_query_string:[query:'foo', fields:['deeper.deeper_nested_field.a'], default_operator:'AND']]]]]
+        ]]]]
+
+
+        // Unless the nested document isn't included in parent
+        ['nested_not_in_parent_field.a': ['foo']] | [[bool:[must:[
+                [nested:[path:'nested_not_in_parent_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'foo', fields:['nested_not_in_parent_field.a'], default_operator:'AND']]]]]
+                ]]]]]
+        ]]]]
+
+        ['deeper.deeper_nested_not_in_parent_field.a': ['foo']] | [[bool:[must:[
+                [nested:[path:'deeper.deeper_nested_not_in_parent_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'foo', fields:['deeper.deeper_nested_not_in_parent_field.a'], default_operator:'AND']]]]]
+                ]]]]]
+        ]]]]
+
+        // Implicit AND
+        ['nested_field.a': ['foo'], 'nested_field.b': ['bar']] | [[bool:[must:[
+                [nested:[path:'nested_field', query:[bool:[must:[
+                        [bool:[should:[[simple_query_string:[query:'bar', fields:['nested_field.b'], default_operator:'AND']]]]],
+                        [bool:[should:[[simple_query_string:[query:'foo', fields:['nested_field.a'], default_operator:'AND']]]]]
+                ]]]]]
+        ]]]]
+
+        // Explicit OR inside and outside nested document
+        ['or-nested_not_in_parent_field.a': ['foo'], 'or-not_nested.a': ['bar']] | [[bool:[must:[
+                [bool:[should:[
+                        [simple_query_string:[query:'bar', fields:['not_nested.a'], default_operator:'AND']],
+                        [nested:[path:'nested_not_in_parent_field', query:[simple_query_string:[query:'foo', fields:['nested_not_in_parent_field.a'], default_operator:'AND']]]]
+                ]]]
+        ]]]]
+
+        ['or-deeper.deeper_nested_not_in_parent_field.a': ['foo'], 'or-not_nested.a': ['bar']] | [[bool:[must:[
+                [bool:[should:[
+                        [simple_query_string:[query:'bar', fields:['not_nested.a'], default_operator:'AND']],
+                        [nested:[path:'deeper.deeper_nested_not_in_parent_field', query:[simple_query_string:[query:'foo', fields:['deeper.deeper_nested_not_in_parent_field.a'], default_operator:'AND']]]]
+                ]]]
+        ]]]]
+
+        ['or-nested_field.a': ['foo'], 'or-not_nested.a': ['bar']] | [[bool:[must:[
+                [bool:[should:[
+                        [simple_query_string:[query:'bar', fields:['not_nested.a'], default_operator:'AND']],
+                        [simple_query_string:[query:'foo', fields:['nested_field.a'], default_operator:'AND']]
+                ]]]
+        ]]]]
+
+        ['or-deeper.deeper_nested_field.a': ['foo'], 'or-not_nested.a': ['bar']] | [[bool:[must:[
+                [bool:[should:[
+                        [simple_query_string:[query:'bar', fields:['not_nested.a'], default_operator:'AND']],
+                        [simple_query_string:[query:'foo', fields:['deeper.deeper_nested_field.a'], default_operator:'AND']]
+                ]]]
+        ]]]]
     }
 
     def "should create bool filter"(String key, String[] vals, Map result) {

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -1,7 +1,6 @@
 package whelk.search
 
 import groovy.json.JsonOutput
-import spock.lang.Ignore
 import spock.lang.Specification
 import whelk.JsonLd
 

--- a/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search/ESQuerySpec.groovy
@@ -285,6 +285,13 @@ class ESQuerySpec extends Specification {
                                                [simple_query_string:[query:'qux', fields:['nested_field.c'], default_operator:'AND']]]]]]
                 ]]]]
         ]]]]
+
+        //
+        ['nested_field_not_really.a': ['foo'], 'nested_field_not_really.b': ['bar']] | [[bool:[must:[
+                [bool:[should:[[simple_query_string:[query:'foo', fields:['nested_field_not_really.a'], default_operator:'AND']]]]],
+                [bool:[should:[[simple_query_string:[query:'bar', fields:['nested_field_not_really.b'], default_operator:'AND']]]]]
+        ]]]]
+
     }
 
     def "should create bool filter"(String key, String[] vals, Map result) {


### PR DESCRIPTION
* Index `@reverse.itemOf` as nested
* Handle query parameter prefixes (`and-`, `or-`, `not-`, `exists-`) on nested fields/documents
* Make faceting work on nested documents
* Handle nested documents where `included_in_parent = false`
* Use the same type of filter inside nested docs as outside.
    * Makes e.g. prefix search on ISBN work

Not handled yet
* `and-matches`
* ranges (`min-`, `max-` etc.)