### PR TITLE
Feature/type facets

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -125,18 +125,19 @@ public class SearchUtils2 {
 
         public Map<String, Object> getPartialCollectionView(Map<String, Object> esResponse) {
             int numHits = (int) esResponse.getOrDefault("totalHits", 0);
+            var aliases = XLQLQuery.getAliasMappings(outsetType);
             var view = new LinkedHashMap<String, Object>();
             view.put(JsonLd.TYPE_KEY, "PartialCollectionView");
             view.put(JsonLd.ID_KEY, makeFindUrl(freeText, queryString, offset));
             view.put("itemOffset", offset);
             view.put("itemsPerPage", limit);
             view.put("totalItems", numHits);
-            view.put("search", Map.of("mapping", toMappings()));
+            view.put("search", Map.of("mapping", toMappings(aliases)));
             view.putAll(makePaginationLinks(numHits));
             if (esResponse.containsKey("items")) {
                 view.put("items", esResponse.get("items"));
             }
-            view.put("stats", xlqlQuery.getStats(esResponse, statsRepr, simpleQueryTree, getNonQueryParams(0), outsetType));
+            view.put("stats", xlqlQuery.getStats(esResponse, statsRepr, simpleQueryTree, getNonQueryParams(0), aliases));
             if (debug) {
                 view.put("_debug", Map.of("esQuery", esQueryDsl));
             }
@@ -220,8 +221,8 @@ public class SearchUtils2 {
             return params;
         }
 
-        private List<Map<?, ?>> toMappings() {
-            return List.of(xlqlQuery.toMappings(simpleQueryTree, makeNonQueryParams(0)));
+        private List<Map<?, ?>> toMappings(Map<String, String> aliases) {
+            return List.of(xlqlQuery.toMappings(simpleQueryTree, aliases, makeNonQueryParams(0)));
         }
 
         private static Optional<String> getOptionalSingleFilterEmpty(String name, Map<String, String[]> queryParameters) {

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -136,7 +136,7 @@ public class SearchUtils2 {
             if (esResponse.containsKey("items")) {
                 view.put("items", esResponse.get("items"));
             }
-            view.put("stats", xlqlQuery.getStats(esResponse, statsRepr, simpleQueryTree, getNonQueryParams(0)));
+            view.put("stats", xlqlQuery.getStats(esResponse, statsRepr, simpleQueryTree, getNonQueryParams(0), outsetType));
             if (debug) {
                 view.put("_debug", Map.of("esQuery", esQueryDsl));
             }

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -132,7 +132,7 @@ public class Disambiguate {
     }
 
     public boolean isType(String property) {
-        return "rdf:type".equals(property);
+        return "rdf:type".equals(property) || jsonLd.getSubProperties("rdf:type").contains(property);
     }
 
     public PropertyChain expandChainAxiom(List<String> path) {

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -36,6 +36,7 @@ public class Disambiguate {
         ENUM
     }
 
+    //TODO: Abstract away the need for OutsetType/DomainCategory
     public enum OutsetType {
         INSTANCE,
         WORK,

--- a/whelk-core/src/main/groovy/whelk/xlql/Path.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Path.java
@@ -9,9 +9,11 @@ public class Path {
     public List<DefaultField> defaultFields;
     public List<String> path;
 
+    // TODO: Get substituions from context instead?
     private static final Map<String, String> substitutions = Map.of(
             "rdf:type", JsonLd.TYPE_KEY,
-            "hasItem", String.format("%s.itemOf", JsonLd.REVERSE_KEY)
+            "hasItem", String.format("%s.itemOf", JsonLd.REVERSE_KEY),
+            "hasInstance", String.format("%s.instanceOf", JsonLd.REVERSE_KEY)
     );
 
     public Path(List<String> path) {
@@ -28,6 +30,12 @@ public class Path {
     }
 
     public List<Path> expand(String property, Disambiguate disambiguate, Disambiguate.OutsetType outsetType) {
+        List<Path> altPaths = new ArrayList<>(List.of(this));
+
+        if ("rdf:type".equals(property)) {
+            return altPaths;
+        }
+
         expandChainAxiom(disambiguate);
 
         String domain = disambiguate.getDomain(property);
@@ -36,8 +44,6 @@ public class Path {
         if (domainCategory == Disambiguate.DomainCategory.ADMIN_METADATA) {
             prependMeta();
         }
-
-        List<Path> altPaths = new ArrayList<>(List.of(this));
 
         switch (outsetType) {
             case WORK -> {

--- a/whelk-core/src/main/groovy/whelk/xlql/Path.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Path.java
@@ -32,11 +32,11 @@ public class Path {
     public List<Path> expand(String property, Disambiguate disambiguate, Disambiguate.OutsetType outsetType) {
         List<Path> altPaths = new ArrayList<>(List.of(this));
 
-        if ("rdf:type".equals(property)) {
+        expandChainAxiom(disambiguate);
+
+        if (disambiguate.isType(property)) {
             return altPaths;
         }
-
-        expandChainAxiom(disambiguate);
 
         String domain = disambiguate.getDomain(property);
 

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -85,7 +85,7 @@ public class QueryTree {
     }
 
     static Node newFields(SimpleQueryTree.PropertyValue pv, Path path, Disambiguate disambiguate) {
-        if (disambiguate.isType(pv.property())) {
+        if ("rdf:type".equals(pv.property())) {
             return buildTypeField(pv, path, disambiguate);
         }
 


### PR DESCRIPTION
Adds support for displaying both instance type and work type as facets. 

Since work and instance types are to be displayed as 'type' and 'carrier type' respectively it was necessary to map `rdf:type` to different aliases depending on which type of entities we're looking at in a search result. These mappings are now hardcoded in `XLQLQuery.getAliasMappings()`. Feels a bit ad hoc of course but does the trick for now. And I think at least the mechanism itself might be of use in the future since it's likely that we want to display properties differently depending on the context.

Required for this to work:
- https://github.com/libris/definitions/pull/482
- https://github.com/libris/lxlviewer/pull/1011