### PR TITLE
Interpret property=* as existence query

### DIFF
--- a/whelk-core/src/main/groovy/whelk/xlql/Operator.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Operator.java
@@ -10,6 +10,8 @@ public enum Operator {
     LESS_THAN_OR_EQUALS("lessThanOrEquals"),
     LESS_THAN("lessThan");
 
+    public static final String WILDCARD = "*";
+
     public final String termKey;
 
     Operator(String termKey) {

--- a/whelk-core/src/main/groovy/whelk/xlql/Path.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Path.java
@@ -124,4 +124,14 @@ public class Path {
     private String substitute(String property) {
         return Optional.ofNullable(substitutions.get(property)).orElse(property);
     }
+
+    @Override
+    public String toString() {
+        var s = new StringBuilder();
+        s.append(path);
+        if (!defaultFields.isEmpty()) {
+            s.append("(defaultFields: ").append(defaultFields).append(")");
+        }
+        return s.toString();
+    }
 }

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -39,7 +39,7 @@ public class QueryTree {
 
     public record FreeText(Operator operator, String value) implements Node {
         public boolean isWild() {
-            return operator == EQUALS && "*".equals(value);
+            return operator == EQUALS && Operator.WILDCARD.equals(value);
         }
     }
 


### PR DESCRIPTION
Corresponding to `exists-` prefix in old style API