### PR TITLE
Range filter 

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -44,9 +44,14 @@ public class SearchUtils2 {
         for (Map<String, Object> slice : sliceList) {
             String key = (String) ((List<?>) slice.get("dimensionChain")).getFirst();
             int limit = (Integer) slice.get("itemLimit");
-            var m = Map.of("sort", "value",
-                    "sortOrder", "desc",
-                    "size", limit);
+            String range = (String) slice.get("range");
+            var m = new HashMap<>();
+            m.put("sort", "value");
+            m.put("sortOrder", "desc");
+            m.put("size", limit);
+            if (range != null) {
+                m.put("range", range);
+            }
             statsfind.put(key, m);
         }
         return statsfind;


### PR DESCRIPTION
For properties that can be filtered by range (see https://github.com/libris/definitions/commit/ae5c4df3eb511ad6dd39fa0adf55b0ea754cdbad) supply a url template in which custom min/max values can be inserted. Example:
```
{
  "stats": {
    "sliceByDimension": {
      "yearPublished": {
        "search": {
          "template": "/find?_i=&_q=boll%20{?yearPublished}&_limit=20",
          "mapping": {
            "variable": "yearPublished",
            "greaterThanOrEquals": "",
            "lessThanOrEquals": "2020"
          }
        },
        "dimension": "yearPublished",
        "observation": {}
      }
    }
  }
}
```

Unless the previous query included a valid filter on `yearPublished` both `greaterThanOrEquals` and `lessThanOrEquals` will be empty, however in the above example the previous query included `yearPublished<=2020` (or `yearPublished<2021`).
Min/max values that contain non-numeric characters will not be mapped to `greaterThanOrEquals`/`lessThanOrEquals`, i.e. they will remain empty. They will also remain empty if multiple or ambiguous ranges were given in the previous query, e.g. `yearPublished>=2010 yearPublished>=2005` or `yearPublished>=2010 yearPublished<=2020 yearPublished>=2000 yearPublished<=2005`.