### PR TITLE
Use shadowjar to build fat jars; fixes Jena XML problems

### DIFF
--- a/apix_server/build.gradle
+++ b/apix_server/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def mainClassName = "whelk.ApixServer"
 
@@ -37,9 +38,14 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
     dependsOn ':server-common:jar'
-    
+    dependsOn(shadowJar)
+
     manifest {
         attributes "Main-Class": mainClassName,
                 // log4j uses multi-release to ship different stack walking implementations for different java
@@ -47,14 +53,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(appRun, dependsOn: "classes", type: JavaExec) {

--- a/batchimport/build.gradle
+++ b/batchimport/build.gradle
@@ -46,7 +46,7 @@ shadowJar {
 }
 
 jar {
-    dependsOn ':server-common:jar'
+    dependsOn ':whelk-core:jar'
     dependsOn(shadowJar)
 
     manifest {

--- a/batchimport/build.gradle
+++ b/batchimport/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'application'
 apply plugin: 'groovy'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
@@ -40,8 +41,14 @@ application {
     mainClass = 'whelk.importer.Main'
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
-    dependsOn ':whelk-core:jar'
+    dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
+
     manifest {
         attributes 'Implementation-Title':'Libris XL metadata importer',
                 'Implementation-Version': '1.0',
@@ -51,8 +58,5 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {it.isDirectory() ? it : zipTree(it) }
-    }
+    archiveClassifier = "nonfat"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "nebula.lint" version "16.16.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 allprojects {

--- a/gui-whelktool/build.gradle
+++ b/gui-whelktool/build.gradle
@@ -1,4 +1,7 @@
+def mainClassName = "whelk.gui.GuiWhelkTool"
+
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
@@ -6,22 +9,24 @@ repositories {
 
 dependencies {
     implementation project(':whelktool')
+    implementation project(':whelk-core')
+}
+
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+    project.setProperty("mainClassName", mainClassName)
 }
 
 jar {
+    dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
+
     manifest {
-        attributes "Main-Class": "whelk.gui.GuiWhelkTool",
+        attributes "Main-Class": mainClassName,
                 // log4j uses multi-release to ship different stack walking implementations for different java
                 // versions. Since we repackage everything as a fat jar, that jar must also be multi-release.
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }

--- a/housekeeping/build.gradle
+++ b/housekeeping/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'java-library'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def mainClassName = "whelk.HouseKeepingServer"
 
@@ -65,8 +66,13 @@ test.testLogging {
     exceptionFormat = "full"
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
     dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
 
     manifest {
         attributes "Main-Class": mainClassName,
@@ -75,14 +81,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(appRun, dependsOn: "classes", type: JavaExec) {

--- a/importers/build.gradle
+++ b/importers/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'groovy'
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+def mainClassName = "whelk.importer.ImporterMain"
 
 loadConfiguration()
 def loadConfiguration() {
@@ -90,26 +93,23 @@ dependencies {
     implementation 'org.slf4j:slf4j-simple:1.7.32'
 }
 
-// Include dependent libraries in archive.
+shadowJar {
+    archivesBaseName = "xlimporter"
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
-    archivesBaseName = 'xlimporter'
-	
+    dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
+
     manifest {
-        attributes "Main-Class": "whelk.importer.ImporterMain",
+        attributes "Main-Class": mainClassName,
                 // log4j uses multi-release to ship different stack walking implementations for different java
                 // versions. Since we repackage everything as a fat jar, that jar must also be multi-release.
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
-
+    archiveClassifier = "nonfat"
 }
 
 task(doRun, dependsOn: "classes", type: JavaExec) {

--- a/librisworks/build.gradle
+++ b/librisworks/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
 apply plugin: 'groovy'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+def mainClassName = "whelk.datatool.WhelkTool"
 
 sourceSets {
     scripts {
@@ -26,19 +29,21 @@ test {
     useJUnitPlatform()
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+    project.setProperty("mainClassName", mainClassName)
+}
+
 jar {
+    dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
+
     manifest {
-        attributes "Main-Class": "whelk.datatool.WhelkTool",
+        attributes "Main-Class": mainClassName,
                 // log4j uses multi-release to ship different stack walking implementations for different java
                 // versions. Since we repackage everything as a fat jar, that jar must also be multi-release.
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }

--- a/marc_export/build.gradle
+++ b/marc_export/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def mainClassName = "whelk.export.marc.MarcCliExport"
 
@@ -52,8 +53,13 @@ dependencies {
 
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
     dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
 
     manifest {
         attributes "Main-Class": mainClassName,
@@ -62,14 +68,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(appRun, dependsOn: "classes", type: JavaExec) {

--- a/oaipmh/build.gradle
+++ b/oaipmh/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def mainClassName = "whelk.OaiPmhServer"
 
@@ -39,8 +40,13 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
     dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
 
     manifest {
         attributes "Main-Class": mainClassName,
@@ -49,14 +55,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(appRun, dependsOn: "classes", type: JavaExec) {

--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -1,6 +1,11 @@
+plugins {
+    id "nebula.lint" version "16.16.0"
+}
+
 apply plugin: 'groovy'
 apply plugin: 'java-library'
 apply plugin: 'jacoco'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def mainClassName = "whelk.RestServer"
 
@@ -93,8 +98,14 @@ dependencies {
     testImplementation 'cglib:cglib-nodep:3.1'
 }
 
+shadowJar {
+    mergeServiceFiles()
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
     dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
 
     manifest {
         attributes "Main-Class": mainClassName,
@@ -103,14 +114,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-                exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA','build','.gradle/**','build.gradle','gradle','gradlew','gradlew.bat','test'
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(appRun, dependsOn: "classes", type: JavaExec) {

--- a/whelktool/build.gradle
+++ b/whelktool/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 def loadConfiguration() {
     ext {
@@ -73,7 +74,14 @@ dependencies {
     whelktoolScriptsCompileOnly project(':whelk-core')
 }
 
+shadowJar {
+    archiveClassifier = null // removes `-all` in the filename of the created .jar
+}
+
 jar {
+    dependsOn ':server-common:jar'
+    dependsOn(shadowJar)
+
     manifest {
         attributes "Main-Class": "whelk.datatool.WhelkTool",
                 // log4j uses multi-release to ship different stack walking implementations for different java
@@ -81,13 +89,7 @@ jar {
                 "Multi-Release": true
     }
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : project.zipTree(it).matching {
-            }
-        }
-    }
+    archiveClassifier = "nonfat"
 }
 
 task(doRun, dependsOn: "classes", type: JavaExec) {


### PR DESCRIPTION
In (at least) the REST API, XML output stopped working after the recent change to fat jars. E.g. https://libris.kb.se/j2sg3v54g5qng9rs/data.xml would return HTTP 500 and:

```
javax.servlet.ServletException: Unexpected Exception
  at org.eclipse.jetty.ee8.nested.ContextHandler.doScope(ContextHandler.java:811)
  at org.eclipse.jetty.ee8.nested.ScopedHandler.handle(ScopedHandler.java:117)
  at org.eclipse.jetty.ee8.nested.ContextHandler.handle(ContextHandler.java:1401)
  at org.eclipse.jetty.ee8.nested.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1293)
  at org.eclipse.jetty.ee8.nested.HttpChannel.dispatch(HttpChannel.java:623)
  at org.eclipse.jetty.ee8.nested.HttpChannel.handle(HttpChannel.java:455)
  at org.eclipse.jetty.ee8.nested.ContextHandler$CoreContextHandler$CoreToNestedHandler.handle(ContextHandler.java:2233)
  at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:763)
  at org.eclipse.jetty.server.Handler$Wrapper.handle(Handler.java:716)
  at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:138)
  at org.eclipse.jetty.server.Server.handle(Server.java:179)
  at org.eclipse.jetty.server.internal.HttpChannelState$HandlerInvoker.run(HttpChannelState.java:619)
  at org.eclipse.jetty.server.internal.HttpConnection.onFillable(HttpConnection.java:410)
  at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:322)
  at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:99)
  at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
  at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:478)
  at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:441)
  at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:293)
  at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:201)
  at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:410)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
  at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.apache.jena.rdf.model.ModelFactory
  at whelk.converter.JsonLD2RdfXml.convert(JsonLD2RdfXml.groovy:36)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:48)
  at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSite.invoke(PogoMetaMethodSite.java:166)
  at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:69)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:148)
  at whelk.rest.api.ConverterUtils.convert(ConverterUtils.groovy:29)
  at whelk.rest.api.Crud.getNegotiatedDataBody(Crud.groovy:269)
  at whelk.rest.api.Crud.getFormattedResponseBody(Crud.groovy:263)
  at whelk.rest.api.Crud.handleGetRequest(Crud.groovy:217)
  at whelk.rest.api.Crud.doGet2(Crud.groovy:125)
  at whelk.rest.api.Crud.doGet(Crud.groovy:105)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:503)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:590)
  at org.eclipse.jetty.ee8.servlet.ServletHolder.handle(ServletHolder.java:640)
  at org.eclipse.jetty.ee8.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1374)
  at whelk.AuthenticationFilter.doFilter(AuthenticationFilter.java:127)
  at org.eclipse.jetty.ee8.servlet.FilterHolder.doFilter(FilterHolder.java:171)
  at org.eclipse.jetty.ee8.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1348)
  at com.thetransactioncompany.cors.CORSFilter.doFilter(CORSFilter.java:174)
  at com.thetransactioncompany.cors.CORSFilter.doFilter(CORSFilter.java:237)
  at org.eclipse.jetty.ee8.servlet.FilterHolder.doFilter(FilterHolder.java:171)
  at org.eclipse.jetty.ee8.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1348)
  at org.eclipse.jetty.ee8.servlet.ServletHandler.doHandle(ServletHandler.java:454)
  at org.eclipse.jetty.ee8.nested.ScopedHandler.nextHandle(ScopedHandler.java:181)
  at org.eclipse.jetty.ee8.nested.ContextHandler.doHandle(ContextHandler.java:858)
  at org.eclipse.jetty.ee8.nested.ScopedHandler.nextScope(ScopedHandler.java:152)
  at org.eclipse.jetty.ee8.servlet.ServletHandler.doScope(ServletHandler.java:423)
  at org.eclipse.jetty.ee8.nested.ScopedHandler.nextScope(ScopedHandler.java:150)
  at org.eclipse.jetty.ee8.nested.ContextHandler.doScope(ContextHandler.java:803)
  ... 23 more
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NullPointerException [in thread "etp897848096-62"]
  at org.apache.jena.tdb.sys.EnvTDB.processGlobalSystemProperties(EnvTDB.java:33)
  at org.apache.jena.tdb.TDB.init(TDB.java:250)
  at org.apache.jena.tdb.sys.InitTDB.start(InitTDB.java:29)
  at org.apache.jena.system.JenaSystem.lambda$init$40(JenaSystem.java:114)
  at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
  at org.apache.jena.system.JenaSystem.forEach(JenaSystem.java:179)
  at org.apache.jena.system.JenaSystem.forEach(JenaSystem.java:156)
  at org.apache.jena.system.JenaSystem.init(JenaSystem.java:111)
  at org.apache.jena.rdf.model.ModelFactory.<clinit>(ModelFactory.java:49)
  ```

The reason: https://jena.apache.org/documentation/notes/jena-repack.html

> Apache Jena initializes uses Java’s ServiceLoader mechanism to locate initialization steps. The documentation for process in Jena is available here.
>
> There are a number of files (Java resources) in Jena jars named:
>
> META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
> Each has different contents, usually one or two lines.
> 
> When making a combined jar (“uber-jar”, jar with dependencies) from Jena dependencies and application code, the contents of the Jena files must be combined and be present in the combined jar as a java resource of the same name.

They weren't combined:

```
$ unzip -p /srv/rest.jar META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
org.apache.jena.tdb.sys.InitTDB
```

So Jena didn't initialize properly.

This PR switches to using [Shadow](https://github.com/johnrengelman/shadow) for making fat jars, and, in the case of `rest`, uses Shadow's `mergeServiceFiles()` to handle the service files mentioned above. Now:

```
unzip -p build/libs/rest.jar META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
org.apache.jena.tdb.sys.InitTDB
org.apache.jena.riot.system.InitRIOT
org.apache.jena.sparql.system.InitARQ
org.apache.jena.system.InitJenaCore
```

And we can get XML again.

(`archiveClassifier = "nonfat"` is necessary, otherwise the fat jar will be overwritten by the non-fat one; there's probably a better way to handle that :shrug: See also https://imperceptiblethoughts.com/shadow/getting-started/#default-java-groovy-tasks )