### PR TITLE
Handle nested fields in new search

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -20,12 +20,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static whelk.util.Jackson.mapper;
+import static whelk.xlql.Disambiguate.RDF_TYPE;
 
 public class SearchUtils2 {
     final static int DEFAULT_LIMIT = 200;
     final static int MAX_LIMIT = 4000;
     final static int DEFAULT_OFFSET = 0;
-    private static final List<SimpleQueryTree.PropertyValue> DEFAULT_FILTERS = List.of(SimpleQueryTree.pvEqualsVocabTerm("rdf:type", "Work"));
+    private static final List<SimpleQueryTree.PropertyValue> DEFAULT_FILTERS = List.of(SimpleQueryTree.pvEqualsVocabTerm(RDF_TYPE, "Work"));
 
     Whelk whelk;
     XLQLQuery xlqlQuery;

--- a/whelk-core/src/main/groovy/whelk/xlql/DefaultField.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/DefaultField.java
@@ -1,6 +1,0 @@
-package whelk.xlql;
-
-import java.util.List;
-
-public record DefaultField(List<String> path, String value) {
-}

--- a/whelk-core/src/main/groovy/whelk/xlql/Path.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Path.java
@@ -4,134 +4,173 @@ import whelk.JsonLd;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static whelk.xlql.Disambiguate.RDF_TYPE;
 
 public class Path {
-    public List<DefaultField> defaultFields;
-    public List<String> path;
+    public List<String> stem;
+    public List<Branch> branches;
+    private List<List<String>> roots;
+
+    public record Branch(List<String> path, SimpleQueryTree.Value value) {
+        Branch(List<String> path) {
+            this(path, null);
+        }
+    }
+
+    String path;
 
     // TODO: Get substituions from context instead?
     private static final Map<String, String> substitutions = Map.of(
-            "rdf:type", JsonLd.TYPE_KEY,
+            RDF_TYPE, JsonLd.TYPE_KEY,
             "hasItem", String.format("%s.itemOf", JsonLd.REVERSE_KEY),
             "hasInstance", String.format("%s.instanceOf", JsonLd.REVERSE_KEY)
     );
 
     public Path(List<String> path) {
-        this.path = new ArrayList<>(path);
+        this.stem = path;
+        this.branches = new ArrayList<>();
+        this.roots = new ArrayList<>();
     }
 
-    Path(Path p) {
-        this.path = new ArrayList<>(p.path);
-        this.defaultFields = new ArrayList<>(p.defaultFields);
+    public void expand(String property, Disambiguate disambiguate, Disambiguate.OutsetType outsetType) {
+        expand(property, disambiguate, outsetType, null);
     }
 
-    Path copy() {
-        return new Path(this);
-    }
-
-    public List<Path> expand(String property, Disambiguate disambiguate, Disambiguate.OutsetType outsetType) {
-        List<Path> altPaths = new ArrayList<>(List.of(this));
-
+    public void expand(String property, Disambiguate disambiguate, Disambiguate.OutsetType outsetType, SimpleQueryTree.Value value) {
         expandChainAxiom(disambiguate);
 
-        if (disambiguate.isType(property)) {
-            return altPaths;
-        }
+        if (!disambiguate.isType(property)) {
+            String domain = disambiguate.getDomain(property);
 
-        String domain = disambiguate.getDomain(property);
+            Disambiguate.DomainCategory domainCategory = disambiguate.getDomainCategory(domain);
+            if (domainCategory == Disambiguate.DomainCategory.ADMIN_METADATA) {
+                prependMeta();
+            }
 
-        Disambiguate.DomainCategory domainCategory = disambiguate.getDomainCategory(domain);
-        if (domainCategory == Disambiguate.DomainCategory.ADMIN_METADATA) {
-            prependMeta();
-        }
-
-        switch (outsetType) {
-            case WORK -> {
-                switch (domainCategory) {
-                    // The property p appears only on instance, modify path to @reverse.instanceOf.p...
-                    case INSTANCE, EMBODIMENT -> setWorkToInstancePath();
-                    case CREATION_SUPER, UNKNOWN -> {
+            switch (outsetType) {
+                case WORK -> {
+                    switch (domainCategory) {
+                        // The property p appears only on instance, modify path to @reverse.instanceOf.p...
+                        case INSTANCE, EMBODIMENT -> setWorkToInstancePath();
                         // The property p may appear on instance, add alternative path @reverse.instanceOf.p...
-                        Path copy = copy();
-                        copy.setWorkToInstancePath();
-                        altPaths.add(copy);
+                        case CREATION_SUPER, UNKNOWN -> setAltWorkToInstancePath();
                     }
                 }
-            }
-            case INSTANCE -> {
-                switch (domainCategory) {
-                    // The property p appears only work, modify path to instanceOf.p...
-                    case WORK -> setInstanceToWorkPath();
-                    case CREATION_SUPER, UNKNOWN -> {
+                case INSTANCE -> {
+                    switch (domainCategory) {
+                        // The property p appears only work, modify path to instanceOf.p...
+                        case WORK -> setInstanceToWorkPath();
                         // The property p may appear on work, add alternative path instanceOf.p...
-                        Path copy = copy();
-                        copy.setInstanceToWorkPath();
-                        altPaths.add(copy);
+                        case CREATION_SUPER, UNKNOWN -> setAltInstanceToWorkPath();
                     }
                 }
             }
-        }
 
-        return altPaths;
-    }
-
-    public void prependMeta() {
-        path.addFirst(JsonLd.RECORD_KEY);
-    }
-
-    public void appendId() {
-        if (!path.getLast().equals(JsonLd.ID_KEY)) {
-            path.add(JsonLd.ID_KEY);
+            addSuffixAndValue(disambiguate, value);
         }
     }
 
-    public void appendUnderscoreStr() {
-        if (!path.getLast().equals(JsonLd.SEARCH_KEY)) {
-            path.add(JsonLd.SEARCH_KEY);
+    public List<Path> getAltStems() {
+        return roots.isEmpty()
+                ? List.of(this)
+                : roots.stream()
+                .map(r -> new Path(concat(r, stem)))
+                .toList();
+    }
+
+    public Path attachBranch(Branch b) {
+        return new Path(concat(stem, b.path()));
+    }
+
+    private List<String> concat(List<String> a, List<String> b) {
+        return Stream.concat(a.stream(), b.stream()).toList();
+    }
+
+    public void addSuffixAndValue(Disambiguate disambiguate, SimpleQueryTree.Value value) {
+        if (branches.isEmpty()) {
+            getSuffix(stem.getLast(), disambiguate, value)
+                    .map(List::of)
+                    .map(b -> new Branch(b, value))
+                    .ifPresent(branches::add);
+        } else {
+            branches = branches.stream().map(b -> {
+                        var val = b.value() != null ? b.value() : value;
+                        return getSuffix(b.path.getLast(), disambiguate, val)
+                                .map(List::of)
+                                .map(s -> new Branch(concat(b.path(), s), val))
+                                .orElse(new Branch(b.path(), val));
+                    })
+                    .toList();
         }
     }
 
-    public void setWorkToInstancePath() {
-        path.addFirst(JsonLd.WORK_KEY);
-        path.addFirst(JsonLd.REVERSE_KEY);
-        if (defaultFields != null) {
-            defaultFields.forEach(df ->
-                    {
-                        df.path().addFirst(JsonLd.WORK_KEY);
-                        df.path().addFirst(JsonLd.REVERSE_KEY);
-                    }
-            );
+    Optional<String> getSuffix(String key, Disambiguate disambiguate, SimpleQueryTree.Value value) {
+        if (disambiguate.isObjectProperty(key) && !disambiguate.hasVocabValue(key)) {
+            return value instanceof SimpleQueryTree.Literal
+                    ? Optional.of(JsonLd.SEARCH_KEY)
+                    : Optional.of(JsonLd.ID_KEY);
         }
+        return Optional.empty();
     }
 
-    public void setInstanceToWorkPath() {
-        path.addFirst(JsonLd.WORK_KEY);
-        if (defaultFields != null) {
-            defaultFields.forEach(df -> df.path().addFirst(JsonLd.WORK_KEY));
-        }
+    private void prependMeta() {
+        extendRoots(JsonLd.RECORD_KEY);
+    }
+
+    private void setInstanceToWorkPath() {
+        extendRoots(JsonLd.WORK_KEY);
+    }
+
+    private void setAltInstanceToWorkPath() {
+        branchOutRoot(JsonLd.WORK_KEY);
+    }
+
+    private void setWorkToInstancePath() {
+        extendRoots(List.of(JsonLd.REVERSE_KEY, JsonLd.WORK_KEY));
+    }
+
+    private void setAltWorkToInstancePath() {
+        branchOutRoot(List.of(JsonLd.REVERSE_KEY, JsonLd.WORK_KEY));
     }
 
     public void expandChainAxiom(Disambiguate disambiguate) {
-        Disambiguate.PropertyChain pc = disambiguate.expandChainAxiom(path);
-        this.path = pc.path();
-        this.defaultFields = pc.defaultFields();
+        disambiguate.expandChainAxiom(this);
     }
 
     public String stringify() {
-        return path.stream().map(this::substitute).collect(Collectors.joining("."));
+        if (path == null) {
+            this.path = stem.stream().map(this::substitute).collect(Collectors.joining("."));
+        }
+        return path;
     }
 
     private String substitute(String property) {
         return Optional.ofNullable(substitutions.get(property)).orElse(property);
     }
 
-    @Override
-    public String toString() {
-        var s = new StringBuilder();
-        s.append(path);
-        if (!defaultFields.isEmpty()) {
-            s.append("(defaultFields: ").append(defaultFields).append(")");
+    private void extendRoots(String key) {
+        extendRoots(List.of(key));
+    }
+
+    private void extendRoots(List<String> path) {
+        if (roots.isEmpty()) {
+            roots.add(path);
+        } else {
+            roots.replaceAll(r -> concat(path, r));
         }
-        return s.toString();
+    }
+
+    private void branchOutRoot(String key) {
+        branchOutRoot(List.of(key));
+    }
+
+    private void branchOutRoot(List<String> path) {
+        roots = roots.isEmpty()
+                ? List.of(path, Collections.emptyList())
+                : roots.stream()
+                .flatMap(r -> Stream.of(r, concat(path, r)))
+                .toList();
     }
 }

--- a/whelk-core/src/test/groovy/whelk/xlql/DisambiguateSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/DisambiguateSpec.groovy
@@ -84,14 +84,16 @@ class DisambiguateSpec extends Specification {
     }
 
     def "expand complex propertyChainAxiom"() {
+        given:
+        def p = new Path(before)
+        disambiguate.expandChainAxiom(p)
+
         expect:
-        disambiguate.expandChainAxiom(path).with {
-            it.path() == extendedPath && it.defaultFields() == defaultFields
-        }
+        p.stem == stem && p.branches as Set == branches
 
         where:
-        path       | extendedPath              | defaultFields
-        ['isbn']   | ['identifiedBy', 'value'] | [new DefaultField(['identifiedBy', '@type'], "ISBN")]
-        ['author'] | ['contribution', 'agent'] | [new DefaultField(['contribution', 'role'], "https://id.kb.se/relator/author")]
+        before     | stem             | branches
+        ['isbn']   | ['identifiedBy'] | [new Path.Branch(['value']), new Path.Branch(['rdf:type'], new SimpleQueryTree.VocabTerm("ISBN"))] as Set
+        ['author'] | ['contribution'] | [new Path.Branch(['agent']), new Path.Branch(['role'], new SimpleQueryTree.Link("https://id.kb.se/relator/author"))] as Set
     }
 }


### PR DESCRIPTION
...to enable filtering on library (@reverse.instanceOf.@reverse.itemOf.heldBy).

I tried to simplify the code but I think it's still a bit messy. More comprehensive refactoring will be needed at some point but this should at least simplify the nested field building part.

There is still work to do for making all types of nested queries work (see TODOs in code).

We should index `contribution` and `@reverse.instanceOf.identifiedBy` as nested too for `isbn:x` and `author:x`to work properly.