### PR TITLE
Feature/xlql handle ambiguities

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -128,7 +128,7 @@ public class SearchUtils2 {
                         this.esQueryDsl = getEsQueryDsl();
                     } else {
                         qSqt.replaceTopLevelFreeText(i.get());
-                        throw new Crud.RedirectException(makeFindUrl(i.get(), qSqt.toQueryString()));
+                        throw new Crud.RedirectException(makeFindUrl(i.get(), xlqlQuery.sqtToQueryString(qSqt)));
                     }
                 } else {
                     throw new Crud.RedirectException(makeFindUrl(iSqt.getFreeTextPart(), i.get()));

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -651,13 +651,14 @@ public class XLQLQuery {
 
         Map<String, Object> template = new LinkedHashMap<>();
 
-        var placeholderNode = new SimpleQueryTree.FreeText(Operator.EQUALS, String.format("{?%s}", property));
+        var variable = disambiguate.getQueryCode(property).orElse(property);
+        var placeholderNode = new SimpleQueryTree.FreeText(Operator.EQUALS, String.format("{?%s}", variable));
         var templateQueryString = tree.andExtend(placeholderNode).toQueryString(disambiguate);
         var templateUrl = makeFindUrl(tree.getFreeTextPart(), templateQueryString, nonQueryParams);
         template.put("template", templateUrl);
 
         var mapping = new LinkedHashMap<>();
-        mapping.put("variable", property);
+        mapping.put("variable", variable);
         mapping.put(Operator.GREATER_THAN_OR_EQUALS.termKey, Objects.toString(min, ""));
         mapping.put(Operator.LESS_THAN_OR_EQUALS.termKey, Objects.toString(max, ""));
         template.put("mapping", mapping);

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -574,9 +574,10 @@ public class XLQLQuery {
 
         propToBuckets.forEach((property, buckets) -> {
             var sliceNode = new LinkedHashMap<>();
-            var observations = getObservations(buckets, sqt, nonQueryParams);
+            var isRange = rangeProps.contains(property);
+            var observations = getObservations(buckets, isRange ? sqt.removeTopLevelRangeNodes(property) : sqt, nonQueryParams);
             if (!observations.isEmpty()) {
-                if (rangeProps.contains(property)) {
+                if (isRange) {
                     sliceNode.put("search", getRangeTemplate(property, sqt, makeParams(nonQueryParams)));
                 }
                 sliceNode.put("dimension", property);

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -76,6 +76,10 @@ public class XLQLQuery {
         return new SimpleQueryTree(flattened, disambiguate);
     }
 
+    public String sqtToQueryString(SimpleQueryTree sqt) {
+        return sqt.toQueryString(disambiguate);
+    }
+
     public SimpleQueryTree addFilters(SimpleQueryTree sqt, List<SimpleQueryTree.PropertyValue> filters) {
         for (SimpleQueryTree.PropertyValue pv : filters) {
             if (sqt.getTopLevelPvNodes().stream().noneMatch(n -> n.property().equals(pv.property()))) {
@@ -271,8 +275,8 @@ public class XLQLQuery {
         return mappingsNode;
     }
 
-    private static String makeFindUrl(SimpleQueryTree sqt, List<String> nonQueryParams) {
-        return makeFindUrl(sqt.getFreeTextPart(), sqt.toQueryString(), nonQueryParams);
+    private String makeFindUrl(SimpleQueryTree sqt, List<String> nonQueryParams) {
+        return makeFindUrl(sqt.getFreeTextPart(), sqt.toQueryString(disambiguate), nonQueryParams);
     }
 
     private static String makeFindUrl(String i, String q, List<String> nonQueryParams) {
@@ -612,7 +616,7 @@ public class XLQLQuery {
         return observations;
     }
 
-    private static Map<String, Object> getRangeTemplate(String property, SimpleQueryTree sqt, List<String> nonQueryParams) {
+    private Map<String, Object> getRangeTemplate(String property, SimpleQueryTree sqt, List<String> nonQueryParams) {
         var GtLtNodes = sqt.getTopLevelPvNodes().stream()
                 .filter(pv -> pv.property().equals(property))
                 .filter(pv -> switch (pv.operator()) {
@@ -648,7 +652,7 @@ public class XLQLQuery {
         Map<String, Object> template = new LinkedHashMap<>();
 
         var placeholderNode = new SimpleQueryTree.FreeText(Operator.EQUALS, String.format("{?%s}", property));
-        var templateQueryString = tree.andExtend(placeholderNode).toQueryString();
+        var templateQueryString = tree.andExtend(placeholderNode).toQueryString(disambiguate);
         var templateUrl = makeFindUrl(tree.getFreeTextPart(), templateQueryString, nonQueryParams);
         template.put("template", templateUrl);
 

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -251,9 +251,7 @@ public class Disambiguate {
 
         for (var m : ambiguousPropertyAliases.entrySet()) {
             for (String prop : m.getValue()) {
-                Map<?, ?> propDef = jsonLd.vocabIndex.get(prop);
-                String queryCode = (String) propDef.get("librisQueryCode");
-                if (m.getKey().toUpperCase().equals(queryCode)) {
+                if (getQueryCode(prop).filter(m.getKey().toUpperCase()::equals).isPresent()) {
                     propertyAliasMappings.put(m.getKey(), prop);
                 }
             }
@@ -340,6 +338,11 @@ public class Disambiguate {
                 .forEach(superProp -> getDefinition(superProp, whelk).ifPresent(inheritable::add));
 
         return inheritable;
+    }
+
+    public Optional<String> getQueryCode(String property) {
+        return Optional.ofNullable((Map<?, ?>) jsonLd.vocabIndex.get(property))
+                .map(propDef -> (String) propDef.get("librisQueryCode"));
     }
 
     private Optional<String> getDomainIri(Map<?, ?> propertyDefinition) {

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -481,6 +481,7 @@ public class Disambiguate {
         nsToPrefix.put("https://id.kb.se/term/barn/", "barn:");
         nsToPrefix.put("https://id.kb.se/term/barngf/", "barngf:");
         nsToPrefix.put("https://libris.kb.se/library/", "sigel:");
+        nsToPrefix.put("https://id.kb.se/language/", "lang:");
         nsToPrefix.put(Document.getBASE_URI().toString(), "libris:");
 
         for (String ns : nsToPrefix.keySet()) {
@@ -508,6 +509,7 @@ public class Disambiguate {
         nsToPrefix.put("https://id.kb.se/term/barn/", "barn:");
         nsToPrefix.put("https://id.kb.se/term/barngf/", "barngf:");
         nsToPrefix.put("https://libris.kb.se/library/", "sigel:");
+        nsToPrefix.put("https://id.kb.se/language/", "lang:");
         nsToPrefix.put(Document.getBASE_URI().toString(), "libris:");
 
         for (String ns : nsToPrefix.keySet()) {

--- a/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/Disambiguate.java
@@ -248,6 +248,16 @@ public class Disambiguate {
                 addAllMappings(termDefinition, termKey, TermType.PROPERTY, whelk);
             }
         }
+
+        for (var m : ambiguousPropertyAliases.entrySet()) {
+            for (String prop : m.getValue()) {
+                Map<?, ?> propDef = jsonLd.vocabIndex.get(prop);
+                String queryCode = (String) propDef.get("librisQueryCode");
+                if (m.getKey().toUpperCase().equals(queryCode)) {
+                    propertyAliasMappings.put(m.getKey(), prop);
+                }
+            }
+        }
     }
 
     private void addAllMappings(Map<?, ?> termDefinition, String termKey, TermType termType, Whelk whelk) {

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -51,7 +51,7 @@ public class SimpleQueryTree {
                 value = Disambiguate.toPrefixed(value);
             }
 
-            if (propertyPath().size() == 1) {
+            if (path().size() == 1) {
                 path = disambiguate.getQueryCode(property()).orElse(path);
             }
 

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -302,6 +302,7 @@ public class SimpleQueryTree {
     public List<PropertyValue> getTopLevelPvNodes() {
         if (topPvNodes == null) {
             topPvNodes = switch (this.tree) {
+                case null -> Collections.emptyList();
                 case And and -> and.conjuncts()
                         .stream()
                         .filter(node -> node instanceof PropertyValue)

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -34,7 +34,7 @@ public class SimpleQueryTree {
             };
         }
 
-        public String toString() {
+        public String asString(Disambiguate disambiguate) {
             String sep = switch (operator()) {
                 case EQUALS, NOT_EQUALS -> ":";
                 case GREATER_THAN_OR_EQUALS -> ">=";
@@ -51,12 +51,16 @@ public class SimpleQueryTree {
                 value = Disambiguate.toPrefixed(value);
             }
 
+            if (propertyPath().size() == 1) {
+                path = disambiguate.getQueryCode(property()).orElse(path);
+            }
+
             return not + quoteIfPhraseOrContainsSpecialSymbol(path) + sep + quoteIfPhraseOrContainsSpecialSymbol(value);
         }
     }
 
     public record FreeText(Operator operator, String value) implements Node {
-        public String toString() {
+        public String asString() {
             String s = value();
             if (operator() == Operator.NOT_EQUALS) {
                 s = "NOT " + s;
@@ -337,33 +341,29 @@ public class SimpleQueryTree {
         return freeTextPart;
     }
 
-    public String toQueryString() {
-        return buildQueryString(tree, true);
+    public String toQueryString(Disambiguate disambiguate) {
+        return buildQueryString(tree, disambiguate, true);
     }
 
-    private String buildQueryString(Node node, boolean topLevel) {
+    private String buildQueryString(Node node, Disambiguate disambiguate, boolean topLevel) {
         return switch (node) {
             case And and -> {
                 String andClause = and.conjuncts()
                         .stream()
-                        .map(this::buildQueryString)
+                        .map(n -> buildQueryString(n, disambiguate, false))
                         .collect(Collectors.joining(" "));
                 yield topLevel ? andClause : "(" + andClause + ")";
             }
             case Or or -> {
                 String orClause = or.disjuncts()
                         .stream()
-                        .map(this::buildQueryString)
+                        .map(n -> buildQueryString(n, disambiguate, false))
                         .collect(Collectors.joining(" OR "));
                 yield topLevel ? orClause : "(" + orClause + ")";
             }
-            case FreeText ft -> ft.toString();
-            case PropertyValue pv -> pv.toString();
+            case FreeText ft -> ft.asString();
+            case PropertyValue pv -> pv.asString(disambiguate);
         };
-    }
-
-    private String buildQueryString(Node node) {
-        return buildQueryString(node, false);
     }
 
     public void replaceTopLevelFreeText(String replacement) {

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -238,16 +238,24 @@ public class SimpleQueryTree {
         }
     }
 
-    public SimpleQueryTree removeTopLevelPvNodes(String property) {
-        return new SimpleQueryTree(removeTopLevelPvNodes(property, tree));
+    public SimpleQueryTree removeTopLevelRangeNodes(String property) {
+        var rangeOps = Set.of(Operator.GREATER_THAN_OR_EQUALS, Operator.GREATER_THAN, Operator.LESS_THAN, Operator.LESS_THAN_OR_EQUALS);
+        return new SimpleQueryTree(removeTopLevelPvNodes(property, tree, rangeOps));
     }
 
-    private static Node removeTopLevelPvNodes(String property, Node tree) {
+    public SimpleQueryTree removeTopLevelPvNodes(String property) {
+        return new SimpleQueryTree(removeTopLevelPvNodes(property, tree, Collections.emptySet()));
+    }
+
+    private static Node removeTopLevelPvNodes(String property, Node tree, Set<Operator> operators) {
         return switch (tree) {
             case And and -> {
                 List<Node> conjuncts = and.conjuncts()
                         .stream()
-                        .filter(n -> !(n instanceof PropertyValue && ((PropertyValue) n).property().equals(property)))
+                        .filter(n -> !(n instanceof PropertyValue
+                                && ((PropertyValue) n).property().equals(property)
+                                && (operators.isEmpty() || operators.contains(((PropertyValue) n).operator())))
+                        )
                         .collect(Collectors.toList());
                 if (conjuncts.isEmpty()) {
                     yield null;


### PR DESCRIPTION
Use designated query codes to avoid the problem with ambiguous property alias mappings such as "språk" mapping to both `language`/`associatedLanguage` and  "år" mapping to `year` when we instead want `yearPublished`.

Also prefer query code over property name to get a more concise normalized query form, e.g.:
![image](https://github.com/libris/librisxl/assets/72360110/4ecfc45f-47fe-4444-a44f-4428fdb8268e)

See suggested codes: https://github.com/libris/definitions/pull/485

There are some issues with defaulting to the code instead of the property name in the normalized form:
- The codes are in Swedish so it will be weird when the user language is English.
  - We could create new corresponding codes in English (e.g. YEAR), however this option will require a new way of declaring them because as far as I understand language tagging an instance of a datatype such as LibrisQueryCode is not possible.
  - Another option is to not include any codes in the normalized form when the language is set to English and instead just default to the property name as before (e.g. yearPublished).
- When the language is set to Swedish on the other hand it will be weird having some codes in Swedish while those properties lacking associated code will be shown in English (the property name). We should probably instead default to the Swedish label when there is no code.

This PR also includes a small fix for the interaction between exact year filter and year range filter. Before this fix we could end up with useless queries such as "year>2000 and year<2010 and year=1990".