### PR TITLE
Feature/lws 66 bool filters

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -156,7 +156,7 @@ public class SearchUtils2 {
             view.put("itemOffset", offset);
             view.put("itemsPerPage", limit);
             view.put("totalItems", numHits);
-            view.put("search", Map.of("mapping", toMappings(aliases)));
+            view.put("search", Map.of("mapping", toMappings(aliases, statsRepr.availableBoolFilters)));
             view.putAll(makePaginationLinks(numHits));
             if (esResponse.containsKey("items")) {
                 @SuppressWarnings("unchecked")
@@ -257,8 +257,8 @@ public class SearchUtils2 {
             return params;
         }
 
-        private List<Map<?, ?>> toMappings(Map<String, String> aliases) {
-            return List.of(xlqlQuery.toMappings(simpleQueryTree, aliases, makeNonQueryParams(0)));
+        private List<Map<?, ?>> toMappings(Map<String, String> aliases, List<Map<String, Object>> filters) {
+            return List.of(xlqlQuery.toMappings(simpleQueryTree, aliases, filters, makeNonQueryParams(0)));
         }
 
         private static Optional<String> getOptionalSingleNonEmpty(String name, Map<String, String[]> queryParameters) {

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -215,9 +215,9 @@ public class SearchUtils2 {
         }
 
         private SimpleQueryTree getFilteredTree() {
-            var filters = new ArrayList<SimpleQueryTree.PropertyValue>();
+            var filters = new ArrayList<>(statsRepr.siteDefaultFilters);
             if (object == null) {
-                filters.addAll(statsRepr.siteDefaultFilters);
+                filters.addAll(statsRepr.siteDefaultTypeFilters);
             }
             if (object != null) {
                 if (predicates.isEmpty()) {

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -8,7 +8,6 @@ import whelk.exception.WhelkRuntimeException;
 import whelk.search.XLQLQuery;
 import whelk.util.DocumentUtil;
 import whelk.xlql.Disambiguate;
-import whelk.xlql.FilterStatus;
 import whelk.xlql.QueryTree;
 import whelk.xlql.SimpleQueryTree;
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -29,11 +29,6 @@ public class SearchUtils2 {
     final static int DEFAULT_OFFSET = 0;
     private static final List<SimpleQueryTree.PropertyValue> DEFAULT_FILTERS = List.of(SimpleQueryTree.pvEqualsVocabTerm(RDF_TYPE, "Work"));
 
-    private static final List<Map<String, String>> BOOL_FILTERS = List.of(
-            Map.of("alias", "excludeEplikt", "filter", "NOT bibliography:\"sigel:EPLK\"", "status", "active"),
-            Map.of("alias", "excludePreliminary", "filter", "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "status", "active"),
-            Map.of("alias", "existsCoverImage", "filter", "image:*", "status", "inactive")
-    );
     Whelk whelk;
     XLQLQuery xlqlQuery;
 
@@ -157,7 +152,7 @@ public class SearchUtils2 {
             return queryDsl;
         }
 
-        public Map<String, Object> getPartialCollectionView(Map<String, Object> esResponse) {
+        public Map<String, Object> getPartialCollectionView(Map<String, Object> esResponse) throws InvalidQueryException {
             int numHits = (int) esResponse.getOrDefault("totalHits", 0);
             var aliases = XLQLQuery.getAliasMappings(outsetType);
             var view = new LinkedHashMap<String, Object>();
@@ -182,7 +177,7 @@ public class SearchUtils2 {
             return view;
         }
 
-        private SimpleQueryTree getFilteredTree() throws InvalidQueryException {
+        private SimpleQueryTree getFilteredTree() {
             var filters = new ArrayList<>(DEFAULT_FILTERS);
             if (object != null) {
                 if (predicates.isEmpty()) {
@@ -342,15 +337,7 @@ public class SearchUtils2 {
         }
 
         private Map<String, Map<String, Object>> getDefaultBoolFilters() throws InvalidQueryException {
-            // TODO: get from apps.jsonld
-            Map<String, Map<String, Object>> m = new HashMap<>();
-            for (var bf : BOOL_FILTERS) {
-                String alias = bf.get("alias");
-                SimpleQueryTree.Node filter = xlqlQuery.getSimpleQueryTree(bf.get("filter")).tree;
-                FilterStatus status = FilterStatus.valueOf(bf.get("status").toUpperCase());
-                m.put(alias, Map.of("filter", filter, "status", status));
-            }
-            return m;
+            return xlqlQuery.getDefaultBoolFilters(statsRepr);
         }
 
         @SuppressWarnings({"rawtypes", "unchecked"})

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static whelk.component.ElasticSearch.flattenedLangMapKey;
 import static whelk.util.DocumentUtil.NOP;

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -958,6 +958,7 @@ public class XLQLQuery {
     public class StatsRepr {
         public final Map<String, Object> statsRepr;
         public final List<SimpleQueryTree.Node> siteDefaultFilters;
+        public final List<SimpleQueryTree.Node> siteDefaultTypeFilters;
 
         public final Map<String, SimpleQueryTree.Node> aliasedFilters;
 
@@ -967,6 +968,7 @@ public class XLQLQuery {
             this.statsRepr = statsRepr;
             this.aliasedFilters = getAliasedFilters();
             this.siteDefaultFilters = getSiteDefaultFilters();
+            this.siteDefaultTypeFilters = getDefaultTypeFilters();
             this.availableBoolFilters = getAvailableBoolFilters();
         }
 
@@ -974,7 +976,18 @@ public class XLQLQuery {
             // TODO: get from apps.jsonld
             var defaultFilters = new ArrayList<SimpleQueryTree.Node>();
 
-            for (String s : List.of("\"rdf:type\":Work", "excludeEplikt", "excludePreliminary", "NOT inCollection:\"https://id.kb.se/term/uniformWorkTitle\"")) {
+            for (String s : List.of("excludeEplikt", "excludePreliminary", "NOT inCollection:\"https://id.kb.se/term/uniformWorkTitle\"")) {
+                defaultFilters.add(getSimpleQueryTree(s, aliasedFilters).tree);
+            }
+
+            return defaultFilters;
+        }
+
+        public List<SimpleQueryTree.Node> getDefaultTypeFilters() throws InvalidQueryException {
+            // TODO: get from apps.jsonld
+            var defaultFilters = new ArrayList<SimpleQueryTree.Node>();
+
+            for (String s : List.of("\"rdf:type\":Work")) {
                 defaultFilters.add(getSimpleQueryTree(s, aliasedFilters).tree);
             }
 

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -86,6 +86,7 @@ public class XLQLQuery {
 
     public SimpleQueryTree setBoolFilters(SimpleQueryTree sqt, Map<String, Map<String, Object>> defaultBoolFilters) {
         var explicitFilters = sqt.getBoolFilterAliases();
+
         for (var entry : defaultBoolFilters.entrySet()) {
             String alias = entry.getKey();
             FilterStatus status = (FilterStatus) entry.getValue().get("status");
@@ -93,6 +94,7 @@ public class XLQLQuery {
                 sqt = sqt.andExtend(new SimpleQueryTree.BoolFilter(alias, status, (SimpleQueryTree.Node) entry.getValue().get("filter")));
             }
         }
+
         return sqt.expandActiveBoolFilters();
     }
 
@@ -626,7 +628,7 @@ public class XLQLQuery {
                 SimpleQueryTree newTree;
                 boolean isSelected;
 
-                if (bfNode == null || defaultStatus.equals(bfNode.status())) {
+                if (bfNode == null) {
                     var newStatus = switch (defaultStatus) {
                         case INACTIVE -> FilterStatus.ACTIVE;
                         case ACTIVE -> FilterStatus.INACTIVE;

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -379,7 +379,7 @@ public class XLQLQuery {
 
         filters.stream().filter(f -> f.get("filter") instanceof SimpleQueryTree.BoolFilter)
                 .filter(f -> bf.alias().equals(((SimpleQueryTree.BoolFilter) f.get("filter")).alias()))
-                .map(f -> Map.of("prefLabelByLang", f.get("prefLabelByLang")))
+                .map(f -> Map.of("prefLabelByLang", f.get("prefLabelByLang"), JsonLd.TYPE_KEY, "Resource"))
                 .findFirst()
                 .ifPresentOrElse(o -> m.put("object", o), () -> m.put("value", bf.alias()));
 
@@ -554,7 +554,6 @@ public class XLQLQuery {
     public Map<String, Object> getStats(Map<String, Object> esResponse, StatsRepr statsRepr, SimpleQueryTree sqt, Map<String, String> nonQueryParams, Map<String, String> aliases) {
         var sliceByDimension = getSliceByDimension(esResponse, statsRepr.statsRepr, sqt, nonQueryParams, aliases);
         var boolFilters = getBoolFilters(sqt, statsRepr.availableBoolFilters, nonQueryParams);
-        sliceByDimension.put("boolFilters", Map.of("dimension", "boolFilters", "observation", boolFilters));
         return Map.of(JsonLd.ID_KEY, "#stats",
                 "sliceByDimension", sliceByDimension,
                 "_boolFilters", boolFilters);
@@ -937,7 +936,7 @@ public class XLQLQuery {
                     Map.of("filter", getSimpleQueryTree("includePreliminary", aliasedFilters).tree,
                             "prefLabelByLang", Map.of("sv", "Inkludera kommande publiceringar", "en", "Include upcoming publications")),
                     Map.of("filter", getSimpleQueryTree("image:*", aliasedFilters).tree,
-                            "prefLabelByLang", Map.of("sv", "Endast resurser med omslags-/miniatyrbild", "en", "Resources with Cover/thumbnail only"))
+                            "prefLabelByLang", Map.of("sv", "Resurser med omslags-/miniatyrbild", "en", "Only resources with cover/thumbnail"))
 //                Map.of("filter", "_TODO", "selectHeader", Map.of("sv", "Endast material som finns online", "en", "Only material available online")),
 //                Map.of("filter", "_TODO", "selectHeader", Map.of("sv", "Endast digitalt material", "en", "Digital material only"))
             );

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -664,9 +664,11 @@ public class XLQLQuery {
     public Map<String, Map<String, Object>> getDefaultBoolFilters(Map<String, Object> statsRepr) throws InvalidQueryException {
         // TODO: get from apps.jsonld
         List<Map<String, String>> boolFilters = List.of(
-                Map.of("alias", "excludeEplikt", "filter", "NOT bibliography:\"sigel:EPLK\"", "status", "active", "selectHeader", "Visa e-pliktsmaterial"),
-                Map.of("alias", "excludePreliminary", "filter", "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "status", "active", "selectHeader", "Visa kommande"),
-                Map.of("alias", "hasImage", "filter", "image:*", "status", "inactive", "selectHeader", "Dölj resurser utan bild")
+                Map.of("alias", "excludeEplikt", "filter", "NOT bibliography:\"sigel:EPLK\"", "status", "active", "selectHeader", "Inkludera e-plikt"),
+                Map.of("alias", "excludePreliminary", "filter", "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "status", "active", "selectHeader", "Inkludera kommande publiceringar"),
+//                Map.of("alias", "availableOnline", "filter", "_TODO", "status", "inactive", "selectHeader", "Endast material som finns online"),
+//                Map.of("alias", "isDigital", "filter", "_TODO", "status", "inactive", "selectHeader", "Endast digitalt material"),
+                Map.of("alias", "hasImage", "filter", "image:*", "status", "inactive", "selectHeader", "Endast resurser med bild")
         );
 
         Map<String, Map<String, Object>> m = new LinkedHashMap<>();

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -291,9 +291,7 @@ public class XLQLQuery {
     }
 
     private String makeFindUrl(SimpleQueryTree sqt, List<String> nonQueryParams) {
-        return sqt.isEmpty()
-                ? makeFindUrl("", "*", nonQueryParams)
-                : makeFindUrl(sqt.getFreeTextPart(), sqt.toQueryString(disambiguate), nonQueryParams);
+        return makeFindUrl(sqt.getFreeTextPart(), sqt.toQueryString(disambiguate), nonQueryParams);
     }
 
     private static String makeFindUrl(String i, String q, List<String> nonQueryParams) {

--- a/whelk-core/src/main/groovy/whelk/xlql/FilterStatus.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/FilterStatus.java
@@ -1,6 +1,0 @@
-package whelk.xlql;
-
-public enum FilterStatus {
-    ACTIVE,
-    INACTIVE
-}

--- a/whelk-core/src/main/groovy/whelk/xlql/FilterStatus.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/FilterStatus.java
@@ -1,0 +1,6 @@
+package whelk.xlql;
+
+public enum FilterStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/FlattenedAst.java
@@ -34,37 +34,7 @@ public class FlattenedAst {
 
     static Node flatten(Ast ast) {
         Ast.Node flattenedCodes = flattenCodes(ast.tree);
-        Node flattenedNegations = flattenNegations(flattenedCodes);
-        return mergeLeaves(flattenedNegations);
-    }
-
-    static Node mergeLeaves(Node astNode) {
-        return switch (astNode) {
-            case And and -> {
-                List<Node> newOperands = new ArrayList<>();
-                List<String> leafValues = new ArrayList<>();
-                for (Node node : and.operands()) {
-                    switch (node) {
-                        case Leaf l -> leafValues.add(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(l.value()));
-                        default -> newOperands.add(mergeLeaves(node));
-                    }
-                }
-                if (!leafValues.isEmpty()) {
-                    newOperands.addFirst(new Leaf(String.join(" ", leafValues)));
-                }
-                yield newOperands.size() > 1 ? new And(newOperands) : newOperands.getFirst();
-            }
-            case Or or -> {
-                List<Node> newOperands = or.operands()
-                        .stream()
-                        .map(FlattenedAst::mergeLeaves)
-                        .toList();
-                yield new Or(newOperands);
-            }
-            case Not not -> new Not(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(not.value()));
-            case Code code -> code;
-            case Leaf leaf -> new Leaf(XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol(leaf.value()));
-        };
+        return flattenNegations(flattenedCodes);
     }
 
     static Node flattenNegations(Ast.Node ast) {

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -14,7 +14,6 @@ import static whelk.xlql.Operator.EQUALS;
 
 import static whelk.xlql.Disambiguate.RDF_TYPE;
 
-
 public class QueryTree {
     public sealed interface Node permits And, Or, Nested, Field, FreeText {
         default List<Node> children() {
@@ -107,6 +106,7 @@ public class QueryTree {
             }
             case SimpleQueryTree.FreeText ft -> new FreeText(ft.operator(), ft.value());
             case SimpleQueryTree.PropertyValue pv -> buildField(pv, disambiguate, outset);
+            case SimpleQueryTree.BoolFilter ignored -> throw new RuntimeException("Failed to create QueryTree. Tree must not contain unexpanded bool filters."); // Should never be reached.
         };
     }
 

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -13,7 +13,7 @@ import static whelk.search.XLQLQuery.quoteIfPhraseOrContainsSpecialSymbol;
 import static whelk.xlql.Disambiguate.RDF_TYPE;
 
 public class SimpleQueryTree {
-    public sealed interface Node permits And, Or, PropertyValue, FreeText {
+    public sealed interface Node permits And, BoolFilter, FreeText, Or, PropertyValue {
     }
 
     public record And(List<Node> conjuncts) implements Node {
@@ -69,6 +69,16 @@ public class SimpleQueryTree {
         }
     }
 
+    public record BoolFilter(String alias, FilterStatus status, Node filter) implements Node {
+        public String asString() {
+            String s = alias();
+            if (status() == FilterStatus.INACTIVE) {
+                s = "NOT " + s;
+            }
+            return s;
+        }
+    }
+
     public sealed interface Value permits Link, Literal, VocabTerm {
         String string();
 
@@ -112,34 +122,43 @@ public class SimpleQueryTree {
     private String freeTextPart;
 
     public SimpleQueryTree(FlattenedAst ast, Disambiguate disambiguate) throws InvalidQueryException {
-        this.tree = buildTree(ast.tree, disambiguate);
+        this(ast, disambiguate, Collections.emptyMap());
+    }
+
+    public SimpleQueryTree(FlattenedAst ast, Disambiguate disambiguate, Map<String, Map<String, Object>> defaultBoolFilters) throws InvalidQueryException {
+        this.tree = buildTree(ast.tree, disambiguate, defaultBoolFilters);
+        normalizeFreeText();
     }
 
     public SimpleQueryTree(Node tree) {
         this.tree = tree;
     }
 
-    private static Node buildTree(FlattenedAst.Node ast, Disambiguate disambiguate) throws InvalidQueryException {
+    private static Node buildTree(FlattenedAst.Node ast, Disambiguate disambiguate, Map<String, Map<String, Object>> defaultBoolFilters) throws InvalidQueryException {
         switch (ast) {
             case FlattenedAst.And and -> {
                 List<Node> conjuncts = new ArrayList<>();
                 for (FlattenedAst.Node o : and.operands()) {
-                    conjuncts.add(buildTree(o, disambiguate));
+                    conjuncts.add(buildTree(o, disambiguate, defaultBoolFilters));
                 }
                 return new And(conjuncts);
             }
             case FlattenedAst.Or or -> {
                 List<Node> disjuncts = new ArrayList<>();
                 for (FlattenedAst.Node o : or.operands()) {
-                    disjuncts.add(buildTree(o, disambiguate));
+                    disjuncts.add(buildTree(o, disambiguate, defaultBoolFilters));
                 }
                 return new Or(disjuncts);
             }
             case FlattenedAst.Not not -> {
-                return new FreeText(Operator.NOT_EQUALS, not.value());
+                return defaultBoolFilters.containsKey(not.value())
+                        ? new BoolFilter(not.value(), FilterStatus.INACTIVE, (Node) defaultBoolFilters.get(not.value()).get("filter"))
+                        : new FreeText(Operator.NOT_EQUALS, not.value());
             }
             case FlattenedAst.Leaf l -> {
-                return new FreeText(Operator.EQUALS, l.value());
+                return defaultBoolFilters.containsKey(l.value())
+                        ? new BoolFilter(l.value(), FilterStatus.ACTIVE, (Node) defaultBoolFilters.get(l.value()).get("filter"))
+                        : new FreeText(Operator.EQUALS, l.value());
             }
             case FlattenedAst.Code c -> {
                 String property = null;
@@ -188,6 +207,65 @@ public class SimpleQueryTree {
         }
     }
 
+    private void normalizeFreeText() {
+        this.tree = normalizeFreeText(tree);
+    }
+
+    private static Node normalizeFreeText(Node node) {
+        return switch (node) {
+            case And and -> {
+                List<Node> conjuncts = new ArrayList<>();
+                List<String> ftStrings = new ArrayList<>();
+                for (Node n : and.conjuncts()) {
+                    if (isFreeText(n)) {
+                        ftStrings.add(quoteIfPhraseOrContainsSpecialSymbol(((FreeText) n).value()));
+                    } else {
+                        conjuncts.add(normalizeFreeText(n));
+                    }
+                }
+                if (!ftStrings.isEmpty()) {
+                    conjuncts.addFirst(new FreeText(Operator.EQUALS, String.join(" ", ftStrings)));
+                }
+                yield conjuncts.size() > 1 ? new And(conjuncts) : conjuncts.getFirst();
+            }
+            case Or or -> {
+                List<Node> disjuncts = or.disjuncts()
+                        .stream()
+                        .map(SimpleQueryTree::normalizeFreeText)
+                        .toList();
+                yield new Or(disjuncts);
+            }
+            case FreeText ft -> new FreeText(ft.operator(), quoteIfPhraseOrContainsSpecialSymbol(ft.value()));
+            default -> node;
+        };
+    }
+
+    public SimpleQueryTree expandActiveBoolFilters() {
+        return new SimpleQueryTree(expandActiveBoolFilters(tree));
+    }
+
+    private static Node expandActiveBoolFilters(Node node) {
+        return switch (node) {
+            case And and -> {
+                var conjuncts = and.conjuncts()
+                        .stream()
+                        .map(SimpleQueryTree::expandActiveBoolFilters)
+                        .filter(Objects::nonNull)
+                        .toList();
+                yield switch (conjuncts.size()) {
+                    case 0 -> null;
+                    case 1 -> conjuncts.getFirst();
+                    default -> new And(conjuncts);
+                };
+            }
+            case BoolFilter bf -> switch (bf.status()) {
+                case INACTIVE -> null;
+                case ACTIVE -> bf.filter();
+            };
+            default -> node;
+        };
+    }
+
     public SimpleQueryTree andExtend(Node node) {
         var conjuncts = switch (tree) {
             case null -> List.of(node);
@@ -212,14 +290,14 @@ public class SimpleQueryTree {
         if (nodeToExclude.equals(tree)) {
             return null;
         }
-        switch (tree) {
+        return switch (tree) {
             case And and -> {
                 List<Node> andClause = and.conjuncts()
                         .stream()
                         .map(c -> excludeFromTree(nodeToExclude, c))
                         .filter(Objects::nonNull)
                         .toList();
-                return andClause.size() > 1 ? new And(andClause) : andClause.getFirst();
+                yield andClause.size() > 1 ? new And(andClause) : andClause.getFirst();
             }
             case Or or -> {
                 List<Node> orClause = or.disjuncts()
@@ -227,15 +305,10 @@ public class SimpleQueryTree {
                         .map(d -> excludeFromTree(nodeToExclude, d))
                         .filter(Objects::nonNull)
                         .toList();
-                return orClause.size() > 1 ? new Or(orClause) : orClause.getFirst();
+                yield orClause.size() > 1 ? new Or(orClause) : orClause.getFirst();
             }
-            case FreeText ignored -> {
-                return tree;
-            }
-            case PropertyValue ignored -> {
-                return tree;
-            }
-        }
+            default -> tree;
+        };
     }
 
     public SimpleQueryTree removeTopLevelRangeNodes(String property) {
@@ -283,7 +356,7 @@ public class SimpleQueryTree {
                     types.add(pv.value().string());
                 }
             }
-            case FreeText ignored -> {
+            default -> {
                 // Nothing to do here
             }
         }
@@ -296,13 +369,28 @@ public class SimpleQueryTree {
     }
 
     public boolean isFreeText() {
-        return tree instanceof FreeText && ((FreeText) tree).operator().equals(Operator.EQUALS);
+        return isFreeText(tree);
+    }
+
+    private static boolean isFreeText(Node node) {
+        return node instanceof FreeText && ((FreeText) node).operator().equals(Operator.EQUALS);
+    }
+
+    public Set<String> getBoolFilterAliases() {
+        return switch (tree) {
+            case And and -> and.conjuncts()
+                    .stream()
+                    .map(node -> node instanceof BoolFilter ? ((BoolFilter) node).alias() : null)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+            case BoolFilter bf -> Set.of(bf.alias());
+            default -> Collections.emptySet();
+        };
     }
 
     public List<PropertyValue> getTopLevelPvNodes() {
         if (topPvNodes == null) {
-            topPvNodes = switch (this.tree) {
-                case null -> Collections.emptyList();
+            topPvNodes = switch (tree) {
                 case And and -> and.conjuncts()
                         .stream()
                         .filter(node -> node instanceof PropertyValue)
@@ -310,7 +398,7 @@ public class SimpleQueryTree {
                         .toList();
                 case Or ignored -> Collections.emptyList(); //TODO
                 case PropertyValue pv -> List.of(pv);
-                case FreeText ignored -> Collections.emptyList();
+                case null, default -> Collections.emptyList();
             };
         }
 
@@ -372,6 +460,7 @@ public class SimpleQueryTree {
             }
             case FreeText ft -> ft.asString();
             case PropertyValue pv -> pv.asString(disambiguate);
+            case BoolFilter bf -> bf.asString();
         };
     }
 

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -493,20 +493,4 @@ public class SimpleQueryTree {
             case BoolFilter bf -> bf.asString();
         };
     }
-
-    public void replaceTopLevelFreeText(String replacement) {
-        if (isFreeText()) {
-            this.tree = new FreeText(Operator.EQUALS, replacement);
-        } else if (tree instanceof And) {
-            List<Node> newConjuncts = ((And) tree).conjuncts().stream()
-                    .filter(Predicate.not(c -> c instanceof FreeText && ((FreeText) c).operator().equals(Operator.EQUALS)))
-                    .collect(Collectors.toList());
-            if (!replacement.isEmpty()) {
-                newConjuncts.addFirst(new FreeText(Operator.EQUALS, replacement));
-            }
-            this.tree = newConjuncts.size() == 1 ? newConjuncts.getFirst() : new And(newConjuncts);
-        } else {
-            this.tree = new And(List.of(new FreeText(Operator.EQUALS, replacement), tree));
-        }
-    }
 }

--- a/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/SimpleQueryTree.java
@@ -377,15 +377,24 @@ public class SimpleQueryTree {
     }
 
     public Set<String> getBoolFilterAliases() {
-        return switch (tree) {
-            case And and -> and.conjuncts()
-                    .stream()
-                    .map(node -> node instanceof BoolFilter ? ((BoolFilter) node).alias() : null)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-            case BoolFilter bf -> Set.of(bf.alias());
-            default -> Collections.emptySet();
-        };
+        return getBoolFiltersByAlias().keySet();
+    }
+
+    public Map<String, BoolFilter> getBoolFiltersByAlias() {
+        Map<String, BoolFilter> bfByAlias = new HashMap<>();
+
+        switch (tree) {
+            case And and -> and.conjuncts().forEach(node -> {
+                if (node instanceof BoolFilter n) {
+                    bfByAlias.put(n.alias(), n);
+                }
+            });
+            case BoolFilter bf -> bfByAlias.put(bf.alias(), bf);
+            default -> {
+            }
+        }
+
+        return bfByAlias;
     }
 
     public List<PropertyValue> getTopLevelPvNodes() {

--- a/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/FlattenedAstSpec.groovy
@@ -141,22 +141,4 @@ class FlattenedAstSpec extends Specification {
                 ] as List<FlattenedAst.Node>
         )
     }
-
-    def "merge leaves"() {
-        given:
-        def input = "x y z \"a b c\" d p:v \"e:f\" not g h i"
-        def lexedSymbols = Lex.lexQuery(input)
-        Parse.OrComb parseTree = Parse.parseQuery(lexedSymbols)
-        Ast ast = new Ast(parseTree)
-        FlattenedAst flattenedAst = new FlattenedAst(ast)
-
-        expect:
-        flattenedAst.tree == new FlattenedAst.And(
-                [
-                        new FlattenedAst.Leaf("x y z \"a b c\" d \"e:f\" h i"),
-                        new FlattenedAst.Code("p", Operator.EQUALS, "v"),
-                        new FlattenedAst.Not("g")
-                ] as List<FlattenedAst.Node>
-        )
-    }
 }

--- a/whelk-core/src/test/groovy/whelk/xlql/SimpleQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/xlql/SimpleQueryTreeSpec.groovy
@@ -56,7 +56,7 @@ class SimpleQueryTreeSpec extends Specification {
         expect:
         sqt.tree == new SimpleQueryTree.Or(
                 [
-                        new SimpleQueryTree.PropertyValue("originDate", ["originDate"] , Operator.LESS_THAN, "2023"),
+                        new SimpleQueryTree.PropertyValue("originDate", ["originDate"], Operator.LESS_THAN, "2023"),
                         new SimpleQueryTree.FreeText(Operator.EQUALS, "\"svarta hål\"")
                 ] as List<SimpleQueryTree.Node>
         )
@@ -142,5 +142,21 @@ class SimpleQueryTreeSpec extends Specification {
 
         expect:
         givenTypes == ["Electronic", "Print"] as Set
+    }
+
+    def "normalize free text"() {
+        given:
+        def input = "x y z \"a b c\" d label:l \"e:f\" not g h i"
+        def sqt = getTree(input)
+
+        expect:
+        sqt.tree == new SimpleQueryTree.And(
+                [
+                        new SimpleQueryTree.FreeText(Operator.EQUALS, "x y z \"a b c\" d \"e:f\" h i"),
+                        SimpleQueryTree.pvEqualsLiteral("label", "l"),
+                        new SimpleQueryTree.FreeText(Operator.NOT_EQUALS, "g"),
+
+                ] as List<SimpleQueryTree.Node>
+        )
     }
 }


### PR DESCRIPTION
- Support aliased predefined filters that get special meaning in the query language, i.e. won't be interpreted as free text.
- Each filter is either active or inactive by default.
- The syntax for deactivating a filter in the query language is `NOT filterAlias` (e.g. `NOT excludeEplikt`) and for activating it's simply `filterAlias`.
- If a user tries to deactivate a filter that is _inactive_ by default by typing `NOT filterAlias` nothing will happen (that part will simply be excluded from the query string). Same thing if typing `alias` when the filter is _active_ by default.
- `selectHeader` describes what happens when switching from the _default mode_ (`_selected: false`) to the _non-default mode_ (`_selected: true`) (not necessarily from inactive to active).

Some "side effects":
- Selected filters are detected during disambiguation so free text node merging had to be moved to _after_ the disambiguation step.
- The redirection flow in `SearchUtils2.Query` has been simplified (see [9a83a6c](https://github.com/libris/librisxl/pull/1437/commits/9a83a6cb0b756cf63fc6009b6b848fa77c23ceef)). Before it was unnecessarily complex and based on a previous idea how the frontend would work. Now it's adjusted to how the frontend actually works. We can adjust as needed later should the frontend flow change.
- As a consequence of the above point, https://github.com/libris/librisxl/pull/1436 is no longer relevant. A simpler solution to the unwanted asterisk in the input field is included in this PR instead, see [6d6ae1e](https://github.com/libris/librisxl/pull/1437/commits/6d6ae1ed7759bdb93065c7800dc2b34348f9ac9e).

TODO:
- Decide how to represent these filters in https://github.com/libris/definitions/blob/develop/source/apps.jsonld. The filter declarations are now hardcoded and incomplete, see https://github.com/libris/librisxl/blob/53fa0aab279a77caaa6f01083e33d8cfa824c69f/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java#L664.
- Decide how selected filters should be reflected in `search.mapping`, i.e. modify this placeholder method https://github.com/libris/librisxl/blob/53fa0aab279a77caaa6f01083e33d8cfa824c69f/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java#L344
- Frontend