### PR TITLE
Add facets for _p when doing _o search

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -168,6 +168,7 @@ public class SearchUtils2 {
             return queryDsl;
         }
 
+        // TODO naming things "curated predicate links" ??
         private List<Map<?, ?>> getCuratedPredicateLinks() {
             var o = getObject();
             if (o == null) {
@@ -215,10 +216,9 @@ public class SearchUtils2 {
                 view.put("items", esItems.stream().map(this::shapeResultItem).toList());
             }
             var stats = new HashMap<>(xlqlQuery.getStats(esResponse, statsRepr, simpleQueryTree, getNonQueryParams(0), aliases));
+            // TODO naming things
             stats.put("_predicates", predicateLinks);
             view.put("stats", stats);
-
-            // TODO naming things
 
             if (debug.contains(Debug.ES_QUERY)) {
                 view.put(P.DEBUG, Map.of(Debug.ES_QUERY, esQueryDsl));

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -174,7 +174,7 @@ public class SearchUtils2 {
                 return Collections.emptyList();
             }
             var esResponse = (Map<String, Object>) whelk.elastic.query(getCuratedPredicateEsQueryDsl(o));
-            return xlqlQuery.predicateLinks(esResponse, getNonQueryParams(0));
+            return xlqlQuery.predicateLinks(esResponse, o, getNonQueryParams(0));
         }
 
         public Map<String, Object> getCuratedPredicateEsQueryDsl(XLQLQuery.Entity o) {

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -434,7 +434,7 @@ public class XLQLQuery {
                 .stream()
                 .collect(Collectors.toMap(
                         Function.identity(),
-                        r -> getEsQuery(new QueryTree(new SimpleQueryTree(pvEqualsLink(r, object.id)), disambiguate, outsetType, esMappings.nestedFields))));
+                        p -> getEsQuery(new QueryTree(new SimpleQueryTree(pvEqualsLink(p, object.id)), disambiguate, outsetType, esMappings.nestedFields))));
 
         if (!filters.isEmpty()) {
             query.put("_p", Map.of("filters", Map.of("filters", filters)));

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -447,9 +447,9 @@ public class XLQLQuery {
         // TODO don't hardcode
         Map<String, List<String>> typeToRelations =
                 Map.of(
-                        "Agent", List.of("subject", "contributor", "publisher"),
+                        "Agent", List.of("contributor", "subject", "publisher"),
                         "Concept", List.of("subject", "genreForm", "hasOccupation", "fieldOfActivity"),
-                        "Work", List.of("subject", "contributor")
+                        "Work", List.of("subject")
                 );
 
         var types = new ArrayList<String>();

--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -707,6 +707,7 @@ public class XLQLQuery {
     public List<Map<?, ?>> predicateLinks (Map<String, Object> esResponse, Entity object, Map<String, String> nonQueryParams) {
         var result = new ArrayList<Map<?, ?>>();
         // FIXME Use constant for _p
+        // whelk-core should not deal with query parameters at all? Should be handled in rest module?
         Set<String> selected = new HashSet<>();
         if (nonQueryParams.containsKey("_p")) {
             selected.add(nonQueryParams.get("_p"));

--- a/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/xlql/QueryTree.java
@@ -51,6 +51,11 @@ public class QueryTree {
 
     public Node tree;
 
+    public QueryTree(Node tree, Set<String> esNestedFields) {
+        this.tree = tree;
+        this.esNestedFields = esNestedFields;
+    }
+
     public QueryTree(SimpleQueryTree sqt, Disambiguate disambiguate, Disambiguate.OutsetType outsetType, Set<String> esNestedFields) {
         this.esNestedFields = esNestedFields;
         this.tree = sqtToQt(sqt.tree, disambiguate, outsetType);


### PR DESCRIPTION
Add facets for predicates (_p) when doing object (_o) search. (RDF subject-predicate-object)
All `_p` values for `_o` are included even when a `_p` is selected. 
So that they can be displayed in a tabbed view in the interface.

For now 
* does an extra database access to lookup the type of the object
* does an extra roundtrip to elastic since the aggregates cannot be generated in the same query (could use multi search API)

TODO
* get the object type -> predicates mapping from configuration