### PR TITLE
ES: store number of incoming links per type, not just total

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -347,8 +347,12 @@ class Whelk {
         Set<Link> addedLinks = (postUpdateLinks - preUpdateLinks)
         Set<Link> removedLinks = (preUpdateLinks - postUpdateLinks)
 
-        removedLinks.findResults { storage.getSystemIdByIri(it.iri) }
-                .each { id -> elastic.decrementReverseLinks(id) }
+        removedLinks.each { link ->
+            String id = storage.getSystemIdByIri(link.iri)
+            if (id) {
+                elastic.decrementReverseLinks(id, link.relation)
+            }
+        }
 
         addedLinks.each { link ->
             String id = storage.getSystemIdByIri(link.iri)
@@ -361,7 +365,7 @@ class Whelk {
                     elastic.index(doc, this)
                 } else {
                     // just update link counter
-                    elastic.incrementReverseLinks(id)
+                    elastic.incrementReverseLinks(id, link.relation)
                 }
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -324,7 +324,7 @@ class ElasticSearch {
             }
             else {
                 log.warn("Failed to update reverse link counter ($deltaCount) for $shortId: $e, placing in retry queue.", e)
-                indexingRetryQueue.add({ -> updateReverseLinkCounter(shortId, deltaCount) })
+                indexingRetryQueue.add({ -> updateReverseLinkCounter(shortId, relation, deltaCount) })
             }
         }
     }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -301,10 +301,12 @@ class ElasticSearch {
         // An indexed document will always have reverseLinks.totalItems set to an integer,
         // and reverseLinks.totalItemsByRelation set to a map, but reverseLinks.totalItemsByRelation['foo']
         // doesn't necessarily exist at this time; hence the null check before trying to update the link counter.
+        // The outer "if (ctx._source.reverseLinks.totalItemsByRelation) {}" can be removed once we've
+        // reindexed once; it's just there so as to not break things too much before that.
         String body = """
         {
             "script" : {
-                "source": "ctx._source.reverseLinks.totalItems += $deltaCount; if (ctx._source.reverseLinks.totalItemsByRelation['$relation'] == null) { if ($deltaCount > 0) { ctx._source.reverseLinks.totalItemsByRelation['$relation'] = $deltaCount; } } else { ctx._source.reverseLinks.totalItemsByRelation['$relation'] += $deltaCount; }",
+                "source": "ctx._source.reverseLinks.totalItems += $deltaCount; if (ctx._source.reverseLinks.totalItemsByRelation != null) { if (ctx._source.reverseLinks.totalItemsByRelation['$relation'] == null) { if ($deltaCount > 0) { ctx._source.reverseLinks.totalItemsByRelation['$relation'] = $deltaCount; } } else { ctx._source.reverseLinks.totalItemsByRelation['$relation'] += $deltaCount; } }",
                 "lang": "painless"
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -260,9 +260,6 @@ class PostgreSQLComponent {
             lddb ON deps.i = lddb.id AND lddb.collection='hold'
             """.stripIndent()
 
-    private static final String GET_INCOMING_LINK_COUNT =
-            "SELECT COUNT(id) FROM lddb__dependencies WHERE dependsOnId = ?"
-
     private static final String GET_INCOMING_LINK_COUNT_BY_ID_AND_RELATION =
             "SELECT relation, count(id) FROM lddb__dependencies WHERE dependsOnId = ? GROUP BY relation"
 
@@ -2243,23 +2240,6 @@ class PostgreSQLComponent {
 
     Set<String> getByReverseRelation(String iri, String relation) {
         return dependencyCache.getDependersOfType(iri, relation)
-    }
-
-    long getIncomingLinkCount(String id) {
-        return withDbConnection {
-            Connection connection = getMyConnection()
-            PreparedStatement preparedStatement = null
-            ResultSet rs = null
-            try {
-                preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_COUNT)
-                preparedStatement.setString(1, id)
-                rs = preparedStatement.executeQuery()
-                rs.next()
-                return rs.getInt(1)
-            } finally {
-                close(rs, preparedStatement)
-            }
-        }
     }
 
     Map<String, Long> getIncomingLinkCountByIdAndRelation(String id) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -263,6 +263,9 @@ class PostgreSQLComponent {
     private static final String GET_INCOMING_LINK_COUNT =
             "SELECT COUNT(id) FROM lddb__dependencies WHERE dependsOnId = ?"
 
+    private static final String GET_INCOMING_LINK_COUNT_BY_ID_AND_RELATION =
+            "SELECT relation, count(id) FROM lddb__dependencies WHERE dependsOnId = ? GROUP BY relation"
+
     private static final String GET_INCOMING_LINK_COUNT_BY_RELATION = """
             SELECT d.relation, count(d.id)
             FROM lddb__dependencies d, lddb__identifiers l
@@ -2253,6 +2256,27 @@ class PostgreSQLComponent {
                 rs = preparedStatement.executeQuery()
                 rs.next()
                 return rs.getInt(1)
+            } finally {
+                close(rs, preparedStatement)
+            }
+        }
+    }
+
+    Map<String, Long> getIncomingLinkCountByIdAndRelation(String id) {
+        return withDbConnection {
+            Connection connection = getMyConnection()
+            PreparedStatement preparedStatement = null
+            ResultSet rs = null
+            def result = new TreeMap<String, Long>()
+            try {
+                preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_COUNT_BY_ID_AND_RELATION)
+
+                preparedStatement.setString(1, id)
+                rs = preparedStatement.executeQuery()
+                while (rs.next()) {
+                    result[rs.getString(1)] = (long) rs.getInt(2)
+                }
+                return result
             } finally {
                 close(rs, preparedStatement)
             }


### PR DESCRIPTION
Previously, when indexing a document into Elasticsearch, we'd only store the number of incoming links to the document (in `reverseLinks.totalItems`). This change makes it so that we also store number of links per type/relation, so that we can reduce the number of `/find` requests in frontend code. Right now a search like https://libris.kb.se/katalogisering/search/libris?q=katt&_limit=20&@type=Instance&_sort=-reverseLinks.totalItems&_offset=0 triggers 41 `/find.jsonld` requests -- the main one, plus two for each instance: one to see whether the currently-logged-in sigel has a holding for that instance, and one to get the total number of holdings for that instance. At least the latter we should be able to avoid easily.

So for example, given an instance like this:

```
whelk_dev=# select count(id) from lddb__dependencies where dependsonid = '9tm3815m5jsr1t6';
 count
-------
    96
(1 row)

whelk_dev=# select relation, count(id) from lddb__dependencies where dependsonid = '9tm3815m5jsr1t6' group by relation;
     relation     | count
------------------+-------
 itemOf           |    95
 meta.derivedFrom |     1
(2 rows)
```

 ...we'd now get this from ES:


```
~ curl -sk -u elastic:elastic "https://localhost:9200/libris_local/_doc/9tm3815m5jsr1t6"|jq '._source.reverseLinks'
{
  "@type": "PartialCollectionView",
  "totalItems": 96,
  "totalItemsByRelation": {
    "itemOf": 95,
    "meta.derivedFrom": 1
  }
}
```

Similarly, for an agent:


```
whelk_dev=# select count(id) from lddb__dependencies where dependsonid = '000n6qq312rjv2cf';
 count
-------
   312
(1 row)

whelk_dev=# select relation, count(id) from lddb__dependencies where dependsonid = '000n6qq312rjv2cf' group by relation;
           relation           | count
------------------------------+-------
 hasComponent.heldBy          |    20
 heldBy                       |    35
 meta.descriptionCreator      |    55
 meta.descriptionLastModifier |   202
 ```

=>


 ```
 ~ curl -sk -u elastic:elastic "https://localhost:9200/libris_local/_doc/000n6qq312rjv2cf"|jq '._source.reverseLinks'
{
  "@type": "PartialCollectionView",
  "totalItems": 312,
  "totalItemsByRelation": {
    "hasComponent.heldBy": 20,
    "heldBy": 35,
    "meta.descriptionCreator": 55,
    "meta.descriptionLastModifier": 202
  }
}
```
