### PR TITLE
In ES, store not just incoming link total but also per type (take 2)

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -205,6 +205,23 @@
                     }
                 }
             },
+            "reverseLinks": {
+              "properties": {
+                "@type": {
+                  "type": "keyword",
+                  "copy_to": [
+                    "_all"
+                  ]
+                },
+                "totalItems": {
+                  "type": "long"
+                },
+                "totalItemsByRelation": {
+                  "type": "object",
+                  "subobjects": false
+                }
+              }
+            },
             "__prefLabel": {
                 "type": "text",
                 "fields": {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -347,8 +347,12 @@ class Whelk {
         Set<Link> addedLinks = (postUpdateLinks - preUpdateLinks)
         Set<Link> removedLinks = (preUpdateLinks - postUpdateLinks)
 
-        removedLinks.findResults { storage.getSystemIdByIri(it.iri) }
-                .each { id -> elastic.decrementReverseLinks(id) }
+        removedLinks.each { link ->
+            String id = storage.getSystemIdByIri(link.iri)
+            if (id) {
+                elastic.decrementReverseLinks(id, link.relation)
+            }
+        }
 
         addedLinks.each { link ->
             String id = storage.getSystemIdByIri(link.iri)
@@ -361,7 +365,7 @@ class Whelk {
                     elastic.index(doc, this)
                 } else {
                     // just update link counter
-                    elastic.incrementReverseLinks(id)
+                    elastic.incrementReverseLinks(id, link.relation)
                 }
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -260,8 +260,8 @@ class PostgreSQLComponent {
             lddb ON deps.i = lddb.id AND lddb.collection='hold'
             """.stripIndent()
 
-    private static final String GET_INCOMING_LINK_COUNT =
-            "SELECT COUNT(id) FROM lddb__dependencies WHERE dependsOnId = ?"
+    private static final String GET_INCOMING_LINK_COUNT_BY_ID_AND_RELATION =
+            "SELECT relation, count(id) FROM lddb__dependencies WHERE dependsOnId = ? GROUP BY relation"
 
     private static final String GET_INCOMING_LINK_COUNT_BY_RELATION = """
             SELECT d.relation, count(d.id)
@@ -2242,17 +2242,21 @@ class PostgreSQLComponent {
         return dependencyCache.getDependersOfType(iri, relation)
     }
 
-    long getIncomingLinkCount(String id) {
+    Map<String, Long> getIncomingLinkCountByIdAndRelation(String id) {
         return withDbConnection {
             Connection connection = getMyConnection()
             PreparedStatement preparedStatement = null
             ResultSet rs = null
+            def result = new TreeMap<String, Long>()
             try {
-                preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_COUNT)
+                preparedStatement = connection.prepareStatement(GET_INCOMING_LINK_COUNT_BY_ID_AND_RELATION)
+
                 preparedStatement.setString(1, id)
                 rs = preparedStatement.executeQuery()
-                rs.next()
-                return rs.getInt(1)
+                while (rs.next()) {
+                    result[rs.getString(1)] = (long) rs.getInt(2)
+                }
+                return result
             } finally {
                 close(rs, preparedStatement)
             }


### PR DESCRIPTION
Same as https://github.com/libris/librisxl/pull/1439 except ES mapping has now been updated. With the former PR many things failed to index because of (for example) `object mapping for [reverseLinks.totalItemsByRelation.instanceOf] tried to parse field [instanceOf] as object, but found a concrete value`. These failures were all silent (!) because it seems like we don't actually check for ES errors when doing bulk indexing? (I'll create a separate issue for this.)

Anyway, the problem, and the solution, was exactly this: https://www.elastic.co/guide/en/elasticsearch/reference/8.13/subobjects.html (e.g. we wanted to set `reverseLinks.totalItemsByRelation.instanceOf.subject = 1` and `reverseLinks.totalItemsByRelation.instanceOf = 1` but, having already seen `instanceOf.subject`, `instanceOf` was considered to be an object).

( I copied the dynamic mapping for `reverseLinks` generated by ES and added `totalItemsByRelation` with `subobjects` set to false.)