### PR TITLE
Do AND-search instead of OR-search in multi-word valued fields

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search/XLQLQuery.java
@@ -265,6 +265,7 @@ public class XLQLQuery {
     }
 
     private Map<String, Object> esNestedFilter(QueryTree.Nested n) {
+        // TODO: Use simple_query_string / query_string instead of match?
         var musts = n.fields()
                 .stream()
                 .flatMap(f -> Arrays.stream(f.value().split("\\s+"))


### PR DESCRIPTION
See https://kbse.atlassian.net/browse/LWS-185. The default operator in Elasticsearch is apparently OR (thought it was AND) and since we didn't override this before a query like e.g. `titel:”harry potter och fången från azkaban”` was interpreted as `"hasTitle.mainTitle": "harry || potter || och || fången || från || azkaban"` giving lots of irrelevant hits.

Now we get instead:
`titel:”harry potter och fången från azkaban”` --> `"hasTitle.mainTitle": "harry && potter && och && fången && från && azkaban"`
`contributor:"astrid lindgren"` --> `"contribution.agent": "astrid && lindgren"`

Should do for now.