### PR TITLE
Fix ImageLinker state keys

### DIFF
--- a/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
@@ -115,7 +115,7 @@ public class ImageLinker extends HouseKeeper {
         if (linkedNewInstancesUpTo.isAfter(linkNewInstancesSince.toInstant())) {
             Map<String, String> newState = new HashMap<>();
             newState.put(INSTANCES_STATE_KEY, linkedNewInstancesUpTo.atOffset(ZoneOffset.UTC).toString());
-            whelk.getStorage().putState(getName(), newState);
+            whelk.getStorage().putState(getName() + "-" + INSTANCES_STATE_KEY, newState);
         }
     }
 
@@ -197,7 +197,7 @@ public class ImageLinker extends HouseKeeper {
         if (linkedNewImagesUpTo.isAfter(linkNewImagesSince.toInstant())) {
             Map<String, String> newState = new HashMap<>();
             newState.put(IMAGES_STATE_KEY, linkedNewImagesUpTo.atOffset(ZoneOffset.UTC).toString());
-            whelk.getStorage().putState(getName(), newState);
+            whelk.getStorage().putState(getName() + "-" + IMAGES_STATE_KEY, newState);
         }
     }
 

--- a/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
@@ -53,7 +53,7 @@ public class ImageLinker extends HouseKeeper {
 
     public void scanForNewInstances() {
         Timestamp linkNewInstancesSince = Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS));
-        Map linkerState = whelk.getStorage().getState(getName());
+        Map linkerState = whelk.getStorage().getState(INSTANCES_STATE_KEY);
         if (linkerState != null && linkerState.containsKey(INSTANCES_STATE_KEY))
             linkNewInstancesSince = Timestamp.from( ZonedDateTime.parse( (String) linkerState.get(INSTANCES_STATE_KEY), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant() );
         Instant linkedNewInstancesUpTo = linkNewInstancesSince.toInstant();
@@ -115,14 +115,14 @@ public class ImageLinker extends HouseKeeper {
         if (linkedNewInstancesUpTo.isAfter(linkNewInstancesSince.toInstant())) {
             Map<String, String> newState = new HashMap<>();
             newState.put(INSTANCES_STATE_KEY, linkedNewInstancesUpTo.atOffset(ZoneOffset.UTC).toString());
-            whelk.getStorage().putState(getName() + "-" + INSTANCES_STATE_KEY, newState);
+            whelk.getStorage().putState(INSTANCES_STATE_KEY, newState);
         }
     }
 
     public void scanForNewImages() {
 
         Timestamp linkNewImagesSince = Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS));
-        Map linkerState = whelk.getStorage().getState(getName());
+        Map linkerState = whelk.getStorage().getState(IMAGES_STATE_KEY);
         if (linkerState != null && linkerState.containsKey(IMAGES_STATE_KEY))
             linkNewImagesSince = Timestamp.from( ZonedDateTime.parse( (String) linkerState.get(IMAGES_STATE_KEY), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant() );
         Instant linkedNewImagesUpTo = linkNewImagesSince.toInstant();
@@ -197,7 +197,7 @@ public class ImageLinker extends HouseKeeper {
         if (linkedNewImagesUpTo.isAfter(linkNewImagesSince.toInstant())) {
             Map<String, String> newState = new HashMap<>();
             newState.put(IMAGES_STATE_KEY, linkedNewImagesUpTo.atOffset(ZoneOffset.UTC).toString());
-            whelk.getStorage().putState(getName() + "-" + IMAGES_STATE_KEY, newState);
+            whelk.getStorage().putState(IMAGES_STATE_KEY, newState);
         }
     }
 


### PR DESCRIPTION
ImageLinker has `scanForNewInstances()` and `scanForNewImages()`. Both use `lddb__state` to get/set state (`linkedNewInstancesUpTo` + timestamp, `linkedNewImagesUpTo` + timestamp) but use the same key (`Image linker`), so only one can exist at a time (https://github.com/libris/librisxl/blob/develop/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy#L440).

As observed:

```
 whelk=> select * from lddb__state ;
     key      |                        value
--------------+-----------------------------------------------------
 Image linker | {"linkedNewImagesUpTo": "2024-06-16T14:40:20.811Z"}
(1 row)

...a moment later...

whelk=> select * from lddb__state ;
     key      |                         value
--------------+--------------------------------------------------------
 Image linker | {"linkedNewInstancesUpTo": "2024-06-16T13:52:54.761Z"}
(1 row)
```

Currently on dev ImageLinker keeps linking the same instances to the same images over and over. Hopefully this should fix it.

Should probably also insert these manually on DEV and QA pgsql.