### PR TITLE
Rotate log4j logs automatically

### DIFF
--- a/apix_server/src/main/resources/log4j2.xml
+++ b/apix_server/src/main/resources/log4j2.xml
@@ -8,9 +8,15 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk-apix.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-apix.log" filePattern="${sys:xl.logRoot}/whelk-apix.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/batchimport/src/main/resources/log4j2.xml
+++ b/batchimport/src/main/resources/log4j2.xml
@@ -8,9 +8,15 @@
         <Console name="STDERR" target="SYSTEM_ERR">
             <PatternLayout pattern="%msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk-batchimport.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-batchimport.log" filePattern="${sys:xl.logRoot}/whelk-batchimport.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/housekeeping/src/main/resources/log4j2.xml
+++ b/housekeeping/src/main/resources/log4j2.xml
@@ -8,9 +8,15 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk-housekeeping.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-housekeeping.log" filePattern="${sys:xl.logRoot}/whelk-housekeeping.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/importers/src/main/resources/log4j2.xml
+++ b/importers/src/main/resources/log4j2.xml
@@ -11,6 +11,15 @@
         <File name="File" fileName="${sys:xl.logRoot}/xlimporter.log">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </File>
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/xlimporter.log" filePattern="${sys:xl.logRoot}/xlimporter.%i.log.gz">
+            <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/marc_export/src/main/resources/log4j2.xml
+++ b/marc_export/src/main/resources/log4j2.xml
@@ -8,9 +8,15 @@
         <Console name="STDERR" target="SYSTEM_ERR">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk-marc-export.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-marc-export.log" filePattern="${sys:xl.logRoot}/whelk-marc-export.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/oaipmh/src/main/resources/log4j2.xml
+++ b/oaipmh/src/main/resources/log4j2.xml
@@ -8,9 +8,15 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-oaipmh.log" filePattern="${sys:xl.logRoot}/whelk-apix.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>

--- a/rest/src/main/resources/log4j2.xml
+++ b/rest/src/main/resources/log4j2.xml
@@ -8,12 +8,22 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:xl.logRoot}/whelk.log">
+        <!-- We have to use %i in filePattern, and no date, because otherwise DefaultRolloverStrategy won't delete old logs
+             (unless we use a hacky <Delete> solution.) -->
+        <RollingFile name="File" fileName="${sys:xl.logRoot}/whelk-rest.log" filePattern="${sys:xl.logRoot}/whelk-rest.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
-        <File name="DigitalReproductionApi" fileName="${sys:xl.logRoot}/digital-reproduction-api.log">
+            <DefaultRolloverStrategy max="30" />
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+            </Policies>
+        </RollingFile>
+        <RollingFile name="DigitalReproductionApi" fileName="${sys:xl.logRoot}/digital-reproduction-api.log" filePattern="${sys:xl.logRoot}/digital-reproduction-api.%i.log.gz">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
+            <Policies>
+                <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+                <DefaultRolloverStrategy max="30"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>


### PR DESCRIPTION
See https://kbse.atlassian.net/browse/LXL-4523

We could use the system's logrotate, but then we'd either have to introduce signal handling in XL, so that something like `kill -USR1 <xl service pid>` would make the XL service re-open its log file (without restarting the entire service), _or_ use logrotate's `copytruncate` option, but then "Note that there is a very small  time slice between copying the file and truncating it, so some logging data might be lost."

Log4j has a massive (and confusing) amount of options to do the same: https://logging.apache.org/log4j/2.x/manual/appenders.html#RollingFileAppender

After some trial and error this seems to work. This simple policy deletes logs after 30 days but there are many other possibilities.
