### PR TITLE
ImageLinker: check existing images before linking

### DIFF
--- a/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
@@ -286,12 +286,10 @@ public class ImageLinker extends HouseKeeper {
         }
         String instanceId = tempDoc.getShortId();
         List<Map<String, String>> imageList = tempDoc.getImages();
-        if (imageList != null) {
-            for (Map<String, String> image : imageList) {
-                if (image.containsValue(imageUri)) {
-                    logger.warn("{} already contains image {}; not linking", instanceId, imageUri);
-                    return;
-                }
+        for (Map<String, String> image : imageList) {
+            if (image.containsValue(imageUri)) {
+                logger.warn("{} already contains image {}; not linking", instanceId, imageUri);
+                return;
             }
         }
 

--- a/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/ImageLinker.java
@@ -52,6 +52,8 @@ public class ImageLinker extends HouseKeeper {
     }
 
     public void scanForNewInstances() {
+        logger.debug("Scanning for new instances");
+
         Timestamp linkNewInstancesSince = Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS));
         Map linkerState = whelk.getStorage().getState(INSTANCES_STATE_KEY);
         if (linkerState != null && linkerState.containsKey(INSTANCES_STATE_KEY))
@@ -120,6 +122,7 @@ public class ImageLinker extends HouseKeeper {
     }
 
     public void scanForNewImages() {
+        logger.debug("Scanning for new images");
 
         Timestamp linkNewImagesSince = Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS));
         Map linkerState = whelk.getStorage().getState(IMAGES_STATE_KEY);
@@ -272,10 +275,25 @@ public class ImageLinker extends HouseKeeper {
     }
 
     private void linkImage(String instanceUri, String imageUri) {
+        logger.debug("Trying to link {} to image {}", instanceUri, imageUri);
+
         if (instanceUri.startsWith("/")) // A relative URI
             instanceUri = Document.getBASE_URI().resolve(instanceUri).toString();
 
-        String instanceId = whelk.getStorage().getSystemIdByIri(instanceUri);
+        Document tempDoc = whelk.getStorage().getDocumentByIri(instanceUri);
+        if (tempDoc == null) {
+            return;
+        }
+        String instanceId = tempDoc.getShortId();
+        List<Map<String, String>> imageList = tempDoc.getImages();
+        if (imageList != null) {
+            for (Map<String, String> image : imageList) {
+                if (image.containsValue(imageUri)) {
+                    logger.warn("{} already contains image {}; not linking", instanceId, imageUri);
+                    return;
+                }
+            }
+        }
 
         if (instanceId != null) {
             whelk.storeAtomicUpdate(instanceId, true, false, "ImageLinker", "SEK",

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -161,7 +161,7 @@ class Document {
     List getImages() {
         def images = get(imagePath)
         if (images == null)
-            return null
+            return Collections.emptyList()
         if (images instanceof List)
             return images
         return [images]

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -141,7 +141,6 @@ class Document {
     }
 
     void addImage(String imageUri) {
-
         // Make imagePath point to a list
         preparePath(imagePath)
         Object imageList = get(imagePath)
@@ -161,6 +160,8 @@ class Document {
 
     List getImages() {
         def images = get(imagePath)
+        if (images == null)
+            return null
         if (images instanceof List)
             return images
         return [images]


### PR DESCRIPTION
This adds a little overhead but ensures ImageLinker never saves a document if the specified image has already been linked (for example, if the state in `lddb__state` is whack or accidentally deleted or if the same image has returned with a newer `created` time).