### PR TITLE
Optionally copy document history when using WhelkCopier

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -137,18 +137,19 @@ class ImporterMain {
      * SOURCE_PROPERTIES RECORD_ID_FILE MovingImageInstance,Map
      */
     @Command(args='SOURCE_PROPERTIES RECORD_ID_FILE [<ADDITIONAL_TYPES | --all-types | ""> [--exclude-items]]')
-    void copywhelk(String sourcePropsFile, String recordsFile, additionalTypes=null, String excludeItems=null) {
+    void copywhelk(String sourcePropsFile, String recordsFile, String additionalTypes=null, String excludeItems=null, String includeHistory=null) {
         def sourceProps = new Properties()
         new File(sourcePropsFile).withInputStream { it
             sourceProps.load(it)
         }
-        def source = Whelk.createLoadedCoreWhelk(sourceProps)
-        def dest = Whelk.createLoadedSearchWhelk(props)
-        def recordIds = new File(recordsFile).collect {
+        Whelk source = Whelk.createLoadedCoreWhelk(sourceProps)
+        Whelk dest = Whelk.createLoadedSearchWhelk(props)
+        List<String> recordIds = new File(recordsFile).collect {
             it.split(/\t/)[0]
         }
         boolean shouldExcludeItems = excludeItems && excludeItems == '--exclude-items'
-        def copier = new WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems)
+        boolean shouldIncludeHistory = includeHistory && includeHistory == '--include-history'
+        WhelkCopier copier = new WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems, shouldIncludeHistory)
         copier.run()
     }
 

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -122,22 +122,33 @@ class ImporterMain {
     }
 
     /**
-     * The additional_types argument should be one of:
-     * - comma-separated list of types to include. Like so: Person,GenreForm
-     * - --all-types, to copy *all* types
-     * - "", to be able to use --exclude-items without specifying additional types
+     * The --additional-types argument can look like one of the following:
+     * --additional-types=all              # Copy all types
+     * --additional-types=none             # Don't copy additional types (default)
+     * --additional-types=Person,GenreForm # Copy specific types
+     *
+     * You can also optionally copy historical document versions (from lddb__versions)
+     * for certain types, all types, or not at all (default). "all" means
+     * "copy versions of all records selected by RECORD_ID_FILE":
+     * --copy-versions=all              # Copy history for every document added
+     * --copy-versions=Instance,Person  # Copy history only for specific types
+     * --copy-versions=none             # Don't copy history (default)
      *
      * E.g., copy everything except items (holdings):
-     * SOURCE_PROPERTIES RECORD_ID_FILE --all-types --exclude-items
+     * SOURCE_PROPERTIES RECORD_ID_FILE --additional-types=all --exclude-items
      *
      * Copy only what's in RECORD_ID_FILE, but exclude items:
-     * SOURCE_PROPERTIES RECORD_ID_FILE "" --exclude-items
+     * SOURCE_PROPERTIES RECORD_ID_FILE --additional-types=none --exclude-items
      *
-     * Copy what's in RECORD_ID_FILE and types MovingImageInstance and Map, don't exclude items:
-     * SOURCE_PROPERTIES RECORD_ID_FILE MovingImageInstance,Map
+     * Copy what's in RECORD_ID_FILE and types MovingImageInstance and Map, include items:
+     * SOURCE_PROPERTIES RECORD_ID_FILE --additional-types=MovingImageInstance,Map
+     *
+     * Copy what's in RECORD_ID_FILE and types MovingImageInstance and Map, include items,
+     * and copy historical versions of Instance and Map:
+     * SOURCE_PROPERTIES RECORD_ID_FILE --additional-types=MovingImageInstance,Map --include-items --copy-versions=Instance,Map
      */
-    @Command(args='SOURCE_PROPERTIES RECORD_ID_FILE [<ADDITIONAL_TYPES | --all-types | ""> [--exclude-items]]')
-    void copywhelk(String sourcePropsFile, String recordsFile, String additionalTypes=null, String excludeItems=null, String includeHistory=null) {
+    @Command(args='SOURCE_PROPERTIES RECORD_ID_FILE [--additional-types=<types>] [--exclude-items | --dont-exclude-items] [--copy-versions=<types>]')
+    void copywhelk(String sourcePropsFile, String recordsFile, String additionalTypes=null, String excludeItems=null, String copyVersions=null) {
         def sourceProps = new Properties()
         new File(sourcePropsFile).withInputStream { it
             sourceProps.load(it)
@@ -148,8 +159,7 @@ class ImporterMain {
             it.split(/\t/)[0]
         }
         boolean shouldExcludeItems = excludeItems && excludeItems == '--exclude-items'
-        boolean shouldIncludeHistory = includeHistory && includeHistory == '--include-history'
-        WhelkCopier copier = new WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems, shouldIncludeHistory)
+        WhelkCopier copier = new WhelkCopier(source, dest, recordIds, additionalTypes, shouldExcludeItems, copyVersions)
         copier.run()
     }
 

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -317,6 +317,10 @@ class Document {
         get(createdPath)
     }
 
+    Instant getCreatedTimestamp() {
+        ZonedDateTime.parse(getCreated(), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant()
+    }
+
     void setModified(Date modified) {
         ZonedDateTime zdt = ZonedDateTime.ofInstant(modified.toInstant(), ZoneId.systemDefault())
         String formatedModified = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(zdt)

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -511,6 +511,14 @@ class Whelk {
         return storage.quickCreateDocument(document, changedIn, changedBy, collection)
     }
 
+    /**
+     * Like quickCreateDocument but for adding historical document versions. NOT to be used in production
+     * environments; for development purposes only.
+     */
+    boolean quickCreateDocumentVersion(Document document, Date createdTime, Date modTime, String changedIn, String changedBy, String collection) {
+        return storage.quickCreateDocumentVersion(document, createdTime, modTime, changedIn, changedBy, collection)
+    }
+
     void remove(String id, String changedIn, String changedBy, boolean force = false) {
         log.debug "Deleting ${id} from Whelk"
         Document doc


### PR DESCRIPTION
Related to https://kbse.atlassian.net/browse/LXL-4531

Currently we can't do some export tests properly because the dev environment lacks historical versions of records. This change makes it possible to optionally copy records from `lddb__versions` for each imported record (optionally restricted to type, e.g. Instance; otherwise with `import_work_example_data` we'd get a couple million historical auth records, which adds a bunch of extra time).

Also makes the "additional types" parameter more readable.

Example:

`java -Dxl.secret.properties=secret.properties -jar importers/build/libs/xlimporter.jar copywhelk temp_source_secret.properties temp_example_records.tsv --additional-types=Meeting,Person,Topic,Agent --include-items --copy-versions=Instance`