### PR TITLE
find API: add experimental spell checking

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -83,6 +83,16 @@
                         "numeric_keeper"
                     ],
                     "tokenizer": "numeric_keeper_tokenizer"
+                },
+                "trigram": {
+                    "type": "custom",
+                    "tokenizer": "standard",
+                    "filter": ["lowercase","shingle"]
+                },
+                "reverse": {
+                    "type": "custom",
+                    "tokenizer": "standard",
+                    "filter": ["lowercase","reverse"]
                 }
             },
             "tokenizer": {
@@ -131,6 +141,11 @@
                     "type": "pattern_replace",
                     "pattern": "[\u0027|\u2019]",
                     "replacement": ""
+                },
+                "shingle": {
+                    "type": "shingle",
+                    "min_shingle_size": 2,
+                    "max_shingle_size": 3
                 }
             },
             "normalizer": {
@@ -257,6 +272,14 @@
                             "keyword": {
                                 "type": "keyword",
                                 "normalizer": "custom_case_insensitive"
+                            },
+                            "trigram": {
+                                "type": "text",
+                                "analyzer": "trigram"
+                            },
+                            "reverse": {
+                                "type": "text",
+                                "analyzer": "reverse"
                             }
                         }
                     },

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -234,7 +234,7 @@ class SearchUtils {
             esResult["spell"].each { Map suggestion ->
                 result['_spell'] << [
                         'label': suggestion['text'],
-                        'labelWithMarkup': suggestion['highlighted'],
+                        'labelHTML': suggestion['highlighted'],
                         'view': [
                                 '@id': makeFindUrl(
                                         SearchType.ELASTIC,

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -230,7 +230,19 @@ class SearchUtils {
         }
 
         if (spell) {
-            result["_spell"] = esResult["spell"]
+            result['_spell'] = []
+            esResult["spell"].each { Map suggestion ->
+                result['_spell'] << [
+                        'label': suggestion['text'],
+                        'labelWithMarkup': suggestion['highlighted'],
+                        'view': [
+                                '@id': makeFindUrl(
+                                        SearchType.ELASTIC,
+                                        pageParams - ['q': pageParams['q']] + ['q': suggestion['text']],
+                                        offset)
+                        ]
+                ]
+            }
         }
 
         if (esResult['_debug']) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -653,6 +653,10 @@ class ElasticSearch {
             results.totalHits = responseMap.hits.total.value
             results.items = responseMap.hits.hits.collect(hitCollector)
             results.aggregations = responseMap.aggregations
+            // Spell checking
+            if (responseMap.suggest?.simple_phrase) {
+                results.spell = responseMap.suggest.simple_phrase[0].options
+            }
             return results
         }
         catch (Exception e) {

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -1195,6 +1195,7 @@ class ESQuery {
                 'phrase': [
                     'field': SPELL_CHECK_FIELD,
                     'size': 1,
+                    'max_errors': 2,
                     'direct_generator': [
                         [
                             'field': SPELL_CHECK_FIELD,


### PR DESCRIPTION
A first stab at adding spell checking, to be used by Libris sök. Uses Elasticsearch's [phrase suggester](https://www.elastic.co/guide/en/elasticsearch/reference/8.13/search-suggesters.html#phrase-suggester) with two generators as described in the ES docs.

Uses `_sortKeyByLang.sv` as the field to get suggestions from, as it seems like a reasonable choice; with e.g.  `_all` we'd get lots of "bad" suggestions since it contains lots of oft-repeated vocab stuff. (sv vs en shouldn't matter for these purposes.)

Quick testing on the dev data is promising. We might want to tinker with both the suggester configuration/query and the field(s) to target. This is just somerthing to start with.

With `/find?q=foobar&_spell=true` the spell checking is done in _addition_ to the regular query and returned along with the usual results.

With `/find?q=foobar&_spell=only` _only_ the spell checking query is performed.

(Possibly we want to keep it separate from /find though? :thinking: ...or have it both in /find, for internal use, and a bibspell-like thing (returning "bibspell-compatible" results would of course be trivial))

```
~ curl -s "http://localhost:8180/find?q=dynimical%20systems&_spell=true"|jq '._spell'
[
  {
    "text": "dynamical systems",
    "highlighted": "<em>dynamical</em> systems",
    "score": 0.005399387
  }
]
~ curl -s "http://localhost:8180/find?q=dynimical%20systemms&_spell=true"|jq '._spell'
[
  {
    "text": "dynamical systems",
    "highlighted": "<em>dynamical systems</em>",
    "score": 0.005399387
  }
]
```

curl directly against ES, local dev:
```
curl --request POST \
  --url https://localhost:9200/libris_local/_search \
  -k \
  -u elastic:elastic \
  --header 'Content-Type: application/json' \
  --data '{
  "suggest": {
    "text" : "dynimical system",
    "simple_phrase" : {
      "phrase" : {
        "field" : "_sortKeyByLang.sv.trigram",
        "size" : 1,
	"max_errors": 2,
        "direct_generator" : [
		{
			"field" : "_sortKeyByLang.sv.trigram",
			"suggest_mode" : "always"
        	},
		{
			"field" : "_sortKeyByLang.sv.reverse",
			"suggest_mode" : "always",
			"pre_filter" : "reverse",
			"post_filter" : "reverse"
      		}
	],
	"highlight": {
          "pre_tag": "<em>",
          "post_tag": "</em>"
        }
      }
    }
  }
}'
```

https://kbse.atlassian.net/browse/LWS-87