### PR TITLE
Add support for Item subclasses.

### DIFF
--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -1190,7 +1190,7 @@ class CrudSpec extends Specification {
                                     "@type": "Item",
                                     "contains": "some new data",
                                     "heldBy":
-                                            ["code": "Ting"]]]]
+                                            ["@id": "https://libris.kb.se/library/Ting"]]]]
         request.getInputStream() >> {
             new ServletInputStreamMock(mapper.writeValueAsBytes(postData))
         }
@@ -1201,7 +1201,7 @@ class CrudSpec extends Specification {
             "POST"
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
-            return "bib"
+            return "hold"
         }
         request.getContentType() >> {
             "application/ld+json"

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -370,7 +370,7 @@ class Document {
     }
 
     boolean isHolding(JsonLd jsonld) {
-        return ("hold" == getLegacyCollection(jsonld))
+        return "hold" == getLegacyCollection(jsonld) || jsonld.isSubClassOf(getThingType(), "Item")
     }
     
     String getLegacyCollection(JsonLd jsonld) {

--- a/whelk-core/src/test/groovy/whelk/LegacyIntegrationToolsSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/LegacyIntegrationToolsSpec.groovy
@@ -21,7 +21,10 @@ class LegacyIntegrationToolsSpec extends Specification {
              "category": [ ["@id": "http://example.org/ns/"] ]],
             ["@id": "http://example.org/ns/Paperback",
              "subClassOf": [ ["@id": "http://example.org/ns/Print"] ],
-             "category": ["@id": "http://example.org/ns/pending"]]
+             "category": ["@id": "http://example.org/ns/pending"]],
+            ["@id": "http://example.org/ns/None",
+             "subClassOf": [ ["@id": "http://example.org/ns/Instance"] ],
+             "category": [ ["@id": "$MARC/none"] ]],
         ]
     ]
 
@@ -31,14 +34,14 @@ class LegacyIntegrationToolsSpec extends Specification {
         expect:
         tool.getMarcCollectionForTerm([category: cats]) == id
         where:
-        id      | cats
-        'bib'   | ['@id': "$MARC/bib"]
-        'bib'   | [['@id': "$MARC/bib"], ['@id': "pending"]]
-        'auth'  | [['@id': "$MARC/auth"]]
-        'none'  | ['@id': 'other']
-        'none'  | [['@id': 'other']]
-        'none'  | []
-        'none'  | null
+        id          | cats
+        'bib'       | ['@id': "$MARC/bib"]
+        'bib'       | [['@id': "$MARC/bib"], ['@id': "pending"]]
+        'auth'      | [['@id': "$MARC/auth"]]
+        'undefined' | ['@id': 'other']
+        'undefined' | [['@id': 'other']]
+        'undefined' | []
+        'undefined' | null
     }
 
     def "should get marc collection for type"() {
@@ -51,6 +54,7 @@ class LegacyIntegrationToolsSpec extends Specification {
         'Print'     | 'bib'
         'Paperback' | 'bib'
         'Other'     | 'none'
+        'None'      | 'none'
     }
 
 }


### PR DESCRIPTION
Make it possible to have linked `SingleItem` (sv: "Exemplar") inside `Item` `hasComponent`.

* `SingleItem` is in collection `none` instead of `hold` so that we don't get any of the special handling for holdings
    * => it is possible to have multiple `SingleItem` records per library
    * => it is not involved in MARC export except as an embellished `hasComponent` of a regular holding record
* Access control for holdings is extend to all subclasses of `Item` instead of just collection `hold`
    * i.e. only owning library + global registrant can write `SingleItem`

See also
https://github.com/libris/definitions/pull/494


Later on `Item` might be replaced by `ItemHolding` for the holding, with `SingleItem` and `SomeItem` for 1 vs many items.
See https://github.com/libris/definitions/pull/483