### PR TITLE
Add support for spell check in new search

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -25,6 +25,7 @@ public class QueryParams {
         public static final String LIMIT = "_limit";
         public static final String OFFSET = "_offset";
         public static final String LENS = "_lens";
+        public static final String SPELL = "_spell";
         public static final String OBJECT = "_o";
         public static final String PREDICATES = "_p";
         public static final String EXTRA = "_x";
@@ -44,6 +45,7 @@ public class QueryParams {
     public final String mode;
     public final List<String> debug;
     public final String lens;
+    public final Spell spell;
 
     public final String q;
     public final String i;
@@ -58,6 +60,7 @@ public class QueryParams {
         this.limit = getLimit(apiParameters);
         this.offset = getOffset(apiParameters);
         this.lens = getOptionalSingleNonEmpty(ApiParams.LENS, apiParameters).orElse("cards");
+        this.spell = new Spell(getOptionalSingleNonEmpty(ApiParams.SPELL, apiParameters).orElse(""));
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
     }
@@ -80,6 +83,10 @@ public class QueryParams {
         }
         if (mode != null) {
             params.put(ApiParams.EXTRA, mode);
+        }
+        var spellP = spell.asString();
+        if (!spellP.isEmpty()) {
+            params.put(ApiParams.SPELL, spellP);
         }
         var sort = sortBy.asString();
         if (!sort.isEmpty()) {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -33,8 +33,8 @@ public class QueryUtil {
         this.lensBoost = new ESQueryLensBoost(whelk.getJsonld());
     }
 
-    public Map<String, Object> query(Map<String, Object> queryDsl) {
-        return castToStringObjectMap(whelk.elastic.query(queryDsl));
+    public Map<?, ?> query(Map<String, Object> queryDsl) {
+        return whelk.elastic.query(queryDsl);
     }
 
     public boolean esIsConfigured() {

--- a/whelk-core/src/main/groovy/whelk/search2/Spell.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Spell.java
@@ -1,0 +1,64 @@
+package whelk.search2;
+
+import whelk.JsonLd;
+import whelk.search.ESQuery;
+import whelk.search2.querytree.QueryTree;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+public class Spell {
+    public record Suggestion(String text, String highlighted) {
+    }
+
+    public final boolean suggest;
+    public final boolean suggestOnly;
+
+    Spell(String s) {
+        this.suggest = s.equals("true") || s.equals("only");
+        this.suggestOnly = s.equals("only");
+    }
+
+    public static Optional<Map<String, Object>> getSpellQuery(QueryTree qt) {
+        return Optional.of(qt.getTopLevelFreeText())
+                .filter(Predicate.not(String::isEmpty))
+                .map(ESQuery::getSpellQuery)
+                .map(QueryUtil::castToStringObjectMap);
+    }
+
+    public static List<Map<String, Object>> buildSpellSuggestions(QueryResult queryResult, QueryTree qt,
+                                                      Map<String, String> nonQueryParams) {
+        List<Map<String, Object>> suggestions = new ArrayList<>();
+        for (Suggestion s : queryResult.spell) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("label", s.text());
+            m.put("labelHtml", s.highlighted());
+            m.put("view", Map.of(JsonLd.ID_KEY, QueryUtil.makeFindUrl(qt.replaceFreeText(s.text()), nonQueryParams)));
+            suggestions.add(m);
+        }
+        return suggestions;
+    }
+
+    public static List<Suggestion> collectSuggestions(Map<String, Object> esResponse) {
+        return ((List<?>) esResponse.getOrDefault("spell", Collections.emptyList()))
+                .stream()
+                .map(Map.class::cast)
+                .map(m -> new Suggestion((String) m.get("text"), (String) m.get("highlighted")))
+                .toList();
+    }
+
+    public String asString() {
+        if (suggestOnly) {
+            return "only";
+        }
+        if (suggest) {
+            return "true";
+        }
+        return "";
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -124,6 +124,20 @@ public class QueryTree {
         };
     }
 
+    public QueryTree replaceFreeText(String replacement) {
+        if (isFreeText()) {
+            return new QueryTree(new FreeText(Operator.EQUALS, replacement));
+        }
+        if (tree instanceof And) {
+            return new QueryTree(
+                    ((And) tree).mapAndReinstantiate(n -> isFreeText(n)
+                            ? new FreeText(Operator.EQUALS, replacement)
+                            : n)
+            );
+        }
+        throw new RuntimeException("Failed to replace free text"); // Should never be reached
+    }
+
     public QueryTree addToTopLevel(Node node) {
         return new QueryTree(addToTopLevel(tree, node));
     }


### PR DESCRIPTION
Continuation of https://github.com/libris/librisxl/pull/1459 which added spell check support to the cataloguing version of the search API. Now adding the equivalent to the new search API version.

Spell check will only be performed on the free text part of a query, so for a query like e.g. "ryda rummer contributor:agaust" we get "röda rummet" as suggestion.