### PR TITLE
Redirect root context ref to systemContextUri

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -116,6 +116,8 @@ class Crud extends HttpServlet {
             if (request.pathInfo == "/") {
                 measurement = metrics.measure('INDEX')
                 displayInfo(response)
+            } else if (request.pathInfo == CONTEXT_PATH) {
+              sendRedirect(request, response, whelk.systemContextUri)
             } else if (siteSearch.isSearchResource(request.pathInfo)) {
                 measurement = metrics.measure('FIND')
                 handleQuery(request, response)


### PR DESCRIPTION
**[Untested Draft]**

Currently, we're not serving working JSON-LD, since the `/context.jsonld` reference used both in the embedded `@context`  
reference:

```
curl -s -L -HAccept:application/ld+json https://libris.kb.se/fxql7jqr38b1dkf
```
and the Linke header variant served for plain JSON:
```
curl -v -HAccept:application/json https://libris.kb.se/fxql7jqr38b1dkf
< link: </context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
```

(This was pointed out during the BIBFRAME conference.)

This **Untested Draft** PR simply redirects to the chosen system context, from the previously working "convenience" URI (the root `/context.jsonld` resource; i.e. resolving to either https://libris.kb.se/context.jsonld and https://id.kb.se/context.jsonld).

If you so decide, it could set the `whelk.systemContextUri` directly (it's not as "nice", but more explicit, and may be easier depending on web server configuration complexity).