### PR TITLE
Jetty: Allow ambiguous path separator

### DIFF
--- a/rest/src/main/java/whelk/RestServer.java
+++ b/rest/src/main/java/whelk/RestServer.java
@@ -40,13 +40,21 @@ public class RestServer extends XlServer {
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
 
-        // TODO: this takes care of double slashes in id.kb.se paths from nginx
+        // TODO: AMBIGUOUS_EMPTY_SEGMENT care of double slashes in id.kb.se paths from nginx
         // try to eliminate them there instead?
+        // AMBIGUOUS_PATH_SEPARATOR allows e.g. /term/gmgpc%2F%2Fswe/Kartor
+        // https://jetty.org/docs/jetty/12/programming-guide/server/compliance.html
+        // https://javadoc.jetty.org/jetty-12/org/eclipse/jetty/http/UriCompliance.Violation.html
         Arrays.stream(server.getConnectors()).forEach(
                 connector -> { connector
                         .getConnectionFactory(HttpConnectionFactory.class)
                         .getHttpConfiguration()
-                        .setUriCompliance(UriCompliance.DEFAULT.with("DOUBLE_SLASH", UriCompliance.Violation.AMBIGUOUS_EMPTY_SEGMENT));
+                        .setUriCompliance(UriCompliance.DEFAULT
+                                .with("DOUBLE_SLASH",
+                                        UriCompliance.Violation.AMBIGUOUS_EMPTY_SEGMENT,
+                                        UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR
+                                )
+                        );
                 }
         );
         var rewriteHandler = new RewriteHandler();


### PR DESCRIPTION
`http://id.kb.se/term/gmgpc/swe/Kartor` has sameAs `https://id.kb.se/term/gmgpc%2F%2Fswe/Kartor`. The latter results in a 400, specifically:
```
~ curl -i -H "Accept: application/json+ld" http://id.kb.se.localhost:8180/https://id.kb.se/term/gmgpc%2F%2Fswe/Kartor
HTTP/1.1 400 Bad Request
Server: Jetty(12.0.6)
...
<tr><th>CAUSED BY:</th><td>org.eclipse.jetty.http.BadMessageException: 400: Ambiguous URI path separator</td></tr>
```
Allowing [AMBIGIOUS_PATH_SEPARATOR](https://javadoc.jetty.org/jetty-12/org/eclipse/jetty/http/UriCompliance.Violation.html#AMBIGUOUS_PATH_SEPARATOR) fixes the problem (and _hopefully_ doesn't cause other issues, but I don't _think_ it will):
```
~ curl -i -H "Accept: application/json+ld" http://id.kb.se.localhost:8180/https://id.kb.se/term/gmgpc%2F%2Fswe/Kartor
HTTP/1.1 302 Found
Server: Jetty(12.0.6)
Date: Thu, 26 Sep 2024 11:22:48 GMT
Location: https://id.kb.se/term/gmgpc/swe/Kartor
```

(Also works through nginx / id.kb.se)

https://kbse.atlassian.net/browse/LXL-1469