### PR TITLE
fix(whelktool): Actually catch internal exceptions in processBatch

### DIFF
--- a/whelktool/scripts/examples/updatebyid.groovy
+++ b/whelktool/scripts/examples/updatebyid.groovy
@@ -1,5 +1,5 @@
 selectByIds([
-    'https://libris-dev.kb.se/j2vzn03v08lfhrm',
+    'j2vzn03v08lfhrm',
 ]) {
     it.scheduleSave()
 }


### PR DESCRIPTION
Thread.setDefaultUncaughtExceptionHandler had no effect here. Any exceptions thrown by the runnable will get swallowed by the executorservice. I think the intent was make it easier to find any future unintended exceptions in processBatch. (Exceptions thrown by the script are already handled inside processBatch.)

We also don't want to set the global UncaughtExceptionHandler when running Whelktool embedded.

Instead wrap the Runnable and catch any exceptions.