### PR TITLE
feat(rest-search): Add support for range prefix queries in nested documents

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -40,9 +40,10 @@ class ESQuery {
     private static final String NOT_PREFIX = 'not-'
     private static final String EXISTS_PREFIX = 'exists-'
 
+    private static final List<String> QUERY_RANGE_PREFIXES = [AND_MATCHES_PREFIX] + RangeParameterPrefix.values().collect{ it.prefix }
     // Prefixes are matched in this order so AND_MATCHES_PREFIX must be before AND_PREFIX.
-    private static final List<String> QUERY_PREFIXES = [AND_MATCHES_PREFIX, AND_PREFIX, OR_PREFIX,
-                                                        NOT_PREFIX, EXISTS_PREFIX]
+    private static final List<String> QUERY_PREFIXES = QUERY_RANGE_PREFIXES + [AND_PREFIX, OR_PREFIX, NOT_PREFIX,
+                                                                               EXISTS_PREFIX]
 
     private static final String FILTERED_AGG_NAME = 'a'
     private static final String NESTED_AGG_NAME = 'n'
@@ -762,12 +763,12 @@ class ESQuery {
             prefix: "@reverse.itemOf"
             nestedQuery: ["@reverse.itemOf.heldBy.@id":[".../library/A"], "not-@reverse.itemOf.availability.@id": ["X"] ]
         */
-        var andMatches = nestedQuery.findAll { it.key.startsWith(AND_MATCHES_PREFIX) }
-        var ands = nestedQuery.findAll { !it.key.startsWith(AND_MATCHES_PREFIX) && it.key.startsWith(AND_PREFIX) }
+        var ands = nestedQuery.findAll { it.key.startsWith(AND_PREFIX) && !it.key.startsWith(AND_MATCHES_PREFIX) }
         var nots = nestedQuery.findAll { it.key.startsWith(NOT_PREFIX) }
-        var rest = nestedQuery.findAll { !(it.key in nots.keySet() || it.key in ands.keySet() || it.key in andMatches.keySet()) }
+        var ranges = nestedQuery.findAll { e -> QUERY_RANGE_PREFIXES.any { p -> e.key.startsWith(p) } }
+        var rest = nestedQuery.findAll { !(it.key in nots.keySet() || it.key in ands.keySet() || it.key in ranges.keySet()) }
 
-        if (nots && !andMatches && !ands && !rest) {
+        if (nots && !ranges && !ands && !rest) {
             return nots.collect {
                 String prop = stripPrefix(it.key, NOT_PREFIX)
                 Q.not([Q.nested(prefix, createBoolFilter([(prop): it.value]))])
@@ -786,7 +787,7 @@ class ESQuery {
                     musts.add(createBoolFilter(it))
                 }
 
-                makeRangeFilters(andMatches).with { _, List rangeFilters ->
+                makeRangeFilters(ranges).with { _, List rangeFilters ->
                     musts.addAll(rangeFilters)
                 }
 

--- a/whelk-core/src/main/groovy/whelk/search/RangeParameterPrefix.java
+++ b/whelk-core/src/main/groovy/whelk/search/RangeParameterPrefix.java
@@ -7,7 +7,7 @@ public enum RangeParameterPrefix {
     MAX_EX("maxEx-"),
     MATCHES("matches-");
 
-    String prefix;
+    final String prefix;
 
     RangeParameterPrefix(String prefix) {
         this.prefix = prefix;
@@ -18,12 +18,12 @@ public enum RangeParameterPrefix {
     }
 
     String asElasticRangeOperator() {
-        switch(this) {
-            case MIN: return "gte";
-            case MIN_EX: return "gt";
-            case MAX: return "lte";
-            case MAX_EX: return "lt";
-            default: throw new IllegalArgumentException("No elastic operator for " + this);
-        }
+        return switch (this) {
+            case MIN -> "gte";
+            case MIN_EX -> "gt";
+            case MAX -> "lte";
+            case MAX_EX -> "lt";
+            default -> throw new IllegalArgumentException("No elastic operator for " + this);
+        };
     }
 }


### PR DESCRIPTION
The last TODO from https://github.com/libris/librisxl/pull/1486

Now `matches-`, `min-`, `minEx-`, `max-` and `maxEx-` also work.

Example:
http://libris.kb.se.localhost:5000/find?q=*&_limit=20&matches-@reverse.itemOf.subject.@id=https://queerlit.dh.gu.se/qlit/v1/os99go07&min-@reverse.itemOf.meta.modified=2024-01-01&_debug=esQuery

(Couldn't think of a better example of Item data to query right now. 
@reverse.itemOf.meta.modified is not indexed. But the query looks right.)
```
{
  "bool": {
    "must": [
      {
        "nested": {
          "path": "@reverse.itemOf",
          "query": {
            "bool": {
              "must": [
                {
                  "terms": {
                    "@reverse.itemOf.subject.@id": [
                      "https://queerlit.dh.gu.se/qlit/v1/os99go07",
                      "https://id.kb.se/term/sao/Poliser",
                      "https://id.kb.se/term/barn/Poliser",
                      "https://id.kb.se/term/sao/Kvarterspoliser",
                      "https://queerlit.dh.gu.se/qlit/v1/os99go07",
                      "https://id.kb.se/term/sao/Kvinnliga%20poliser",
                      "https://id.kb.se/term/sao/Milit%C3%A4rpoliser",
                      "https://id.kb.se/term/sao/S%C3%A4kerhetspolis"
                    ]
                  }
                },
                {
                  "range": {
                    "@reverse.itemOf.meta.modified": {
                      "gte": "2024-01-01"
                    }
                  }
                }
              ]
            }
          }
        }
      }
    ]
  }
}
```