### PR TITLE
Feature/bulk change match base type

### DIFF
--- a/whelktool/src/main/groovy/whelk/datatool/form/ModifiedThing.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/ModifiedThing.groovy
@@ -29,6 +29,10 @@ class ModifiedThing {
     }
 
     private Map modify(Map thing) {
+        if (!transform.matches(thing)) {
+            return thing
+        }
+
         if (!transform.getMatchFormVariants().any { isMatch(it, thing) }) {
             return thing
         }

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -30,41 +30,25 @@ class Transform {
     private static final String VALUE_FROM = 'valueFrom'
     private static final String ANY_TYPE = "Any"
     private static final String BASE_TYPE = "BaseType"
-
     private static final String BASE_TYPE_TMP_PROP = '_baseTypeTmp'
+    private static final String EXACT = 'Exact'
 
     Map matchForm
     Map targetForm
 
-    Set<List> exactMatchPaths
-
     List<List> addedPaths
     List<List> removedPaths
 
-    Map<String, Map> blankNodes
-
-    Map<String, List<String>> nodeIdMappings
+    Map<String, Set<String>> nodeIdMappings
     Map<String, Set<String>> baseTypeMappings
 
     List<ChangesForNode> changes
-
-    static enum MatchingMode {
-        EXACT('Exact'),
-        SUBSET('Subset')
-
-        String str
-
-        MatchingMode(String str) {
-            this.str = str
-        }
-    }
 
     Transform(Map matchForm, Map targetForm, Whelk whelk) {
         this.matchForm = matchForm
         this.targetForm = targetForm
         this.removedPaths = collectRemovedPaths()
         this.addedPaths = collectAddedPaths()
-        this.blankNodes = collectBlankNodes()
         this.nodeIdMappings = collectNodeIdMappings(whelk)
         this.baseTypeMappings = collectBaseTypeMappings(whelk?.jsonld)
     }
@@ -100,34 +84,16 @@ class Transform {
                     .collect { parentPath, changeList ->
                         new ChangesForNode(dropIndexes(parentPath),
                                 getAtPath(matchForm, parentPath) as Map,
-                                changeList,
-                                parentPath in exactMatchPaths ? MatchingMode.EXACT : MatchingMode.SUBSET)
+                                changeList)
                     }
         }
         return changes
     }
 
-    private Map<String, Map> collectBlankNodes() {
-        return collectBlankNodes(matchForm)
-    }
-
-    private static Map<String, Map> collectBlankNodes(Map form) {
-        Map<String, Map> bNodes = [:]
-        DocumentUtil.traverse(form) { value, path ->
-            if (value instanceof Map && value.containsKey(_ID)) {
-                bNodes[(String) value[_ID]] = value
-                return new DocumentUtil.Nop()
-            }
-        }
-        return bNodes
-    }
-
     private List<Remove> collectRemove() {
         return (List<Remove>) removedPaths.collect { fullPath ->
             asList(getAtPath(matchForm, fullPath)).collect { value ->
-                value instanceof Map
-                        ? new Remove(fullPath, value, exactMatchPaths.contains(fullPath) ? MatchingMode.EXACT : MatchingMode.SUBSET)
-                        : new Remove(fullPath, value, MatchingMode.EXACT)
+                new Remove(fullPath, value)
             }
         }.flatten()
     }
@@ -135,7 +101,7 @@ class Transform {
     private List<Add> collectAdd() {
         return (List<Add>) addedPaths.collect { fullPath ->
             asList(getAtPath(targetForm, fullPath)).collect { value ->
-                new Add(fullPath, value instanceof Map ? withoutAnyMarkers(value) : value)
+                new Add(fullPath, value)
             }
         }.flatten()
     }
@@ -189,101 +155,6 @@ class Transform {
         throw new Exception("Changing datatype of a value is not allowed.")
     }
 
-    private Set<List> collectExactMatchPaths() {
-        Set paths = []
-        DocumentUtil.findKey(matchForm, _MATCH) { value, path ->
-            if (value == MatchingMode.EXACT.str) {
-                paths.add(path.dropRight(1))
-                return new DocumentUtil.Nop()
-            }
-        }
-        return paths
-    }
-
-    Iterable<Map> getMatchFormVariants() {
-        return getFormVariants(matchForm)
-    }
-
-    private Iterable<Map> getFormVariants(Map form) {
-        Map bNodeIdToPath = [:]
-        DocumentUtil.findKey(form, _ID) { value, path ->
-            if (nodeIdMappings.containsKey(value) && value != getThingTmpId() && value != getRecordTmpId()) {
-                bNodeIdToPath[value] = path.dropRight(1)
-                return new DocumentUtil.Nop()
-            }
-        }
-
-        Map variant = withoutAnyMarkers(form)
-
-        if (bNodeIdToPath.isEmpty()) {
-            return [variant]
-        }
-
-        Iterator<Map> i = new Iterator<Map>() {
-            private def bNodeIds = bNodeIdToPath.keySet().toList()
-            private def idListLengths = bNodeIds.collect { nodeIdMappings[it].size() }
-            private def currentIndexes = bNodeIds.collect { 0 }
-            private def hasNext = true
-
-            @Override
-            boolean hasNext() {
-                return hasNext
-            }
-
-            @Override
-            Map next() {
-                // Set ids for current variant
-                [bNodeIds, currentIndexes].transpose().each { bNodeId, idx ->
-                    def path = bNodeIdToPath[bNodeId]
-                    def node = path.isEmpty() ? variant : getAtPath(variant, path)
-                    def mappedId = nodeIdMappings[bNodeId][idx]
-                    node[ID_KEY] = mappedId
-                }
-
-                // Update cursors
-                for (i in idListLengths.size() - 1..0) {
-                    if (currentIndexes[i] == idListLengths[i] - 1) {
-                        currentIndexes[i] = 0
-                        if (i == 0) {
-                            hasNext = false
-                        }
-                    } else {
-                        currentIndexes[i] += 1
-                        break
-                    }
-                }
-
-                // Return current variant
-                return variant
-            }
-        }
-
-        return () -> i
-    }
-
-    static Map withoutAnyMarkers(Map form) {
-        return withoutMarkers(form, this.&clearAllMarkers)
-    }
-
-    private static withoutMarkers(Map form, Closure clearMarkers) {
-        var f = (Map) Document.deepCopy(form)
-        clearMarkers(f)
-        return f
-    }
-
-    private static void clearAllMarkers(Object o) {
-        clearMarkers(o, [_ID, _MATCH, _ID_LIST, BASE_TYPE_TMP_PROP] as Set, [(TYPE_KEY): ANY_TYPE])
-    }
-
-    private static void clearMarkers(Object o, Set<String> keys, Map<String, Object> keyValuePairs) {
-        DocumentUtil.traverse(o) { v, p ->
-            if (v instanceof Map) {
-                v.removeAll { keys.contains(it.key) || (it.value != null && keyValuePairs[it.key] == it.value) }
-                return new DocumentUtil.Nop()
-            }
-        }
-    }
-
     private static List dropLastIndex(List path) {
         return !path.isEmpty() && path.last() instanceof Integer ? path.dropRight(1) : path
     }
@@ -312,24 +183,22 @@ class Transform {
     private Map getSparqlPreparedForm() {
         Map matchFormCopy = (Map) Document.deepCopy(matchForm)
 
-        collectBlankNodes(matchFormCopy).each { _id, node ->
-            node.keySet().each { k ->
-                if (asList(node[k]).isEmpty()) {
-                    node[k] = [:]
+        DocumentUtil.traverse(matchFormCopy) { node, path ->
+            if (node instanceof Map) {
+                def _id = node.remove(_ID)
+                if (!_id) return
+                node.remove(_ID_LIST)
+                if (node[TYPE_KEY] == ANY_TYPE) {
+                    node.remove(TYPE_KEY)
                 }
-            }
-            node.remove(_ID)
-            node.remove(_ID_LIST)
-            if (node[TYPE_KEY] == ANY_TYPE) {
-                node.remove(TYPE_KEY)
-            }
-            def _match = asList(node.remove(_MATCH))
-            if (_match.contains(BASE_TYPE)) {
-                def baseType = node.remove(TYPE_KEY)
-                node[BASE_TYPE_TMP_PROP] = baseType
-            }
-            if (nodeIdMappings.containsKey(_id)) {
-                node[ID_KEY] = _id
+                if (asList(node.remove(_MATCH)).contains(BASE_TYPE)) {
+                    def baseType = node.remove(TYPE_KEY)
+                    node[BASE_TYPE_TMP_PROP] = baseType
+                }
+                if (nodeIdMappings.containsKey(_id)) {
+                    node[ID_KEY] = _id
+                }
+                return new DocumentUtil.Nop()
             }
         }
 
@@ -338,8 +207,8 @@ class Transform {
 
     private String insertVars(String ttl) {
         def substitutions = [
-                ("<" + getThingTmpId() + ">")        : getVar(getThingTmpId()),
-                ("<" + getRecordTmpId() + ">")       : getVar(getRecordTmpId())
+                ("<" + getThingTmpId() + ">") : getVar(getThingTmpId()),
+                ("<" + getRecordTmpId() + ">"): getVar(getRecordTmpId())
         ]
 
         baseTypeMappings.keySet().each { baseType ->
@@ -381,27 +250,26 @@ class Transform {
                 .trim()
     }
 
-    Map<String, List<String>> collectNodeIdMappings(Whelk whelk) {
-        Map<String, List<String>> nodeIdMappings = [:]
+    Map<String, Set<String>> collectNodeIdMappings(Whelk whelk) {
+        Map<String, Set<String>> nodeIdMappings = [:]
 
         IdLoader idLoader = whelk ? new IdLoader(whelk.storage) : null
 
         DocumentUtil.traverse(matchForm) { node, path ->
             if (node instanceof Map && node.containsKey(_ID_LIST)) {
                 def idList = node[_ID_LIST]
-                def ids = idList[VALUE] as List<String>
-                        ?: (idList[VALUE_FROM] ? IdLoader.fromFile((String) idList[VALUE_FROM][ID_KEY]) : [])
+                def ids = (idList[VALUE] ?: (idList[VALUE_FROM] ? IdLoader.fromFile((String) idList[VALUE_FROM][ID_KEY]) : [])) as Set<String>
                 if (ids) {
-                    def nodeId = (String) node[_ID]
-
-                    if (!idLoader) {
-                        nodeIdMappings[nodeId] = ids
-                        return
-                    }
+                    String nodeId = node[_ID]
 
                     def (iris, shortIds) = ids.split(JsonLd::looksLikeIri)
                     if (shortIds.isEmpty()) {
                         nodeIdMappings[nodeId] = iris
+                        return
+                    }
+
+                    if (!idLoader) {
+                        nodeIdMappings[nodeId] = iris + shortIds.collect { Document.BASE_URI.toString() + it + Document.HASH_IT }
                         return
                     }
 
@@ -434,11 +302,12 @@ class Transform {
             return mappings
         }
 
-        blankNodes.each { _id, node ->
-            if (node.containsKey(_MATCH) && ((List) node[_MATCH]).contains(BASE_TYPE)) {
+        DocumentUtil.traverse(matchForm) { node, path ->
+            if (node instanceof Map && node.containsKey(_MATCH) && ((List) node[_MATCH]).contains(BASE_TYPE)) {
                 def baseType = (String) node[TYPE_KEY]
                 Set<String> subTypes = getSubtypes(baseType, jsonLd) as Set
-                baseTypeMappings[baseType] = subTypes
+                mappings[baseType] = subTypes
+                return new DocumentUtil.Nop()
             }
         }
 
@@ -458,37 +327,76 @@ class Transform {
         return getAtPath(matchForm, [RECORD_KEY, _ID], "TEMP_ID")
     }
 
-    boolean matches(Map form, Map thing) {
-        // TODO
-        return true
+    boolean matches(Object node) {
+        return matches(matchForm, node)
     }
 
-    static boolean isSubset(Object a, Object b) {
-        return comparator.isSubset(a, b)
+    boolean matches(Object matchForm, Object node) {
+        return comparator.isSubset(["x": matchForm], ["x": node], this::_matches)
     }
 
-    static boolean isEqual(Object a, Object b) {
-        return comparator.isEqual(["x": a], ["x": b], Transform::isEqualNoType)
-    }
-
-    private static boolean isEqualNoType(Map a, Map b) {
-        if (a == null || b == null) {
+    private boolean _matches(Map matchForm, Map bNode) {
+        if (matchForm == null || bNode == null) {
             return false
         }
-        if (a.size() != b.size()) {
-            if (!a.containsKey(TYPE_KEY) && b.containsKey(TYPE_KEY)) {
-                b = new HashMap<>(b)
-                b.remove(TYPE_KEY)
-                return comparator.isEqual(a, b, Transform::isEqualNoType)
+        matchForm = new HashMap(matchForm)
+        def match = asList(matchForm[_MATCH])
+        if (match.contains(EXACT)) {
+            return exactMatches(matchForm, bNode)
+        }
+        if (match.contains(BASE_TYPE)) {
+            String aType = matchForm[TYPE_KEY]
+            String bType = bNode[TYPE_KEY]
+            if (!(baseTypeMappings[aType] + aType).contains(bType)) {
+                return false
+            } else {
+                matchForm.remove(TYPE_KEY)
             }
-            if (a.containsKey(TYPE_KEY) && !b.containsKey(TYPE_KEY)) {
-                a = new HashMap<>(a)
-                a.remove(TYPE_KEY)
-                return comparator.isEqual(a, b, Transform::isEqualNoType)
-            }
+        }
+        matchForm.remove(_MATCH)
+        if (matchForm[TYPE_KEY] == ANY_TYPE) {
+            matchForm.remove(TYPE_KEY)
+        }
+        def ids = nodeIdMappings[matchForm.remove(_ID)]
+        if (ids && !ids.contains(bNode[ID_KEY])) {
             return false
         }
-        return comparator.isEqual(a, b, Transform::isEqualNoType)
+        matchForm.remove(_ID_LIST)
+        if (matchForm.size() > bNode.size()) {
+            return false
+        }
+        return comparator.isSubset(matchForm, bNode, this::_matches)
+    }
+
+    private boolean exactMatches(Map matchForm, Map bNode) {
+        if (matchForm == null || bNode == null) {
+            return false
+        }
+        matchForm = new HashMap(matchForm)
+        bNode = new HashMap(bNode)
+        if (asList(matchForm.remove(_MATCH)).contains(BASE_TYPE)) {
+            String aType = matchForm[TYPE_KEY]
+            String bType = bNode[TYPE_KEY]
+            if ((baseTypeMappings[aType] + aType).contains(bType)) {
+                matchForm.remove(TYPE_KEY)
+                bNode.remove(TYPE_KEY)
+            } else {
+                return false
+            }
+        }
+        if (matchForm[TYPE_KEY] == ANY_TYPE) {
+            matchForm.remove(TYPE_KEY)
+            bNode.remove(TYPE_KEY)
+        }
+        def ids = nodeIdMappings[matchForm.remove(_ID)]
+        if (ids && !ids.contains(bNode[ID_KEY])) {
+            return false
+        }
+        matchForm.remove(_ID_LIST)
+        if (matchForm.size() != bNode.size()) {
+            return false
+        }
+        return comparator.isEqual(matchForm, bNode, this::exactMatches)
     }
 
     // Need a better name for this...
@@ -496,26 +404,15 @@ class Transform {
         List<String> propertyPath
         Map form
         List<Change> changeList
-        private MatchingMode matchingMode
 
-        ChangesForNode(List<String> propertyPath, Map form, List<Change> changeList, MatchingMode matchingMode) {
+        ChangesForNode(List<String> propertyPath, Map form, List<Change> changeList) {
             this.propertyPath = propertyPath
             this.form = form
             this.changeList = changeList
-            this.matchingMode = matchingMode
         }
 
         boolean matches(Map node) {
-            return formMatches(node) && removeMatches(node)
-        }
-
-        private formMatches(Map node) {
-            getFormVariants(form).any { f ->
-                switch (matchingMode) {
-                    case MatchingMode.EXACT: return isEqual(f, node)
-                    case MatchingMode.SUBSET: return isSubset(f, node)
-                }
-            }
+            return matches(form, node) && removeMatches(node)
         }
 
         private removeMatches(Map node) {
@@ -542,15 +439,14 @@ class Transform {
         String property() {
             return propertyPath().last()
         }
+
+        abstract boolean matches(Object o)
     }
 
     class Remove extends Change {
-        private final MatchingMode matchingMode
-
-        Remove(List path, Object value, MatchingMode matchingMode) {
+        Remove(List path, Object value) {
             this.path = path
             this.value = value
-            this.matchingMode = matchingMode
         }
 
         boolean matches(String property, Object o) {
@@ -558,15 +454,7 @@ class Transform {
         }
 
         boolean matches(Object o) {
-            if (property() == TYPE_KEY && value == ANY_TYPE) {
-                return true
-            }
-            return (value instanceof Map ? getFormVariants(value) : [value]).any { v ->
-                switch (matchingMode) {
-                    case MatchingMode.EXACT: return isEqual(v, o)
-                    case MatchingMode.SUBSET: return isSubset(v, o)
-                }
-            }
+            return Transform.this.matches(value, o) || (property() == TYPE_KEY && value == ANY_TYPE)
         }
     }
 
@@ -575,6 +463,14 @@ class Transform {
         Add(List path, Object value) {
             this.path = path
             this.value = value
+        }
+
+        Add(Object value) {
+            this(null, value)
+        }
+
+        boolean matches(Object o) {
+            return comparator.isEqual(["x": value], ["x": o])
         }
     }
 

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -200,6 +200,9 @@ class Transform {
                 }
                 return new DocumentUtil.Nop()
             }
+            if (asList(node).isEmpty()) {
+                return new DocumentUtil.Replace([:])
+            }
         }
 
         return matchFormCopy

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -29,8 +29,8 @@ class Transform {
     private static final String VALUE = 'value'
     private static final String VALUE_FROM = 'valueFrom'
     private static final String ANY_TYPE = "Any"
-    private static final String BASE_TYPE = "BaseType"
-    private static final String BASE_TYPE_TMP_PROP = '_baseTypeTmp'
+    private static final String SUBTYPES = "Subtypes"
+    private static final String HAS_BASE_TYPE_TMP = '_hasBaseTypeTmp'
     private static final String EXACT = 'Exact'
 
     Map matchForm
@@ -191,9 +191,9 @@ class Transform {
                 if (node[TYPE_KEY] == ANY_TYPE) {
                     node.remove(TYPE_KEY)
                 }
-                if (asList(node.remove(_MATCH)).contains(BASE_TYPE)) {
+                if (asList(node.remove(_MATCH)).contains(SUBTYPES)) {
                     def baseType = node.remove(TYPE_KEY)
-                    node[BASE_TYPE_TMP_PROP] = baseType
+                    node[HAS_BASE_TYPE_TMP] = baseType
                 }
                 if (nodeIdMappings.containsKey(_id)) {
                     node[ID_KEY] = _id
@@ -215,7 +215,7 @@ class Transform {
         ]
 
         baseTypeMappings.keySet().each { baseType ->
-            substitutions.put(":$BASE_TYPE_TMP_PROP \"$baseType\"".toString(), "a ?" + baseType)
+            substitutions.put(":$HAS_BASE_TYPE_TMP \"$baseType\"".toString(), "a ?" + baseType)
         }
 
         nodeIdMappings.keySet().each { _id ->
@@ -306,7 +306,7 @@ class Transform {
         }
 
         DocumentUtil.traverse(matchForm) { node, path ->
-            if (node instanceof Map && node.containsKey(_MATCH) && ((List) node[_MATCH]).contains(BASE_TYPE)) {
+            if (node instanceof Map && node.containsKey(_MATCH) && ((List) node[_MATCH]).contains(SUBTYPES)) {
                 def baseType = (String) node[TYPE_KEY]
                 Set<String> subTypes = getSubtypes(baseType, jsonLd) as Set
                 mappings[baseType] = subTypes
@@ -347,7 +347,7 @@ class Transform {
         if (match.contains(EXACT)) {
             return exactMatches(matchForm, bNode)
         }
-        if (match.contains(BASE_TYPE)) {
+        if (match.contains(SUBTYPES)) {
             String aType = matchForm[TYPE_KEY]
             String bType = bNode[TYPE_KEY]
             if (!(baseTypeMappings[aType] + aType).contains(bType)) {
@@ -377,7 +377,7 @@ class Transform {
         }
         matchForm = new HashMap(matchForm)
         bNode = new HashMap(bNode)
-        if (asList(matchForm.remove(_MATCH)).contains(BASE_TYPE)) {
+        if (asList(matchForm.remove(_MATCH)).contains(SUBTYPES)) {
             String aType = matchForm[TYPE_KEY]
             String bType = bNode[TYPE_KEY]
             if ((baseTypeMappings[aType] + aType).contains(bType)) {

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -31,7 +31,6 @@ class Transform {
     private static final String ANY_TYPE = "Any"
     private static final String BASE_TYPE = "BaseType"
 
-    private static final String EMPTY_BLANK_NODE_TMP_ID = "EMPTY_BN_ID"
     private static final String BASE_TYPE_TMP_PROP = '_baseTypeTmp'
 
     Map matchForm
@@ -314,6 +313,11 @@ class Transform {
         Map matchFormCopy = (Map) Document.deepCopy(matchForm)
 
         collectBlankNodes(matchFormCopy).each { _id, node ->
+            node.keySet().each { k ->
+                if (asList(node[k]).isEmpty()) {
+                    node[k] = [:]
+                }
+            }
             node.remove(_ID)
             node.remove(_ID_LIST)
             if (node[TYPE_KEY] == ANY_TYPE) {
@@ -327,9 +331,6 @@ class Transform {
             if (nodeIdMappings.containsKey(_id)) {
                 node[ID_KEY] = _id
             }
-            if (node.isEmpty()) {
-                node[ID_KEY] = EMPTY_BLANK_NODE_TMP_ID
-            }
         }
 
         return matchFormCopy
@@ -338,11 +339,10 @@ class Transform {
     private String insertVars(String ttl) {
         def substitutions = [
                 ("<" + getThingTmpId() + ">")        : getVar(getThingTmpId()),
-                ("<" + getRecordTmpId() + ">")       : getVar(getRecordTmpId()),
-                ("<" + EMPTY_BLANK_NODE_TMP_ID + ">"): "[]",
+                ("<" + getRecordTmpId() + ">")       : getVar(getRecordTmpId())
         ]
 
-        baseTypeMappings.keySet().each { baseType  ->
+        baseTypeMappings.keySet().each { baseType ->
             substitutions.put(":$BASE_TYPE_TMP_PROP \"$baseType\"".toString(), "a ?" + baseType)
         }
 

--- a/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
@@ -130,11 +130,11 @@ class TransformSpec extends Specification {
     def "form to sparql pattern: unspecified types"() {
         given:
         def form = [
-                '_id'  : '#1',
-                '@type': 'Any',
-                'p1'   : ['_id': '#2', '@type': 'Any'],
-                'p2'   : ['_id': '#3', '@type': 'Any', 'p': 'v'],
-                'marc:p'   : ['_id': '#4', '@type': 'marc:T', 'p': 'v']
+                '_id'   : '#1',
+                '@type' : 'Any',
+                'p1'    : ['_id': '#2', '@type': 'Any'],
+                'p2'    : ['_id': '#3', '@type': 'Any', 'p': 'v'],
+                'marc:p': ['_id': '#4', '@type': 'marc:T', 'p': 'v']
         ]
 
         def expectedPattern = "?graph :mainEntity ?1 .\n" +
@@ -146,6 +146,26 @@ class TransformSpec extends Specification {
 
         expect:
         new Transform.MatchForm(form).getSparqlPattern(context) == expectedPattern
+    }
+
+    def "form to sparql pattern: base types"() {
+        given:
+        def form = [
+                '_id'   : '#1',
+                '@type' : 'T1',
+                '_match': ['BaseType']
+        ]
+
+        def expectedPattern = "VALUES ?T1 { :T1 :T1x :T1y :T1z }\n" +
+                "?graph :mainEntity ?1 .\n" +
+                "\n" +
+                "?1 a ?T1 ."
+
+        def transform = new Transform.MatchForm(form)
+        transform.baseTypeMappings['T1'] = ['T1x', 'T1y', 'T1z'] as Set
+
+        expect:
+        transform.getSparqlPattern(context) == expectedPattern
     }
 
     def "is equal"() {
@@ -160,7 +180,7 @@ class TransformSpec extends Specification {
         Transform.isEqual(a, c)
         !Transform.isEqual(b, c)
         Transform.isEqual(["p": [["a": "b"], a]], ["p": [a, ["a": "b"]]])
-        Transform.isEqual(["p": [["a":"b"], a]], ["p": [b, ["a":"b"]]])
-        !Transform.isEqual(["p": [["a":"b"], c]], ["p": [b, ["a":"b"]]])
+        Transform.isEqual(["p": [["a": "b"], a]], ["p": [b, ["a": "b"]]])
+        !Transform.isEqual(["p": [["a": "b"], c]], ["p": [b, ["a": "b"]]])
     }
 }

--- a/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
@@ -61,7 +61,7 @@ class TransformSpec extends Specification {
     def "form to sparql pattern: null/empty value"() {
         given:
         def form = ['_id': '#1', 'p1': v]
-        def expectedPattern = "?graph :mainEntity ?1 .\n\n?1 :p1 [] ."
+        def expectedPattern = "?graph :mainEntity ?1 .\n\n?1 :p1 [ ] ."
 
         expect:
         new Transform.MatchForm(form).getSparqlPattern(context) == expectedPattern
@@ -72,8 +72,8 @@ class TransformSpec extends Specification {
 
     def "form to sparql pattern: nested null/empty value"() {
         given:
-        def form = ['_id': '#1', 'p1': ['p2': v]]
-        def expectedPattern = "?graph :mainEntity ?1 .\n\n?1 :p1 [ :p2 [] ] ."
+        def form = ['_id': '#1', 'p1': ['_id': '#2', 'p2': v]]
+        def expectedPattern = "?graph :mainEntity ?1 .\n\n?1 :p1 [ :p2 [ ] ] ."
 
         expect:
         new Transform.MatchForm(form).getSparqlPattern(context) == expectedPattern
@@ -139,7 +139,7 @@ class TransformSpec extends Specification {
 
         def expectedPattern = "?graph :mainEntity ?1 .\n" +
                 "\n" +
-                "?1 :p1 [] ;\n" +
+                "?1 :p1 [ ] ;\n" +
                 "  :p2 [ :p \"v\" ] ;\n" +
                 "  marc:p [ a marc:T ;\n" +
                 "      :p \"v\" ] ."

--- a/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/form/TransformSpec.groovy
@@ -153,7 +153,7 @@ class TransformSpec extends Specification {
         def form = [
                 '_id'   : '#1',
                 '@type' : 'T1',
-                '_match': ['BaseType']
+                '_match': ['Subtypes']
         ]
 
         def expectedPattern = "VALUES ?T1 { :T1 :T1x :T1y :T1z }\n" +
@@ -185,10 +185,10 @@ class TransformSpec extends Specification {
         ["x": "a"]                                                | ["x": ["a", "b"]]                           | true
         ["x": "a", "_match": ["Exact"]]                           | ["x": ["a", "b"]]                           | false
         ["x": ["a", "b"], "_match": ["Exact"]]                    | ["x": ["a", "b"]]                           | true
-        ["@type": "T", "_match": ["BaseType"], "a": "b"]          | ["@type": "Tx", "a": "b"]                   | true
+        ["@type": "T", "_match": ["Subtypes"], "a": "b"]          | ["@type": "Tx", "a": "b"]                   | true
         ["@type": "T", "a": "b"]                                  | ["@type": "Tx", "a": "b"]                   | false
-        ["@type": "T", "_match": ["BaseType", "Exact"], "a": "b"] | ["@type": "Ty", "a": "b"]                   | true
-        ["@type": "T", "_match": ["BaseType", "Exact"], "a": "b"] | ["@type": "Ty", "a": "b", "c": "d"]         | false
+        ["@type": "T", "_match": ["Subtypes", "Exact"], "a": "b"] | ["@type": "Ty", "a": "b"]                   | true
+        ["@type": "T", "_match": ["Subtypes", "Exact"], "a": "b"] | ["@type": "Ty", "a": "b", "c": "d"]         | false
         ["@type": "Any", "a": "b"]                                | ["@type": "T", "a": "b", "c": "d"]          | true
         ["@type": "Any", "a": "b", "_match": ["Exact"]]           | ["@type": "T", "a": "b", "c": "d"]          | false
         ["x": ["_id": "#1"]]                                      | ["x": ["@id": "https://libris.kb.se/y#it"]] | true

--- a/whelktool/src/test/groovy/whelk/datatool/util/DocumentComparatorSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/util/DocumentComparatorSpec.groovy
@@ -6,7 +6,6 @@ import spock.lang.Specification
 import static whelk.util.Jackson.mapper
 
 class DocumentComparatorSpec extends Specification {
-    
     def "isEqual"() {
         given:
         DocumentComparator d = new DocumentComparator({ o -> ("ordered" == o) })
@@ -51,6 +50,10 @@ class DocumentComparatorSpec extends Specification {
         [1: 2]                                      | [1: 1]                                                          || false
         [:]                                         | [1: [2: 2]]                                                     || true
         [1: [:]]                                    | [1: [2: 2]]                                                     || true
+        ["x": "a"]                                  | ["x": ["a"]]                                                    || true
+        ["x": ["a"]]                                | ["x": "a"]                                                      || true
+        ["x": "a"]                                  | ["x": ["a", "b"]]                                               || true
+        ["x": ["a", "b"]]                           | ["x": "a"]                                                      || false
         ["x": ["b", "c"]]                           | ["x": ["a", "b", "c"]]                                          || true
         ["x": ["c", "a"]]                           | ["x": ["a", "b", "c"]]                                          || true
         ["x": ["a", "a"]]                           | ["x": ["a"]]                                                    || false

--- a/whelktool/src/test/resources/whelk/datatool/form/specs.json
+++ b/whelktool/src/test/resources/whelk/datatool/form/specs.json
@@ -3145,10 +3145,30 @@
       "targetForm": {
         "_id": "1",
         "p1": {
-          "_id": "2"
+          "_id": "2",
+          "_idList": [
+            {
+              "@type": "AnyOf",
+              "value": [
+                "https://id.kb.se/x",
+                "https://id.kb.se/y",
+                "https://id.kb.se/z"
+              ]
+            }
+          ]
         },
         "p2": {
-          "_id": "3"
+          "_id": "3",
+          "_idList": [
+            {
+              "@type": "AnyOf",
+              "value": [
+                "https://id.kb.se/a",
+                "https://id.kb.se/b",
+                "https://id.kb.se/c"
+              ]
+            }
+          ]
         }
       },
       "removedPaths": [

--- a/whelktool/src/test/resources/whelk/datatool/form/specs.json
+++ b/whelktool/src/test/resources/whelk/datatool/form/specs.json
@@ -2680,7 +2680,6 @@
         "p2": {
           "_id": "2",
           "p3": {
-            "@type": "Any",
             "p4": {
               "@id": "https://id.kb.se/x"
             }
@@ -3116,29 +3115,25 @@
         "_id": "1",
         "p1": {
           "_id": "2",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/x",
-                "https://id.kb.se/y",
-                "https://id.kb.se/z"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/x",
+              "https://id.kb.se/y",
+              "https://id.kb.se/z"
+            ]
+          }
         },
         "p2": {
           "_id": "3",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/a",
-                "https://id.kb.se/b",
-                "https://id.kb.se/c"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/a",
+              "https://id.kb.se/b",
+              "https://id.kb.se/c"
+            ]
+          }
         },
         "p3": "v3"
       },
@@ -3146,29 +3141,25 @@
         "_id": "1",
         "p1": {
           "_id": "2",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/x",
-                "https://id.kb.se/y",
-                "https://id.kb.se/z"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/x",
+              "https://id.kb.se/y",
+              "https://id.kb.se/z"
+            ]
+          }
         },
         "p2": {
           "_id": "3",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/a",
-                "https://id.kb.se/b",
-                "https://id.kb.se/c"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/a",
+              "https://id.kb.se/b",
+              "https://id.kb.se/c"
+            ]
+          }
         }
       },
       "removedPaths": [
@@ -3202,16 +3193,14 @@
         "_id": "1",
         "p1": {
           "_id": "2",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/x",
-                "https://id.kb.se/y",
-                "https://id.kb.se/z"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/x",
+              "https://id.kb.se/y",
+              "https://id.kb.se/z"
+            ]
+          }
         },
         "p2": "v2"
       },
@@ -3242,16 +3231,14 @@
         "r1": [
           {
             "_id": "2",
-            "_idList": [
-              {
-                "@type": "AnyOf",
-                "value": [
-                  "https://id.kb.se/x",
-                  "https://id.kb.se/y",
-                  "https://id.kb.se/z"
-                ]
-              }
-            ]
+            "_idList": {
+              "@type": "AnyOf",
+              "value": [
+                "https://id.kb.se/x",
+                "https://id.kb.se/y",
+                "https://id.kb.se/z"
+              ]
+            }
           }
         ],
         "p2": "v2"
@@ -3295,16 +3282,14 @@
         "_id": "1",
         "p1": {
           "_id": "2",
-          "_idList": [
-            {
-              "@type": "AnyOf",
-              "value": [
-                "https://id.kb.se/x",
-                "https://id.kb.se/y",
-                "https://id.kb.se/z"
-              ]
-            }
-          ]
+          "_idList": {
+            "@type": "AnyOf",
+            "value": [
+              "https://id.kb.se/x",
+              "https://id.kb.se/y",
+              "https://id.kb.se/z"
+            ]
+          }
         },
         "p2": "v2"
       },
@@ -3345,16 +3330,14 @@
         "r1": [
           {
             "_id": "2",
-            "_idList": [
-              {
-                "@type": "AnyOf",
-                "value": [
-                  "https://id.kb.se/x",
-                  "https://id.kb.se/y",
-                  "https://id.kb.se/z"
-                ]
-              }
-            ]
+            "_idList": {
+              "@type": "AnyOf",
+              "value": [
+                "https://id.kb.se/x",
+                "https://id.kb.se/y",
+                "https://id.kb.se/z"
+              ]
+            }
           }
         ],
         "p2": "v2"
@@ -3370,12 +3353,14 @@
       },
       "removedPaths": [
         [
-          "r1", 0
+          "r1",
+          0
         ]
       ],
       "addedPaths": [
         [
-          "r1", 0
+          "r1",
+          0
         ]
       ],
       "before": {


### PR DESCRIPTION
Use  `_match: BaseType` to express that all subclasses of a type should be matched, e.g.:
```
"matchForm": {
        "_id": "#1",
        "@type": "Instance",
        "_match": ["BaseType"]
      }
```

I've reworked the code quite a bit once again, mainly to make it more efficient now that we end up with even more variants of the form to match (different ids, different types).