### PR TITLE
Feature/bulk create

### DIFF
--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -147,7 +147,6 @@ class WhelkTool {
         if (!silent) {
             log "Select by ${ids.size()} IDs"
         }
-
         def idItems = idLoader.collectXlShortIds(ids)
         if (idItems.isEmpty()) {
             return

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -162,7 +162,7 @@ class Transform {
         return path.findAll { it instanceof String } as List<String>
     }
 
-    private static Map<String, List> collectNodeIdToPath(Map form) {
+    static Map<String, List> collectNodeIdToPath(Map form) {
         Map<String, List> nodeIdToPath = [:]
         DocumentUtil.findKey(form, _ID) { _id, path ->
             nodeIdToPath[(String) _id] = path.dropRight(1)
@@ -262,11 +262,15 @@ class Transform {
     }
 
     Map<String, Set<String>> collectNodeIdMappings(Whelk whelk) {
+        return collectNodeIdMappings(matchForm, whelk)
+    }
+
+    static Map<String, Set<String>> collectNodeIdMappings(Map form, Whelk whelk) {
         Map<String, Set<String>> nodeIdMappings = [:]
 
         IdLoader idLoader = whelk ? new IdLoader(whelk.storage) : null
 
-        DocumentUtil.traverse(matchForm) { node, path ->
+        DocumentUtil.traverse(form) { node, path ->
             if (!(node instanceof Map)) {
                 return
             }

--- a/whelktool/src/main/resources/bulk-change-scripts/create.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/create.groovy
@@ -1,5 +1,6 @@
 import whelk.Document
 import whelk.datatool.form.Transform
+import whelk.util.DocumentUtil
 
 import static whelk.JsonLd.GRAPH_KEY
 import static whelk.JsonLd.ID_KEY
@@ -7,6 +8,7 @@ import static whelk.JsonLd.RECORD_KEY
 import static whelk.JsonLd.THING_KEY
 import static whelk.JsonLd.TYPE_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.TARGET_FORM_KEY
+import static whelk.util.DocumentUtil.traverse
 
 Map targetForm = parameters.get(TARGET_FORM_KEY)
 
@@ -36,6 +38,8 @@ selectByIds(ids) {
     }
 }
 
+clearBulkTerms(targetForm)
+
 def docs = verifiedUris.collect { uri ->
     Map thing = Document.deepCopy(targetForm) as Map
     Map varyingNode = getAtPath(thing, varyingNodePath)
@@ -50,4 +54,13 @@ def docs = verifiedUris.collect { uri ->
 
 selectFromIterable(docs) {
     it.scheduleSave()
+}
+
+static void clearBulkTerms(Map form) {
+    traverse(form) { node, path ->
+        if (node instanceof Map) {
+            node.removeAll { ((String) it.key).startsWith("bulk:") }
+            return new DocumentUtil.Nop()
+        }
+    }
 }

--- a/whelktool/src/main/resources/bulk-change-scripts/create.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/create.groovy
@@ -1,5 +1,53 @@
+import whelk.Document
+import whelk.datatool.form.Transform
+
+import static whelk.JsonLd.GRAPH_KEY
+import static whelk.JsonLd.ID_KEY
+import static whelk.JsonLd.RECORD_KEY
+import static whelk.JsonLd.THING_KEY
+import static whelk.JsonLd.TYPE_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.TARGET_FORM_KEY
 
 Map targetForm = parameters.get(TARGET_FORM_KEY)
 
-// TODO
+Map<String, Set<String>> nodeIdMappings = Transform.collectNodeIdMappings(targetForm, getWhelk())
+
+if (nodeIdMappings.size() != 1) {
+    // Allow only one id list
+    return
+}
+
+def varyingNodeId = nodeIdMappings.keySet().find()
+def varyingNodePath = Transform.collectNodeIdToPath(targetForm)[varyingNodeId]
+def ids = nodeIdMappings.values().find()
+
+if (varyingNodePath == [] || varyingNodePath == [RECORD_KEY]) {
+    // Ids must not apply to thing or record
+    return
+}
+
+def verifiedUris = Collections.synchronizedSet()
+selectByIds(ids) {
+    def (record, thing) = it.graph
+    def recordId = record[ID_KEY]
+    def thingId = thing[ID_KEY]
+    if (ids.contains(recordId)) {
+        verifiedUris.add(ids.contains(recordId) ? recordId : thingId)
+    }
+}
+
+def docs = verifiedUris.collect { uri ->
+    Map thing = Document.deepCopy(targetForm) as Map
+    Map varyingNode = getAtPath(thing, varyingNodePath)
+    varyingNode.clear()
+    varyingNode[ID_KEY] = uri
+    Map record = (Map) thing.remove(RECORD_KEY) ?: [(TYPE_KEY): RECORD_KEY]
+    thing[ID_KEY] = "TEMPID#it"
+    record[ID_KEY] = "TEMPID"
+    record[THING_KEY] = [(ID_KEY): "TEMPID#it"]
+    return create([(GRAPH_KEY): [thing, record]])
+}
+
+selectFromIterable(docs) {
+    it.scheduleSave()
+}


### PR DESCRIPTION
I think this is all that's needed (in backend) to create records from a target form. The target form itself should suffice as preview for now.

The script expects exactly one id list attached in the target form and it must not be attached to the thing or record. This could maybe be restricted already in the interface. One record per unique and valid id in the list will be created.

For example
```
{
    "bulk:formBlankNodeId": "#1"
    "@type": "Item",
    "heldBy": {"@id": "https://libris.kb.se/library/SEK"},
    "hasComponent": [
        {
            "bulk:formBlankNodeId": "#2"
            "@type": "Item",
            "heldBy": {"@id": "https://libris.kb.se/library/SEK"}
        }
    ],
    "itemOf": { 
        "bulk:formBlankNodeId": "#3",
        "bulk:hasId": [
            {
                "bulk:formBlankNodeId": "#4"
                "@type": "bulk:AnyOf",
                "value": [
                    "gzrmdkks2zw7zs6",
                    "j1thr9kv2jbjk34",
                    "r93gg3c32rgcg2f"
                ]
            }
        ]
    }
}
```
would create three holding records with different links in itemOf.