### PR TITLE
Feature/bulk merge

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/BulkChangePreviewAPI.java
+++ b/rest/src/main/groovy/whelk/rest/api/BulkChangePreviewAPI.java
@@ -57,11 +57,12 @@ public class BulkChangePreviewAPI extends HttpServlet {
 
             var changeDoc = load(systemId);
 
-            // TODO? let Specifications create their own previews?
+            // TODO? let Specifications create their own previews? create preview in Whelktool instead?
             var result = switch (changeDoc.getSpecification()) {
                 case Specification.Update update -> makePreview(update, offset, limit, id);
                 case Specification.Delete delete -> makePreview(delete, offset, limit, id);
-                case Specification.Create create -> Collections.emptyMap(); //TODO
+                case Specification.Create ignored -> Collections.emptyMap();
+                case Specification.Merge ignored -> Collections.emptyMap();
             };
 
             // TODO support turtle etc?

--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -912,29 +912,12 @@ class DocumentItem {
         whelk.storage.loadAllVersions(doc.shortId)
     }
 
+    def getDependers() {
+        whelk.storage.getDependers(doc.shortId)
+    }
+
     Map asCard(boolean withSearchKey = false) {
         return whelk.jsonld.toCard(doc.data, false, withSearchKey)
-    }
-    
-    boolean modify(Map matchForm, Map targetForm) {
-        Map thing = (Map) this.graph[1]
-        thing[RECORD_KEY] = (Map) this.graph[0]
-
-        var m = new ModifiedThing(
-                thing,
-                new Transform(matchForm, targetForm, whelk),
-                whelk.jsonld.repeatableTerms)
-
-        this.graph[1] = m.after
-        this.graph[0] = m.after.remove(RECORD_KEY)
-
-        return m.isModified()
-    }
-
-    boolean matches(Map matchForm) {
-        Map thing = (Map) this.graph[1]
-        thing[RECORD_KEY] = (Map) this.graph[0]
-        return new Transform.MatchForm(matchForm, whelk).matches(thing)
     }
 }
 

--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -912,10 +912,6 @@ class DocumentItem {
         whelk.storage.loadAllVersions(doc.shortId)
     }
 
-    def getDependers() {
-        whelk.storage.getDependers(doc.shortId)
-    }
-
     Map asCard(boolean withSearchKey = false) {
         return whelk.jsonld.toCard(doc.data, false, withSearchKey)
     }

--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -912,6 +912,10 @@ class DocumentItem {
         whelk.storage.loadAllVersions(doc.shortId)
     }
 
+    def getDependers() {
+        whelk.storage.getDependers(doc.shortId)
+    }
+
     Map asCard(boolean withSearchKey = false) {
         return whelk.jsonld.toCard(doc.data, false, withSearchKey)
     }

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -356,10 +356,6 @@ class Transform {
     }
 
     boolean mapMatches(Map matchForm, Map bNode) {
-        return _mapMatches(matchForm, bNode)
-    }
-
-    private boolean _mapMatches(Map matchForm, Map bNode) {
         if (matchForm == null || bNode == null) {
             return false
         }
@@ -389,7 +385,7 @@ class Transform {
         if (matchForm.size() > bNode.size()) {
             return false
         }
-        return comparator.isSubset(matchForm, bNode, this::_mapMatches)
+        return comparator.isSubset(matchForm, bNode, this::mapMatches)
     }
 
     private boolean exactMatches(Map matchForm, Map bNode) {

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static whelk.JsonLd.ID_KEY;
 import static whelk.util.JsonLdKey.fromKey;
 
 // All terms are defined in https://github.com/libris/definitions/blob/develop/source/vocab/platform.ttl
@@ -18,7 +19,8 @@ public class BulkJobDocument extends Document {
     public enum SpecType implements JsonLdKey {
         Update("bulk:Update"),
         Delete("bulk:Delete"),
-        Create("bulk:Create");
+        Create("bulk:Create"),
+        Merge("bulk:Merge");
 
         private final String key;
 
@@ -59,6 +61,8 @@ public class BulkJobDocument extends Document {
     public static final String TARGET_FORM_KEY = "bulk:targetForm";
     public static final String COMMENT_KEY = "comment";
     public static final String LABEL_KEY = "label";
+    public static final String KEEP_KEY = "bulk:keep";
+    public static final String DEPRECATE_KEY = "bulk:deprecate";
 
     private static final List<Object> STATUS_PATH = List.of(JsonLd.GRAPH_KEY, 1, STATUS_KEY);
     private static final List<Object> UPDATE_TIMESTAMP_PATH = List.of(JsonLd.GRAPH_KEY, 1, SHOULD_UPDATE_TIMESTAMP_KEY);
@@ -119,6 +123,10 @@ public class BulkJobDocument extends Document {
             );
             case SpecType.Create -> new Specification.Create(
                     get(spec, TARGET_FORM_KEY, Collections.emptyMap())
+            );
+            case SpecType.Merge -> new Specification.Merge(
+                    get(spec, List.of(DEPRECATE_KEY, "*", ID_KEY), Collections.emptyList()),
+                    get(spec, List.of(KEEP_KEY, ID_KEY), "")
             );
             case null -> throw new ModelValidationException(String.format("Bad %s %s: %s",
                     CHANGE_SPEC_KEY, JsonLd.TYPE_KEY, specType));

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
@@ -6,22 +6,16 @@ import whelk.Whelk;
 import whelk.datatool.Script;
 import whelk.datatool.form.ModifiedThing;
 import whelk.datatool.form.Transform;
-import whelk.util.DocumentUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static whelk.JsonLd.ID_KEY;
+import static whelk.JsonLd.GRAPH_KEY;
+import static whelk.JsonLd.RECORD_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY;
@@ -31,19 +25,13 @@ public sealed interface Specification permits Specification.Create, Specificatio
 
     Script getScript(String bulkJobId);
 
-    List<String> findAffectedIds(Whelk whelk);
-
-    default Map<?, ?> getAfter(Map<String, Object> thing, Whelk whelk) {
-        return Collections.emptyMap();
-    }
-
     final class Update implements Specification {
         private final Map<String, Object> matchForm;
         private final Map<String, Object> targetForm;
 
         private Transform transform;
 
-        Update(Map<String, Object> matchForm, Map<String, Object> targetForm) {
+        public Update(Map<String, Object> matchForm, Map<String, Object> targetForm) {
             this.matchForm = matchForm;
             this.targetForm = targetForm;
         }
@@ -58,14 +46,17 @@ public sealed interface Specification permits Specification.Create, Specificatio
             return s;
         }
 
-        @Override
-        public List<String> findAffectedIds(Whelk whelk) {
-            return queryIdsByForm(getTransform(whelk), whelk);
-        }
+        @SuppressWarnings("unchecked")
+        public boolean modify(Document doc, Whelk whelk) {
+            Map<String, Object> thing = doc.getThing();
+            thing.put(RECORD_KEY, doc.getRecord());
 
-        @Override
-        public Map<?, ?> getAfter(Map<String, Object> thing, Whelk whelk) {
-            return new ModifiedThing(thing, getTransform(whelk), whelk.getJsonld().repeatableTerms).getAfter();
+            var m = new ModifiedThing(thing, getTransform(whelk), whelk.getJsonld().repeatableTerms);
+
+            ((List<Map<?,?>>) doc.data.get(GRAPH_KEY)).set(0, (Map<?, ?>) m.getAfter().remove(RECORD_KEY));
+            ((List<Map<?,?>>) doc.data.get(GRAPH_KEY)).set(1, m.getAfter());
+
+            return m.isModified();
         }
 
         public Transform getTransform(Whelk whelk) {
@@ -76,7 +67,15 @@ public sealed interface Specification permits Specification.Create, Specificatio
         }
     }
 
-    record Delete(Map<String, Object> matchForm) implements Specification {
+    final class Delete implements Specification {
+        private final Map<String, Object> matchForm;
+
+        private Transform.MatchForm matchFormObj;
+
+        public Delete(Map<String, Object> matchForm) {
+            this.matchForm = matchForm;
+        }
+
         @Override
         public Script getScript(String bulkJobId) {
             Script s = new Script(loadClasspathScriptSource("delete.groovy"), bulkJobId);
@@ -86,9 +85,18 @@ public sealed interface Specification permits Specification.Create, Specificatio
             return s;
         }
 
-        @Override
-        public List<String> findAffectedIds(Whelk whelk) {
-            return queryIdsByForm(new Transform.MatchForm(matchForm, whelk), whelk);
+        @SuppressWarnings("unchecked")
+        public boolean matches(Document doc, Whelk whelk) {
+            Map<String, Object> thing = doc.clone().getThing();
+            thing.put(RECORD_KEY, doc.getRecord());
+            return getMatchForm(whelk).matches(thing);
+        }
+
+        public Transform.MatchForm getMatchForm(Whelk whelk) {
+            if (matchFormObj == null) {
+                matchFormObj = new Transform.MatchForm(matchForm, whelk);
+            }
+            return matchFormObj;
         }
     }
 
@@ -101,25 +109,9 @@ public sealed interface Specification permits Specification.Create, Specificatio
             ));
             return s;
         }
-
-        @Override
-        public List<String> findAffectedIds(Whelk whelk) {
-            return Collections.emptyList();
-        }
     }
 
-    final class Merge implements Specification {
-        Collection<String> deprecate;
-        String keep;
-
-        private Set<String> obsoleteThingIdentifiers;
-        private Map<String, String> thingUriToShortId;
-
-        public Merge(Collection<String> deprecate, String keep) {
-            this.deprecate = deprecate;
-            this.keep = keep;
-        }
-
+    record Merge(Collection<String> deprecate, String keep) implements Specification {
         @Override
         public Script getScript(String bulkJobId) {
             Script s = new Script(loadClasspathScriptSource("merge.groovy"), bulkJobId);
@@ -128,73 +120,6 @@ public sealed interface Specification permits Specification.Create, Specificatio
                     KEEP_KEY, keep
             ));
             return s;
-        }
-
-        @Override
-        public List<String> findAffectedIds(Whelk whelk) {
-            // Include deprecated? Have to be shown as removed in preview.
-            return Stream.concat(Stream.of(keep), getDependers(whelk).stream()).toList();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Map<?, ?> getAfter(Map<String, Object> thing, Whelk whelk) {
-            var copy = (Map<String, Object>) Document.deepCopy(thing);
-            if (keep.equals(thing.get(ID_KEY))) {
-                addSameAsLinks(copy, whelk);
-            } else {
-                relink(copy, whelk);
-            }
-            return copy;
-        }
-
-        @SuppressWarnings("unchecked")
-        public void addSameAsLinks(Map<String, Object> thing, Whelk whelk) {
-            var origSameAs = (List<String>) thing.getOrDefault("sameAs", Collections.emptyList());
-            var newSameAs = Stream.concat(origSameAs.stream(), getObsoleteThingIdentifiers(whelk).stream().map(uri -> Map.of(ID_KEY, uri)))
-                    .distinct()
-                    .toList();
-            thing.put("sameAs", newSameAs);
-        }
-
-        public List<String> getDependers(Whelk whelk) {
-            return deprecate.stream()
-                    .map(uri -> getShortId(uri, whelk))
-                    .map(whelk.getStorage()::getDependers)
-                    .flatMap(SortedSet::stream)
-                    .toList();
-        }
-
-        public boolean relink(Object data, Whelk whelk) {
-            return DocumentUtil.traverse(data, (value, path) -> {
-                if (!path.isEmpty() && ID_KEY.equals(path.getLast()) && getObsoleteThingIdentifiers(whelk).contains(value)) {
-                    // What if there are links to a record uri?
-                    return new DocumentUtil.Replace(keep);
-                }
-                return new DocumentUtil.Nop();
-            });
-        }
-
-        private String getShortId(String thingUri, Whelk whelk) {
-            if (thingUriToShortId == null) {
-                this.thingUriToShortId = new HashMap<>();
-            }
-            if (thingUriToShortId.get(thingUri) == null) {
-                String shortId = whelk.getStorage().getDocumentByIri(thingUri).getShortId();
-                this.thingUriToShortId.put(thingUri, shortId);
-            }
-            return thingUriToShortId.get(thingUri);
-        }
-
-        private Set<String> getObsoleteThingIdentifiers(Whelk whelk) {
-            if (obsoleteThingIdentifiers == null) {
-                this.obsoleteThingIdentifiers = whelk.bulkLoad(deprecate)
-                        .values()
-                        .stream()
-                        .flatMap(doc -> doc.getThingIdentifiers().stream())
-                        .collect(Collectors.toSet());
-            }
-            return obsoleteThingIdentifiers;
         }
     }
 
@@ -206,15 +131,5 @@ public sealed interface Specification permits Specification.Create, Specificatio
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static List<String> queryIdsByForm(Transform transform, Whelk whelk) {
-        // TODO use COUNT + LIMIT & OFFSET and don't fetch all ids every time
-        var sparqlPattern = transform.getSparqlPattern(whelk.getJsonld().context);
-        return whelk.getSparqlQueryClient()
-                .queryIdsByPattern(sparqlPattern)
-                .stream()
-                .sorted()
-                .toList();
     }
 }

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
@@ -1,6 +1,7 @@
 package whelk.datatool.bulkchange;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import whelk.Whelk;
 import whelk.datatool.Script;
 import whelk.datatool.form.Transform;
@@ -8,12 +9,15 @@ import whelk.datatool.form.Transform;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collection;
 import java.util.Map;
 
+import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY;
+import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.TARGET_FORM_KEY;
 
-public sealed interface Specification permits Specification.Create, Specification.Delete, Specification.Update {
+public sealed interface Specification permits Specification.Create, Specification.Delete, Specification.Merge, Specification.Update {
 
     Script getScript(String bulkJobId);
     Transform getTransform(Whelk whelk);
@@ -63,8 +67,24 @@ public sealed interface Specification permits Specification.Create, Specificatio
 
         @Override
         public Transform getTransform(Whelk whelk) {
-            // TODO
-            return null;
+            throw new NotImplementedException("");
+        }
+    }
+
+    record Merge(Collection<String> deprecate, String keep) implements Specification {
+        @Override
+        public Script getScript(String bulkJobId) {
+            Script s = new Script(loadClasspathScriptSource("merge.groovy"), bulkJobId);
+            s.setParameters(Map.of(
+                    DEPRECATE_KEY, deprecate,
+                    KEEP_KEY, keep
+            ));
+            return s;
+        }
+
+        @Override
+        public Transform getTransform(Whelk whelk) {
+            throw new NotImplementedException("");
         }
     }
 

--- a/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
@@ -1,11 +1,13 @@
+import whelk.datatool.bulkchange.Specification
+
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY
 
 Map matchForm = parameters.get(MATCH_FORM_KEY)
 
-println()
+Specification.Delete delete = new Specification.Delete(matchForm)
 
-selectByForm(matchForm) { doc ->
-    if(doc.matches(matchForm)) {
-        doc.scheduleDelete(loud: isLoudAllowed)
+selectByForm(matchForm) {
+    if(delete.matches(it.doc, it.whelk)) {
+        it.scheduleDelete(loud: isLoudAllowed)
     }
 }

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -13,7 +13,7 @@ selectByIds(deprecate) { obsolete ->
     def obsoleteThingUris = obsolete.doc.getThingIdentifiers()
     selectByIds(obsolete.getDependers()) { depender ->
         def modified = DocumentUtil.traverse(depender.graph) { value, path ->
-            // What if there are links to a record uri?
+            // TODO: What if there are links to a record uri?
             if (path && path.last() == ID_KEY && obsoleteThingUris.contains(value)) {
                 return new DocumentUtil.Replace(keep)
             }

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -5,8 +5,8 @@ import static whelk.JsonLd.ID_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
 
-List<String> deprecate = parameters.get(DEPRECATE_KEY)
-String keep = parameters.get(KEEP_KEY)
+List<String> deprecate = ["https://id.kb.se/term/sao/M%C3%84V1"]//parameters.get(DEPRECATE_KEY)
+String keep = "https://id.kb.se/term/sao/M%C3%84V-NY" //parameters.get(KEEP_KEY)
 
 Set<String> allObsoleteThingUris = synchronizedSet([] as Set<String>)
 selectByIds(deprecate) { obsolete ->
@@ -21,6 +21,13 @@ selectByIds(deprecate) { obsolete ->
         if (modified) {
             depender.scheduleSave(loud: isLoudAllowed)
         }
+        // Remove duplicate links
+        DocumentUtil.traverse(depender.graph) { value, path ->
+            if (value instanceof List) {
+                value.unique(true) { it instanceof Map ? it[ID_KEY] : it }
+                return new DocumentUtil.Nop()
+            }
+        }
     }
     allObsoleteThingUris.addAll(obsoleteThingUris)
 }
@@ -30,7 +37,7 @@ selectByIds(deprecate) {
 }
 
 selectByIds([keep]) {
-    allObsoleteThingUris.each {uri ->
+    allObsoleteThingUris.each { uri ->
         it.doc.addThingIdentifier(uri)
     }
     it.scheduleSave()

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -1,28 +1,18 @@
-import whelk.util.DocumentUtil
+import whelk.Whelk
+import whelk.datatool.bulkchange.Specification
 
-import static java.util.Collections.synchronizedSet
-import static whelk.JsonLd.ID_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
 
 List<String> deprecate = parameters.get(DEPRECATE_KEY)
 String keep = parameters.get(KEEP_KEY)
 
-Set<String> allObsoleteThingUris = synchronizedSet([] as Set<String>)
-selectByIds(deprecate) { obsoleteDoc ->
-    def obsoleteThingUris = obsoleteDoc.doc.getThingIdentifiers()
-    selectByIds(obsoleteDoc.getDependers()) { dependingDoc ->
-        def modified = DocumentUtil.traverse(dependingDoc.graph) { value, path ->
-            // What if there are links to a record uri?
-            if (path && path.last() == ID_KEY && obsoleteThingUris.contains(value)) {
-                return new DocumentUtil.Replace(keep)
-            }
-        }
-        if (modified) {
-            dependingDoc.scheduleSave(loud: isLoudAllowed)
-        }
+Specification.Merge merge = new Specification.Merge(deprecate, keep)
+
+selectByIds(merge.getDependers(getWhelk())) {
+    if (merge.relink(it.graph, it.whelk)) {
+        it.scheduleSave(loud: isLoudAllowed)
     }
-    allObsoleteThingUris.addAll(obsoleteThingUris)
 }
 
 selectByIds(deprecate) {
@@ -30,9 +20,7 @@ selectByIds(deprecate) {
 }
 
 selectByIds([keep]) {
-    allObsoleteThingUris.each {uri ->
-        it.doc.addThingIdentifier(uri)
-    }
+    merge.addSameAsLinks((Map<String, Object>) it.graph[1], (Whelk) it.whelk)
     it.scheduleSave()
 }
 

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -1,0 +1,36 @@
+import whelk.util.DocumentUtil
+
+import static whelk.JsonLd.ID_KEY
+import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY
+import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
+
+List<String> deprecate = parameters.get(DEPRECATE_KEY)
+String keep = parameters.get(KEEP_KEY)
+
+Set<String> allDeprecatedThingUris = Collections.synchronizedSet()
+selectByIds(deprecate) {
+    allDeprecatedThingUris.addAll(it.doc.getThingIdentifiers())
+}
+
+selectBySqlWhere("id in (select id from lddb__dependencies where dependsonid in ( '${deprecate.join("','")}' )") { docItem ->
+    def modified = DocumentUtil.traverse(docItem.graph) { value, path ->
+        if (path && path.last() == ID_KEY && allDeprecatedThingUris.contains(value)) {
+            return new DocumentUtil.Replace(keep)
+        }
+    }
+    if (modified) {
+        docItem.scheduleSave(loud: isLoudAllowed)
+    }
+}
+
+selectByIds(deprecate) {
+    it.scheduleDelete()
+}
+
+selectByIds([keep]) { docItem ->
+    allDeprecatedThingUris.each {uri ->
+        docItem.doc.addThingIdentifier(uri)
+    }
+    docItem.scheduleSave()
+}
+

--- a/whelktool/src/main/resources/bulk-change-scripts/update.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/update.groovy
@@ -1,11 +1,15 @@
+import whelk.datatool.bulkchange.Specification
+
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.TARGET_FORM_KEY
 
 Map matchForm = parameters.get(MATCH_FORM_KEY)
 Map targetForm = parameters.get(TARGET_FORM_KEY)
 
-selectByForm(matchForm) { doc ->
-    if(doc.modify(matchForm, targetForm)) {
-        doc.scheduleSave(loud: isLoudAllowed)
+Specification.Update update = new Specification.Update(matchForm, targetForm)
+
+selectByForm(matchForm) {
+    if(update.modify(it.doc, it.whelk)) {
+        it.scheduleSave(loud: isLoudAllowed)
     }
 }


### PR DESCRIPTION
I think we can merge this now. Should be fairly easy to just replace the part where we emulate the changes (https://github.com/libris/librisxl/blob/72e410ff654b2e79083e616f4b3b698d6a5fa98c/rest/src/main/groovy/whelk/rest/api/BulkChangePreviewAPI.java#L62) with the results of a dry-run once we have that in place.

TODO:
- Address this: https://github.com/libris/librisxl/blob/72e410ff654b2e79083e616f4b3b698d6a5fa98c/whelktool/src/main/resources/bulk-change-scripts/merge.groovy#L16 
I don't think we should replace links to record uris with links to thing uri so the question is what to do with them (if they ever appear)?
- Would be nice to make the frontend preview aware of and able to display different types of changes depending on the change sets content.  