### PR TITLE
Bugfix/bulk deprecated

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -50,7 +50,7 @@ class JsonLd {
     public static final List<String> NS_SEPARATORS = ['#', '/', ':']
 
     public static final List<String> NON_DEPENDANT_RELATIONS = ['narrower', 'broader', 'expressionOf', 'related',
-                                                                'derivedFrom', 'bulk:changeSpec.bulk:deprecate']
+                                                                'derivedFrom']
     public static final List<String> ALLOW_LINK_TO_DELETED = [
         'meta.derivedFrom', 'hasTitle.source', 'bulk:changeSpec.bulk:deprecate',
         /* following are combinations only needed while there are local unlinked works */

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -49,9 +49,10 @@ class JsonLd {
 
     public static final List<String> NS_SEPARATORS = ['#', '/', ':']
 
-    public static final List<String> NON_DEPENDANT_RELATIONS = ['narrower', 'broader', 'expressionOf', 'related', 'derivedFrom']
+    public static final List<String> NON_DEPENDANT_RELATIONS = ['narrower', 'broader', 'expressionOf', 'related',
+                                                                'derivedFrom', 'bulk:changeSpec.bulk:deprecate']
     public static final List<String> ALLOW_LINK_TO_DELETED = [
-        'meta.derivedFrom', 'hasTitle.source',
+        'meta.derivedFrom', 'hasTitle.source', 'bulk:changeSpec.bulk:deprecate',
         /* following are combinations only needed while there are local unlinked works */
          'translationOf.hasTitle.source', 'instanceOf.hasTitle.source', 'instanceOf.translationOf.hasTitle.source']
     public static final String CATEGORY_DEPENDENT = 'dependent'

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -115,8 +115,11 @@ class LinkFinder {
     }
 
     private void replaceSameAsLinksWithPrimaries(Map data, List path = []) {
+        def exceptedProperties = ['bulk:deprecate'] as Set
+        if (path && exceptedProperties.contains(path.last())) {
+            return
+        }
         // If this is a link (an object containing _only_ an id)
-
         String id = data.get("@id")
         if (id != null && data.keySet().size() == 1) {
             // Path to same form as in lddb__dependencies.relation
@@ -142,9 +145,9 @@ class LinkFinder {
             Object value = data.get(key)
 
             if (value instanceof List)
-                replaceSameAsLinksWithPrimaries( (List) value, path + keyString )
+                replaceSameAsLinksWithPrimaries((List) value, path + keyString)
             if (value instanceof Map)
-                replaceSameAsLinksWithPrimaries( (Map) value, path + keyString )
+                replaceSameAsLinksWithPrimaries((Map) value, path + keyString)
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -115,21 +115,22 @@ class LinkFinder {
     }
 
     private void replaceSameAsLinksWithPrimaries(Map data, List path = []) {
-        def exceptedProperties = ['bulk:deprecate'] as Set
+        def exceptedPaths = ['bulk:changeSpec.bulk:deprecate'] as Set
 
         // If this is a link (an object containing _only_ an id)
         String id = data.get("@id")
         if (id != null && data.keySet().size() == 1) {
             // Path to same form as in lddb__dependencies.relation
-            List<String> normalizedPath = (path.take(2) == Document.recordPath
+            String normalizedPath = (path.take(2) == Document.recordPath
                     ? [JsonLd.RECORD_KEY] + path.drop(2)
                     : (path.take(2) == Document.thingPath ? path.drop(2) : path)
             )
-                    .findAll { it instanceof String } as List<String>
-            if (normalizedPath && exceptedProperties.contains(normalizedPath.last())) {
+                    .findAll { it instanceof String }
+                    .join('.')
+            if (exceptedPaths.contains(normalizedPath)) {
                 return
             }
-            String primaryId = lookupPrimaryId(id, normalizedPath.join('.'))
+            String primaryId = lookupPrimaryId(id, normalizedPath)
             if (primaryId != null)
                 data.put("@id", primaryId)
             return

--- a/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
+++ b/whelk-core/src/main/groovy/whelk/filter/LinkFinder.groovy
@@ -116,22 +116,23 @@ class LinkFinder {
 
     private void replaceSameAsLinksWithPrimaries(Map data, List path = []) {
         def exceptedProperties = ['bulk:deprecate'] as Set
-        if (path && exceptedProperties.contains(path.last())) {
-            return
-        }
+
         // If this is a link (an object containing _only_ an id)
         String id = data.get("@id")
         if (id != null && data.keySet().size() == 1) {
             // Path to same form as in lddb__dependencies.relation
-            String normalizedPath = (path.take(2) == Document.recordPath
+            List<String> normalizedPath = (path.take(2) == Document.recordPath
                     ? [JsonLd.RECORD_KEY] + path.drop(2)
                     : (path.take(2) == Document.thingPath ? path.drop(2) : path)
             )
-                    .findAll { it instanceof String }
-                    .join('.')
-            String primaryId = lookupPrimaryId(id, normalizedPath)
+                    .findAll { it instanceof String } as List<String>
+            if (normalizedPath && exceptedProperties.contains(normalizedPath.last())) {
+                return
+            }
+            String primaryId = lookupPrimaryId(id, normalizedPath.join('.'))
             if (primaryId != null)
                 data.put("@id", primaryId)
+            return
         }
 
         // Keep looking for more links

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
@@ -66,10 +66,10 @@ public class BulkJobDocument extends Document {
     public static final String TARGET_FORM_KEY = "bulk:targetForm";
     public static final String COMMENT_KEY = "comment";
     public static final String LABEL_KEY = "label";
+    public static final String ADD_KEY = "bulk:add";
     public static final String KEEP_KEY = "bulk:keep";
     public static final String DEPRECATE_KEY = "bulk:deprecate";
     public static final String SCRIPT_KEY = "bulk:script";
-    public static final String RDF_VALUE = "value";
     public static final String EXECUTION_KEY = "bulk:execution";
     public static final String EXECUTION_TYPE = "bulk:Execution";
     public static final String REPORT_KEY = "bulk:report";
@@ -165,8 +165,8 @@ public class BulkJobDocument extends Document {
                     get(spec, TARGET_FORM_KEY, Collections.emptyMap())
             );
             case SpecType.Merge -> new Specification.Merge(
-                    get(spec, List.of(DEPRECATE_KEY, "*", ID_KEY), Collections.emptyList()),
-                    get(spec, List.of(KEEP_KEY, ID_KEY), "")
+                    get(spec, DEPRECATE_KEY, Collections.emptyMap()),
+                    get(spec, KEEP_KEY, Collections.emptyMap())
             );
             case SpecType.Other -> new Specification.Other(
                     get(spec, SCRIPT_KEY, null),

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static whelk.JsonLd.GRAPH_KEY;
 import static whelk.JsonLd.RECORD_KEY;
+import static whelk.datatool.bulkchange.BulkJobDocument.ADD_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY;
@@ -113,7 +114,7 @@ public sealed interface Specification permits Specification.Create, Specificatio
         }
     }
 
-    record Merge(Collection<String> deprecate, String keep) implements Specification {
+    record Merge(Map<String, String> deprecate, Map<String, String> keep) implements Specification {
         @Override
         public Script getScript(String bulkJobId) {
             Script s = new Script(loadClasspathScriptSource("merge.groovy"), bulkJobId);
@@ -127,7 +128,7 @@ public sealed interface Specification permits Specification.Create, Specificatio
 
     record Other(String name, Map<String, ?> parameters) implements Specification {
         private static final Map<String, List<String>> ALLOWED_SCRIPTS_PARAMS = Map.of(
-                "removeTopicSubdivision", List.of(DEPRECATE_KEY, KEEP_KEY)
+                "removeTopicSubdivision", List.of(DEPRECATE_KEY, ADD_KEY)
         );
 
         @Override

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -6,10 +6,10 @@ import static whelk.datatool.bulkchange.BulkJobDocument.JOB_TYPE
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
 
 Map deprecateLink = parameters.get(DEPRECATE_KEY)
-Map keep = parameters.get(KEEP_KEY)
+Map keepLink = parameters.get(KEEP_KEY)
 
 String deprecateId = deprecateLink[ID_KEY]
-String keepId = deprecateLink[ID_KEY]
+String keepId = keepLink[ID_KEY]
 
 if (!deprecateId || !keepId) return
 

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -41,7 +41,6 @@ selectByIds([keep]) {
     allObsoleteThingUris.each { uri ->
         it.doc.addThingIdentifier(uri)
     }
-    // TODO: Don't normalize sameAs links on saving? bulk:deprecate should link to the deleted resource
     it.scheduleSave()
 }
 

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -50,7 +50,7 @@ selectByIds([deprecateId]) { obsolete ->
     obsolete.scheduleDelete()
 }
 
-selectByIds([keep]) { kept ->
+selectByIds([keepId]) { kept ->
     obsoleteThingUris.each { uri ->
         kept.doc.addThingIdentifier(uri)
         kept.scheduleSave()

--- a/whelktool/src/main/resources/bulk-change-scripts/removeTopicSubdivision.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/removeTopicSubdivision.groovy
@@ -14,41 +14,52 @@ import static whelk.JsonLd.ID_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
 
-List deprecateLinks = asList(parameters.get(DEPRECATE_KEY))
-Map keepLink = parameters.get(KEEP_KEY)
+Map deprecate = parameters.get(DEPRECATE_KEY)
+Map addLink = parameters.get(KEEP_KEY)
 
-deprecateLinks.each { deprecate ->
-    selectByIds([deprecate[ID_KEY]]) { obsoleteSubdivision ->
-        selectByIds(obsoleteSubdivision.getDependers()) { depender ->
-            Map thing = depender.graph[1] as Map
+if (!deprecate) return
 
-            if (thing[JsonLd.TYPE_KEY] == 'ComplexSubject') {
-                return
-            }
+def process = { doc ->
+    Map thing = doc.graph[1] as Map
 
-            def modified = DocumentUtil.traverse(thing) { value, path ->
-                if (value instanceof Map && value[JsonLd.TYPE_KEY] == 'ComplexSubject') {
-                    var t = asList(value.get('termComponentList'))
-                    if (deprecate in t) {
-                        // TODO? add way to do this with an op? SplitReplace? [Replace, Insert]?
-                        if (keepLink && path.size() > 1) {
-                            var parent = DocumentUtil.getAtPath(thing, path.dropRight(1))
-                            if (parent instanceof List && !parent.contains(keepLink)) {
-                                parent.add(keepLink)
-                            }
-                        }
+    if (thing[JsonLd.TYPE_KEY] == 'ComplexSubject') {
+        return
+    }
 
-                        return mapSubject(value, t, deprecate)
+    def modified = DocumentUtil.traverse(thing) { value, path ->
+        if (value instanceof Map && value[JsonLd.TYPE_KEY] == 'ComplexSubject') {
+            var t = asList(value.get('termComponentList'))
+            if (deprecate in t) {
+                var parent = DocumentUtil.getAtPath(thing, path.dropRight(1))
+                // TODO? add way to do this with an op? SplitReplace? [Replace, Insert]?
+                if (addLink && addLink[ID_KEY] && path.size() > 1) {
+                    if (parent instanceof List && !parent.contains(addLink)) {
+                        parent.add(addLink)
                     }
                 }
-                return DocumentUtil.NOP
-            }
 
-            if (modified) {
-                depender.scheduleSave(loud: isLoudAllowed)
+                return mapSubject(value, t, deprecate)
             }
         }
+        return DocumentUtil.NOP
     }
+
+    if (modified) {
+        doc.scheduleSave(loud: isLoudAllowed)
+    }
+}
+
+if (deprecate[ID_KEY]) {
+    selectByIds([deprecate[ID_KEY]]) { obsoleteSubdivision ->
+        selectByIds(obsoleteSubdivision.getDependers()) {
+            process(it)
+        }
+    }
+} else {
+    // TODO
+//    selectByForm(deprecate) {
+//        process(it)
+//    }
 }
 
 static DocumentUtil.Operation mapSubject(Map subject, termComponentList, deprecateLink) {

--- a/whelktool/src/main/resources/bulk-change-scripts/removeTopicSubdivision.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/removeTopicSubdivision.groovy
@@ -11,11 +11,11 @@ import whelk.JsonLd
 import whelk.util.DocumentUtil
 
 import static whelk.JsonLd.ID_KEY
+import static whelk.datatool.bulkchange.BulkJobDocument.ADD_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY
-import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY
 
 Map deprecate = parameters.get(DEPRECATE_KEY)
-Map addLink = parameters.get(KEEP_KEY)
+Map addLink = parameters.get(ADD_KEY)
 
 if (!deprecate) return
 


### PR DESCRIPTION
Keep URIs of deleted resources in `bulk:changeSpec.bulk:deprecated`.

Had to hardcode the path in `LinkFinder.replaceSameAsLinksWithPrimaries` to avoid passing a parameter through long chains of methods. We really should refactor all the normalizer stuff sometime for better flexibility.