### PR TITLE
Use perl instead of sed when replacing IDs

### DIFF
--- a/librisxl-tools/scripts/move-lddb-from-backup.sh
+++ b/librisxl-tools/scripts/move-lddb-from-backup.sh
@@ -92,9 +92,9 @@ else
     }
 fi
 
-REPLACEID="s!\(\(\"@id\": \"\|\t\)https://libris\)\(-\w\+\)\?\(.kb.se/[bcdfghjklmnpqrstvwxz0-9]\+\)\>!\1-$DESTENV\4!g"
+REPLACEID="s/((@id\": \"|\t)https:\/\/libris)(?:-\w+)?(.kb.se\/[bcdfghjklmnpqrstvwxz0-9]+)\b/\1-$DESTENV\3/g"
 
 pg_restore -f - "${DUMPPATH}" |
     ( read; cat - |
-    sed "$REPLACEID" |
+    perl -pe "$REPLACEID" |
     handle_sql_dump )


### PR DESCRIPTION
The old sed stuff can probably be optimized but :shrug: Perl is installed by default at least up to (and including) RHEL 8.
```fish
root@l22058 /h/andjen# echo 3 > /proc/sys/vm/drop_caches
root@l22058 /h/andjen# time sed "s!\(\(\"@id\": \"\|\t\)https://libris\)\(-\w\+\)\?\(.kb.se/[bcdfghjklmnpqrstvwxz0-9]\+\)\>!\1-dev\4!g" lddb_500mb.sql > sedfoo

________________________________________________________
Executed in    9.90 secs    fish           external
   usr time    9.07 secs    1.50 millis    9.07 secs
   sys time    0.58 secs    0.00 millis    0.58 secs

root@l22058 /h/andjen# echo 3 > /proc/sys/vm/drop_caches
root@l22058 /h/andjen# time perl -pe 's/((@id": "|\t)https:\/\/libris)(?:-\w+)?(.kb.se\/[bcdfghjklmnpqrstvwxz0-9]+)\b/\1-dev\3/g' lddb_500mb.sql > perlfoo

________________________________________________________
Executed in    1.84 secs    fish           external
   usr time    1.35 secs    1.61 millis    1.34 secs
   sys time    0.43 secs    0.00 millis    0.43 secs

root@l22058 /h/andjen# sha256sum sedfoo perlfoo
1529fdfb784d68e0fd667a4dd9782a54c2d798b1ce9b3336a54fa47aa742e1d5  sedfoo
1529fdfb784d68e0fd667a4dd9782a54c2d798b1ce9b3336a54fa47aa742e1d5  perlfoo
```