### PR TITLE
Support replacing Subdivision with GenreForm

### DIFF
--- a/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJobDocument.java
@@ -66,11 +66,10 @@ public class BulkJobDocument extends Document {
     public static final String TARGET_FORM_KEY = "bulk:targetForm";
     public static final String COMMENT_KEY = "comment";
     public static final String LABEL_KEY = "label";
-    public static final String ADD_KEY = "bulk:add";
     public static final String KEEP_KEY = "bulk:keep";
     public static final String DEPRECATE_KEY = "bulk:deprecate";
     public static final String REMOVE_SUBDIVISION_KEY = "bulk:removeSubdivision";
-    public static final String ADD_SUBJECT_KEY = "bulk:addSubject";
+    public static final String ADD_TERM_KEY = "bulk:addTerm";
     public static final String SCRIPT_KEY = "bulk:script";
     public static final String EXECUTION_KEY = "bulk:execution";
     public static final String EXECUTION_TYPE = "bulk:Execution";

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
@@ -2,10 +2,8 @@ package whelk.datatool.bulkchange;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.io.IOUtils;
-import whelk.Document;
 import whelk.Whelk;
 import whelk.datatool.Script;
-import whelk.datatool.form.ModifiedThing;
 import whelk.datatool.form.Transform;
 
 import java.io.IOException;
@@ -15,9 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static whelk.JsonLd.GRAPH_KEY;
-import static whelk.JsonLd.RECORD_KEY;
-import static whelk.datatool.bulkchange.BulkJobDocument.ADD_SUBJECT_KEY;
+import static whelk.datatool.bulkchange.BulkJobDocument.ADD_TERM_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.KEEP_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY;
 import static whelk.datatool.bulkchange.BulkJobDocument.DEPRECATE_KEY;
@@ -80,7 +76,7 @@ public sealed interface Specification permits Specification.Create, Specificatio
 
     record Other(String name, Map<String, ?> parameters) implements Specification {
         private static final Map<String, List<String>> ALLOWED_SCRIPTS_PARAMS = Map.of(
-                "removeSubdivision", List.of(REMOVE_SUBDIVISION_KEY, ADD_SUBJECT_KEY)
+                "removeSubdivision", List.of(REMOVE_SUBDIVISION_KEY, ADD_TERM_KEY)
         );
 
         @Override


### PR DESCRIPTION
One last addition! :crossed_fingers: Makes sense to be able to add GenreForm term when removing a GenreSubdivision. See example :broom: : 
![image](https://github.com/user-attachments/assets/19340c77-b074-447d-9953-9dceee102a56)
![image](https://github.com/user-attachments/assets/7910e2cd-05f8-486b-869a-964b60e54d3b)

Depends on: https://github.com/libris/definitions/pull/507
Will update the Subdivison template too.
