### PR TITLE
fix(rest/search2): index of out bounds if query is whitespace or ends with 2+ whitespace

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -38,9 +38,7 @@ public class Lex {
     }
 
     private static void consumeWhiteSpace(StringBuilder query, MutableInteger offset) {
-        if (query.isEmpty())
-            return;
-        while (Character.isWhitespace(query.charAt(0))) {
+        while (!query.isEmpty() && Character.isWhitespace(query.charAt(0))) {
             query.deleteCharAt(0);
             offset.increase(1);
         }


### PR DESCRIPTION
On a part-time mission to reduce errwatch messages
```
~ curl 'https://libris-dev.kb.se/find.jsonld?_q=%20'
{"message":"Index 0 out of bounds for length 0","status_code":500,"status":"Server Error","stackTrace":["java.lang.StringIndexOutOfBoundsException: Index 0 out of bounds for length 0"]}
~ curl 'https://libris-dev.kb.se/find.jsonld?_q=foo%20%20'
{"message":"Index 0 out of bounds for length 0","status_code":500,"status":"Server Error","stackTrace":["java.lang.StringIndexOutOfBoundsException: Index 0 out of bounds for length 0"]}
```