### PR TITLE
Feature/lws 88 boosting

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -21,6 +21,7 @@ import whelk.util.http.RedirectException;
 import java.io.IOException;
 import java.util.*;
 
+import static whelk.search2.EsBoost.addConstantBoosts;
 import static whelk.search2.Spell.buildSpellSuggestions;
 import static whelk.util.Jackson.mapper;
 
@@ -84,7 +85,7 @@ public class SearchUtils2 {
     private Map<String, Object> getEsQueryDsl(QueryTree queryTree, QueryParams queryParams, AppParams.StatsRepr statsRepr) {
         var queryDsl = new LinkedHashMap<String, Object>();
 
-        queryDsl.put("query", queryTree.toEs(queryUtil, disambiguate));
+        queryDsl.put("query", addConstantBoosts(queryTree.toEs(queryUtil, disambiguate)));
         queryDsl.put("size", queryParams.limit);
         queryDsl.put("from", queryParams.offset);
         queryDsl.put("sort", (queryParams.sortBy == Sort.DEFAULT_BY_RELEVANCY && queryTree.isWild()

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -85,7 +85,7 @@ public class SearchUtils2 {
     private Map<String, Object> getEsQueryDsl(QueryTree queryTree, QueryParams queryParams, AppParams.StatsRepr statsRepr) {
         var queryDsl = new LinkedHashMap<String, Object>();
 
-        queryDsl.put("query", getEsQuery(queryTree, queryParams.boost));
+        queryDsl.put("query", getEsQuery(queryTree, queryParams.boostFields));
         queryDsl.put("size", queryParams.limit);
         queryDsl.put("from", queryParams.offset);
         queryDsl.put("sort", (queryParams.sortBy == Sort.DEFAULT_BY_RELEVANCY && queryTree.isWild()
@@ -115,11 +115,11 @@ public class SearchUtils2 {
         return queryDsl;
     }
 
-    private Map<String, Object> getEsQuery(QueryTree queryTree, String boostParam) {
-        if (boostParam.contains("^")) {
-            return queryTree.toEs(queryUtil, disambiguate, List.of(boostParam.split(",")));
+    private Map<String, Object> getEsQuery(QueryTree queryTree, List<String> boostFields) {
+        if (!boostFields.isEmpty()) {
+            return queryTree.toEs(queryUtil, disambiguate, boostFields);
         }
-        List<String> boostFields = queryUtil.esBoost.getBoostFields(queryTree.collectTypes());
+        boostFields = queryUtil.esBoost.getBoostFields(queryTree.collectTypes());
         return addConstantBoosts(queryTree.toEs(queryUtil, disambiguate, boostFields));
     }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -85,7 +85,7 @@ public class SearchUtils2 {
     private Map<String, Object> getEsQueryDsl(QueryTree queryTree, QueryParams queryParams, AppParams.StatsRepr statsRepr) {
         var queryDsl = new LinkedHashMap<String, Object>();
 
-        queryDsl.put("query", addConstantBoosts(queryTree.toEs(queryUtil, disambiguate)));
+        queryDsl.put("query", getEsQuery(queryTree, queryParams.boost));
         queryDsl.put("size", queryParams.limit);
         queryDsl.put("from", queryParams.offset);
         queryDsl.put("sort", (queryParams.sortBy == Sort.DEFAULT_BY_RELEVANCY && queryTree.isWild()
@@ -115,7 +115,15 @@ public class SearchUtils2 {
         return queryDsl;
     }
 
-    public Map<String, Object> getPartialCollectionView(QueryResult queryResult,
+    private Map<String, Object> getEsQuery(QueryTree queryTree, String boostParam) {
+        if (boostParam.contains("^")) {
+            return queryTree.toEs(queryUtil, disambiguate, List.of(boostParam.split(",")));
+        }
+        List<String> boostFields = queryUtil.esBoost.getBoostFields(queryTree.collectTypes());
+        return addConstantBoosts(queryTree.toEs(queryUtil, disambiguate, boostFields));
+    }
+
+    private Map<String, Object> getPartialCollectionView(QueryResult queryResult,
                                                         QueryTree qt,
                                                         QueryParams queryParams,
                                                         AppParams appParams) {

--- a/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
@@ -122,9 +122,10 @@ class ESQueryLensBoost {
                 def obj = [(JsonLd.TYPE_KEY): rangeKey]
                 def rangeChipLens = jsonld.getLensFor(obj, chipsLenses)
                 def rangeChipFields = collectBoostFields(
-                        rangeChipLens, CARD_BOOST, seenKeys)
+                        rangeChipLens, CARD_BOOST, [] as Set)
 
                 return rangeChipFields.collect { "${key}.$it" as String }
+                        .findAll {!seenKeys.contains(it) }
             } else {
                 key = "${key}.${JsonLd.SEARCH_KEY}"
             }

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -104,7 +104,7 @@ public class Disambiguate {
     }
 
     public OutsetType decideOutset(QueryTree qt) {
-        Set<OutsetType> outset = qt.collectGivenTypes()
+        Set<OutsetType> outset = qt.collectTypes()
                 .stream()
                 .map(this::getOutsetType)
                 .collect(Collectors.toSet());

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -287,11 +287,11 @@ public class EsBoost {
                 String termType = (String) term.get(TYPE_KEY);
                 if ("ObjectProperty".equals(termType)) {
                     key = key + "." + SEARCH_KEY;
-                } else if (jsonLd.isLangContainer(jsonLd.context.get(key))) {
-                    key = key + "." + jsonLd.locales.getFirst();
                 }
+                boostFields.put(key, boost);
+            } else if (jsonLd.isLangContainer(jsonLd.context.get(key))) {
+                boostFields.put(key + "." + jsonLd.locales.getFirst(), boost);
             }
-            boostFields.put(key, boost);
         }
 
         return boostFields;

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -1,0 +1,358 @@
+package whelk.search2;
+
+import whelk.JsonLd;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static whelk.JsonLd.ALTERNATE_PROPERTIES;
+import static whelk.JsonLd.ID_KEY;
+import static whelk.JsonLd.RANGE;
+import static whelk.JsonLd.SEARCH_KEY;
+import static whelk.JsonLd.SUB_PROPERTY_OF;
+import static whelk.JsonLd.TYPE_KEY;
+import static whelk.JsonLd.asList;
+import static whelk.util.DocumentUtil.getAtPath;
+
+public class EsBoost {
+    private static final int CHIP_BOOST = 200;
+    private static final int STR_BOOST = 100;
+    private static final int CARD_BOOST = 10;
+
+    JsonLd jsonLd;
+    Chips chipLenses;
+    Cards cardLenses;
+
+    private final Map<String, List<String>> boostFieldsByType = new HashMap<>();
+
+    EsBoost(JsonLd jsonLd) {
+        this.jsonLd = jsonLd;
+        this.chipLenses = collectChipLenses();
+        this.cardLenses = collectCardLenses();
+    }
+
+    public List<String> getBoostFields(Collection<String> types) {
+        List<String> sortedTypes = types.stream().sorted().toList();
+
+        String typeKey = String.join(",", sortedTypes);
+
+        List<String> boostFields = boostFieldsByType.getOrDefault(typeKey, computeBoostFields(sortedTypes));
+        boostFieldsByType.put(typeKey, boostFields);
+
+        return boostFields;
+    }
+
+    private List<String> computeBoostFields(List<String> types) {
+        /* FIXME:
+           lensBoost.computeBoostFieldsFromLenses does not give a good result for Concept.
+           Use hand-tuned boosting instead until we improve boosting/ranking in general. See LXL-3399 for details.
+        */
+        List<String> conceptTypes = new ArrayList<>();
+        List<String> otherTypes = new ArrayList<>();
+        for (String s : types) {
+            if (jsonLd.isSubClassOf(s, "Concept")) {
+                conceptTypes.add(s);
+            } else {
+                otherTypes.add(s);
+            }
+        }
+
+        Map<String, Integer> boostFields;
+
+        if (conceptTypes.isEmpty()) {
+            boostFields = computeBoostFieldsFromLenses(otherTypes);
+        } else {
+            boostFields = CONCEPT_BOOST.stream()
+                    .map(s -> s.split("\\^"))
+                    .collect(Collectors.toMap(parts -> parts[0], parts -> Integer.parseInt(parts[1])));
+
+            computeBoostFieldsFromLenses(otherTypes).forEach(boostFields::putIfAbsent);
+        }
+
+        return boostFields.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .sorted(Map.Entry.comparingByValue(Collections.reverseOrder()))
+                .map(e -> e.getKey() + "^" + e.getValue())
+                .toList();
+    }
+
+    private Map<String, Integer> computeBoostFieldsFromLenses(List<String> types) {
+        Map<String, Integer> boostFields = new HashMap<>();
+
+        boostFields.put(SEARCH_KEY, STR_BOOST);
+
+        var baseTypes = List.of("Identity", "Instance", "Item");
+
+        collectLenses().forEach(lensGroup ->
+                lensGroup.collectBoostFields(types, baseTypes)
+                        .forEach(boostFields::putIfAbsent)
+        );
+
+        return boostFields;
+    }
+
+    private List<LensGroup> collectLenses() {
+        List<LensGroup> lensGroups = new ArrayList<>();
+        lensGroups.add(chipLenses);
+        lensGroups.add(cardLenses);
+        return lensGroups;
+    }
+
+    private Chips collectChipLenses() {
+        List<Lens> chips = new ArrayList<>();
+
+        ((Map<?, ?>) getAtPath(jsonLd.displayData, List.of("lensGroups", "chips", "lenses"), Collections.emptyMap()))
+                .forEach((type, lens) -> chips.add(new EsBoost.Chip((String) type, (Map<?, ?>) lens)));
+
+        return new Chips(chips);
+    }
+
+    private Cards collectCardLenses() {
+        List<Lens> cards = new ArrayList<>();
+
+        ((Map<?, ?>) getAtPath(jsonLd.displayData, List.of("lensGroups", "cards", "lenses"), Collections.emptyMap()))
+                .forEach((type, lens) -> cards.add(new EsBoost.Card((String) type, (Map<?, ?>) lens)));
+
+        return new Cards(cards);
+    }
+
+    private sealed abstract class LensGroup permits Cards, Chips {
+        abstract List<Lens> lenses();
+
+        abstract Lens newLens(String type, Map<?, ?> lens);
+
+        Map<String, Integer> collectBoostFields(List<String> types, List<String> baseTypes) {
+            Map<String, Integer> boostFields = new HashMap<>();
+            getLensesForTypes(types, baseTypes)
+                    .forEach(lens -> boostFields.putAll(lens.collectBoostFields()));
+            return boostFields;
+        }
+
+        Map<?, ?> getLensForType(String type) {
+            var lensMap = Map.of("lenses", lenses().stream().collect(Collectors.toMap(Lens::type, Lens::lens)));
+            return jsonLd.getLensFor(Map.of(TYPE_KEY, type), lensMap);
+        }
+
+        private List<Lens> getLensesForTypes(List<String> types, List<String> baseTypes) {
+            return !types.isEmpty() ? getLensesForTypes(types) : getLensesForBaseTypes(baseTypes);
+        }
+
+        private List<Lens> getLensesForTypes(List<String> types) {
+            List<Lens> lenses = new ArrayList<>();
+            types.forEach(t ->
+                    Optional.ofNullable(getLensForType(t))
+                            .map(lens -> newLens(t, lens))
+                            .ifPresent(lenses::add)
+            );
+            return lenses;
+        }
+
+        private List<Lens> getLensesForBaseTypes(List<String> baseTypes) {
+            return lenses().stream()
+                    .filter(c -> baseTypes.stream().anyMatch(c::partiallyAppliesTo))
+                    .toList();
+        }
+    }
+
+    private final class Chips extends LensGroup {
+        List<Lens> chips;
+
+        Chips(List<Lens> chips) {
+            this.chips = chips;
+        }
+
+        @Override
+        List<Lens> lenses() {
+            return chips;
+        }
+
+        @Override
+        Lens newLens(String type, Map<?, ?> lens) {
+            return new Chip(type, lens);
+        }
+    }
+
+    private final class Cards extends LensGroup {
+        List<Lens> cards;
+
+        Cards(List<Lens> cards) {
+            this.cards = cards;
+        }
+
+        @Override
+        List<Lens> lenses() {
+            return cards;
+        }
+
+        @Override
+        Lens newLens(String type, Map<?, ?> lens) {
+            return new Card(type, lens);
+        }
+    }
+
+    private sealed abstract class Lens permits EsBoost.Card, Chip {
+        abstract String type();
+
+        abstract Map<?, ?> lens();
+
+        abstract Map<String, Integer> collectBoostFields();
+
+        boolean partiallyAppliesTo(String baseType) {
+            return jsonLd.isSubClassOf((String) lens().get("classLensDomain"), baseType);
+        }
+    }
+
+    private final class Chip extends Lens {
+        String type;
+        Map<?, ?> lens;
+
+        Chip(String type, Map<?, ?> lens) {
+            this.type = type;
+            this.lens = lens;
+        }
+
+        @Override
+        String type() {
+            return type;
+        }
+
+        @Override
+        Map<?, ?> lens() {
+            return lens;
+        }
+
+        @Override
+        Map<String, Integer> collectBoostFields() {
+            return EsBoost.this.collectBoostFields(lens, CHIP_BOOST);
+        }
+    }
+
+    private final class Card extends Lens {
+        String type;
+        Map<?, ?> lens;
+
+        Card(String type, Map<?, ?> lens) {
+            this.type = type;
+            this.lens = lens;
+        }
+
+        @Override
+        String type() {
+            return type;
+        }
+
+        @Override
+        Map<?, ?> lens() {
+            return lens;
+        }
+
+        @Override
+        Map<String, Integer> collectBoostFields() {
+            Map<String, Integer> boostFields = new HashMap<>();
+            getPropertiesToShow(lens).stream()
+                    .map(EsBoost.this::computeCardPropertyBoosts)
+                    .forEach(boostFields::putAll);
+            return boostFields;
+        }
+    }
+
+    private Map<String, Integer> collectBoostFields(Map<?, ?> lens, int boost) {
+        Map<String, Integer> boostFields = new HashMap<>();
+
+        for (String key : getPropertiesToShow(lens)) {
+            Map<String, Object> term = jsonLd.vocabIndex.get(key);
+            if (term != null) {
+                String termType = (String) term.get(TYPE_KEY);
+                if ("ObjectProperty".equals(termType)) {
+                    key = key + "." + SEARCH_KEY;
+                } else if (jsonLd.isLangContainer(jsonLd.context.get(key))) {
+                    key = key + "." + jsonLd.locales.getFirst();
+                }
+            }
+            boostFields.put(key, boost);
+        }
+
+        return boostFields;
+    }
+
+    private static List<String> getPropertiesToShow(Map<?, ?> lens) {
+        var properties = new LinkedHashSet<String>();
+
+        for (var dfn : (List<?>) lens.get("showProperties")) {
+            if (dfn instanceof String) {
+                properties.add((String) dfn);
+            } else if (dfn instanceof Map) {
+                for (var alt : asList(((Map<?, ?>) dfn).get(ALTERNATE_PROPERTIES))) {
+                    if (alt instanceof String) {
+                        properties.add((String) alt);
+                    } else if (alt instanceof Map) {
+                        var subPropertyOf = ((Map<?, ?>) alt).get(SUB_PROPERTY_OF);
+                        if (subPropertyOf != null) {
+                            properties.add((String) subPropertyOf);
+                        }
+                    }
+                }
+            }
+        }
+
+        return properties.stream().toList();
+    }
+
+    private Map<String, Integer> computeCardPropertyBoosts(String prop) {
+        Map<String, Integer> boostFields = new HashMap<>();
+
+        Map<String, Object> dfn = jsonLd.vocabIndex.get(prop);
+
+        // Follow the object property range to append chip properties to the boosted path.
+        if (dfn != null && "ObjectProperty".equals(dfn.get(TYPE_KEY))) {
+            Optional<String> rangeKey = Optional.ofNullable(dfn.get(RANGE))
+                    .map(r -> r instanceof List ? ((List<?>) r).getFirst() : r)
+                    .map(Map.class::cast)
+                    .map(r -> (String) r.get(ID_KEY))
+                    .map(jsonLd::toTermKey);
+
+            if (rangeKey.isPresent() && jsonLd.isSubClassOf(rangeKey.get(), "QualifiedRole")) {
+                var rangeChipLens = chipLenses.getLensForType(rangeKey.get());
+                collectBoostFields(rangeChipLens, CARD_BOOST).forEach((k, v) -> boostFields.put(prop + "." + k, v));
+            } else {
+                boostFields.put(prop + "." + SEARCH_KEY, CARD_BOOST);
+            }
+        } else if (jsonLd.isLangContainer(jsonLd.context.get(prop))) {
+            boostFields.put(prop + "." + jsonLd.locales.getFirst(), CARD_BOOST);
+        }
+
+        return boostFields;
+    }
+
+    private static final List<String> CONCEPT_BOOST = List.of(
+            "prefLabel^1500",
+            "prefLabelByLang.sv^1500",
+            "label^500",
+            "labelByLang.sv^500",
+            "code^200",
+            "termComponentList._str.exact^125",
+            "termComponentList._str^75",
+            "altLabel^150",
+            "altLabelByLang.sv^150",
+            "hasVariant.prefLabel.exact^150",
+            "_str.exact^100",
+            "inScheme._str.exact^100",
+            "inScheme._str^100",
+            "inCollection._str.exact^10",
+            "broader._str.exact^10",
+            "exactMatch._str.exact^10",
+            "closeMatch._str.exact^10",
+            "broadMatch._str.exact^10",
+            "related._str.exact^10",
+            "scopeNote^10",
+            "keyword._str.exact^10"
+    );
+}

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -21,7 +21,6 @@ import static whelk.JsonLd.SEARCH_KEY;
 import static whelk.JsonLd.SUB_PROPERTY_OF;
 import static whelk.JsonLd.TYPE_KEY;
 import static whelk.JsonLd.asList;
-import static whelk.search2.QueryUtil.boolWrap;
 import static whelk.search2.QueryUtil.mustWrap;
 import static whelk.search2.QueryUtil.shouldWrap;
 import static whelk.util.DocumentUtil.getAtPath;

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -28,6 +28,7 @@ public class QueryParams {
         public static final String EXTRA = "_x";
         public static final String DEBUG = "_debug";
         public static final String APP_CONFIG = "_appConfig";
+        public static final String BOOST = "_boost";
     }
 
     public static class Debug {
@@ -44,6 +45,7 @@ public class QueryParams {
     public final List<String> debug;
     public final String lens;
     public final Spell spell;
+    public final String boost;
 
     public final String q;
     public final String i;
@@ -58,6 +60,7 @@ public class QueryParams {
         this.offset = getOffset(apiParameters);
         this.lens = getOptionalSingleNonEmpty(ApiParams.LENS, apiParameters).orElse("cards");
         this.spell = new Spell(getOptionalSingleNonEmpty(ApiParams.SPELL, apiParameters).orElse(""));
+        this.boost = getOptionalSingleNonEmpty(ApiParams.BOOST, apiParameters).orElse("");
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
     }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -2,7 +2,6 @@ package whelk.search2;
 
 import whelk.exception.InvalidQueryException;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -10,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-
-import static whelk.util.Jackson.mapper;
 
 public class QueryParams {
     private final static int DEFAULT_LIMIT = 200;
@@ -35,6 +32,7 @@ public class QueryParams {
 
     public static class Debug {
         public static final String ES_QUERY = "esQuery";
+        public static final String ES_SCORE = "esScore";
     }
 
     public final int limit;
@@ -50,8 +48,7 @@ public class QueryParams {
     public final String q;
     public final String i;
 
-    public QueryParams(Map<String, String[]> apiParameters) throws InvalidQueryException,
-            IOException {
+    public QueryParams(Map<String, String[]> apiParameters) throws InvalidQueryException {
         this.sortBy = Sort.fromString(getOptionalSingleNonEmpty(ApiParams.SORT, apiParameters).orElse(""));
         this.object = getOptionalSingleNonEmpty(ApiParams.OBJECT, apiParameters).orElse(null);
         this.predicates = getMultiple(ApiParams.PREDICATES, apiParameters);

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -45,7 +45,7 @@ public class QueryParams {
     public final List<String> debug;
     public final String lens;
     public final Spell spell;
-    public final String boost;
+    public final List<String> boostFields;
 
     public final String q;
     public final String i;
@@ -60,7 +60,7 @@ public class QueryParams {
         this.offset = getOffset(apiParameters);
         this.lens = getOptionalSingleNonEmpty(ApiParams.LENS, apiParameters).orElse("cards");
         this.spell = new Spell(getOptionalSingleNonEmpty(ApiParams.SPELL, apiParameters).orElse(""));
-        this.boost = getOptionalSingleNonEmpty(ApiParams.BOOST, apiParameters).orElse("");
+        this.boostFields = getMultiple(ApiParams.BOOST, apiParameters);
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
     }
@@ -94,6 +94,9 @@ public class QueryParams {
         }
         if (!debug.isEmpty()) {
             params.put(ApiParams.DEBUG, String.join(",", debug));
+        }
+        if (!boostFields.isEmpty()) {
+            params.put(ApiParams.BOOST, String.join(",", boostFields));
         }
         return params;
     }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
@@ -58,6 +58,7 @@ public class QueryResult {
     private static List<Map<String, Object>> collectScores(Map<String, Object> esResponse) {
         return ((List<?>) getAtPath(esResponse, List.of("hits", "hits"), Collections.emptyList()))
                 .stream()
+                .filter(m -> ((Map<?, ?>) m).get("_score") != null)
                 .map(QueryUtil::castToStringObjectMap)
                 .filter(m -> m.keySet().retainAll(List.of("_id", "_score", "_explanation")))
                 .toList();

--- a/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
@@ -13,36 +13,54 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static whelk.search2.QueryUtil.castToStringObjectMap;
+import static whelk.util.DocumentUtil.getAtPath;
+
 public class QueryResult {
     public final int numHits;
     private final List<EsItem> esItems;
     public final List<Aggs.Aggregation> aggs;
     public final List<Aggs.Bucket> pAggs;
     public final List<Spell.Suggestion> spell;
+    public final List<Map<String, Object>> scores;
 
     public QueryResult(Map<?, ?> esResponse) {
         var normResponse = normalizeResponse(esResponse);
-        this.numHits = (int) normResponse.getOrDefault("totalHits", 0);
-        this.esItems = getEsItems(normResponse);
+        this.numHits = getNumHits(normResponse);
+        this.esItems = collectEsItems(normResponse);
         this.aggs = Aggs.collectAggResult(normResponse);
         this.pAggs = Aggs.collectPAggResult(normResponse);
         this.spell = Spell.collectSuggestions(normResponse);
+        this.scores = collectScores(normResponse);
     }
 
     public List<Map<String, Object>> collectItems(Function<Map<String, Object>, Map<String, Object>> applyLens) {
         return esItems.stream().map(item -> item.toLd(applyLens)).toList();
     }
 
-    private static List<EsItem> getEsItems(Map<String, Object> esResponse) {
-        return getAsList(esResponse, "items")
+    private static int getNumHits(Map<String, Object> esResponse) {
+        return (int) getAtPath(esResponse, List.of("hits", "total", "value"), 1);
+    }
+
+    private static List<EsItem> collectEsItems(Map<String, Object> esResponse) {
+        return ((List<?>) getAtPath(esResponse, List.of("hits", "hits"), Collections.emptyList()))
                 .stream()
-                .map(QueryUtil::castToStringObjectMap)
+                .map(Map.class::cast)
+                .map(hit -> {
+                    var item = castToStringObjectMap(hit.get("_source"));
+                    item.put("_id", hit.get("_id"));
+                    return item;
+                })
                 .map(EsItem::new)
                 .toList();
     }
 
-    private static List<?> getAsList(Map<String, Object> m, String key) {
-        return ((List<?>) m.getOrDefault(key, Collections.emptyList()));
+    private static List<Map<String, Object>> collectScores(Map<String, Object> esResponse) {
+        return ((List<?>) getAtPath(esResponse, List.of("hits", "hits"), Collections.emptyList()))
+                .stream()
+                .map(QueryUtil::castToStringObjectMap)
+                .filter(m -> m.keySet().retainAll(List.of("_id", "_score", "_explanation")))
+                .toList();
     }
 
     private static Map<String, Object> normalizeResponse(Map<?, ?> esResponse) {
@@ -97,7 +115,7 @@ public class QueryResult {
         }
 
         private List<Map<String, Object>> getIdentifiedBy() {
-            return getAsList(map, "identifiedBy")
+            return ((List<?>) map.getOrDefault("identifiedBy", Collections.emptyList()))
                     .stream()
                     .map(QueryUtil::castToStringObjectMap)
                     .collect(Collectors.toList());

--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -4,7 +4,6 @@ import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 import whelk.JsonLd;
 import whelk.Whelk;
-import whelk.search.ESQueryLensBoost;
 import whelk.search2.querytree.QueryTree;
 import whelk.util.DocumentUtil;
 
@@ -25,12 +24,12 @@ public class QueryUtil {
 
     private final Whelk whelk;
     public final EsMappings esMappings;
-    public final ESQueryLensBoost lensBoost;
+    public final EsBoost esBoost;
 
     public QueryUtil(Whelk whelk) {
         this.whelk = whelk;
         this.esMappings = new EsMappings(whelk.elastic != null ? whelk.elastic.getMappings() : Collections.emptyMap());
-        this.lensBoost = new ESQueryLensBoost(whelk.getJsonld());
+        this.esBoost = new EsBoost(whelk.getJsonld());
     }
 
     public Map<?, ?> query(Map<String, Object> queryDsl) {

--- a/whelk-core/src/main/groovy/whelk/search2/Spell.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Spell.java
@@ -3,6 +3,7 @@ package whelk.search2;
 import whelk.JsonLd;
 import whelk.search.ESQuery;
 import whelk.search2.querytree.QueryTree;
+import whelk.util.DocumentUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import static whelk.util.DocumentUtil.getAtPath;
 
 public class Spell {
     public record Suggestion(String text, String highlighted) {
@@ -45,7 +48,7 @@ public class Spell {
     }
 
     public static List<Suggestion> collectSuggestions(Map<String, Object> esResponse) {
-        return ((List<?>) esResponse.getOrDefault("spell", Collections.emptyList()))
+        return ((List<?>) getAtPath(esResponse, List.of("suggest", "simple_phrase", 0, "options"), Collections.emptyList()))
                 .stream()
                 .map(Map.class::cast)
                 .map(m -> new Suggestion((String) m.get("text"), (String) m.get("highlighted")))

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -39,10 +39,14 @@ public class QueryTree {
     }
 
     public Map<String, Object> toEs(QueryUtil queryUtil, Disambiguate disambiguate) {
-        return (isFiltered() ? filtered.tree : tree)
-                .expand(disambiguate, getOutsetType())
+        List<String> boostFields = queryUtil.esBoost.getBoostFields(getFiltered().collectGivenTypes());
+        return expand(disambiguate)
                 .insertNested(queryUtil::getNestedPath)
-                .toEs(queryUtil.lensBoost.computeBoostFieldsFromLenses(new String[0])); // TODO: Implement boosting
+                .toEs(boostFields);
+    }
+
+    private Node expand(Disambiguate disambiguate) {
+        return getFiltered().tree.expand(disambiguate, getOutsetType());
     }
 
     public Map<String, Object> toSearchMapping(Map<String, String> nonQueryParams) {
@@ -62,7 +66,7 @@ public class QueryTree {
     }
 
     public void setOutsetType(Disambiguate disambiguate) {
-        this.outsetType = disambiguate.decideOutset(isFiltered() ? filtered : this);
+        this.outsetType = disambiguate.decideOutset(getFiltered());
     }
 
     /**
@@ -394,8 +398,8 @@ public class QueryTree {
         this.filtered = new QueryTree(newTree);
     }
 
-    private boolean isFiltered() {
-        return filtered != null;
+    private QueryTree getFiltered() {
+        return filtered != null ? filtered : this;
     }
 
     private List<Node> getFilters(QueryParams queryParams, AppParams appParams) {

--- a/whelk-core/src/test/groovy/whelk/search2/EsBoostSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/EsBoostSpec.groovy
@@ -1,0 +1,88 @@
+package whelk.search2
+
+import spock.lang.Specification
+import whelk.JsonLd
+
+class EsBoostSpec extends Specification {
+    def "should compute boost fields from lenses"() {
+        given:
+        def ns = 'http://example.org/ns/'
+
+        def context = [
+                '@context': [
+                        '@vocab': ns
+                ]
+        ]
+
+        def display = [
+                "lensGroups": [
+                        "chips": [
+                                "lenses": [
+                                        "Instance"   : [
+                                                "classLensDomain": "Instance",
+                                                "showProperties" : ["hasTitle", "comment"]
+                                        ],
+                                        "Publication": [
+                                                "classLensDomain": "Publication",
+                                                "showProperties" : ["agent"]
+                                        ]
+                                ]
+                        ],
+                        "cards": [
+                                "lenses": [
+                                        "Instance": [
+                                                "classLensDomain": "Instance",
+                                                "showProperties" : [
+                                                        [
+                                                                "alternateProperties": [
+                                                                        [
+                                                                                "subPropertyOf": "hasTitle"
+                                                                        ],
+                                                                        [
+                                                                                "subPropertyOf": "value"
+                                                                        ],
+                                                                        [
+                                                                                "noise": "should be ignored"
+                                                                        ],
+                                                                        "hasTitle",
+                                                                        "value"
+                                                                ]
+                                                        ],
+                                                        "publication"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]
+
+        def vocab = [
+                "@graph": [
+                        ["@id": ns + "QualifiedRole", "@type": "Class"],
+                        ["@id"       : ns + "Publication", "@type": "Class",
+                         "subClassOf": ["@id": ns + "QualifiedRole"]],
+                        ["@id"       : ns + "Title", "@type": "Class",
+                         "subClassOf": ["@id": ns + "StructuredValue"]],
+                        ["@id"  : ns + "hasTitle", "@type": "ObjectProperty",
+                         "range": [["@id": ns + "Title"]]],
+                        ["@id"  : ns + "publication", "@type": "ObjectProperty",
+                         "range": [["@id": ns + "Publication"]]],
+                        ["@id"  : ns + "agent", "@type": "ObjectProperty",
+                         "range": [["@id": ns + "Agent"]]],
+                        ["@id": ns + "value", "@type": "DatatypeProperty"],
+                        ["@id": ns + "comment", "@type": "DatatypeProperty"]
+                ]
+        ]
+
+        def jsonld = new JsonLd(context, display, vocab)
+        def lensBoost = new EsBoost(jsonld)
+
+        when:
+        def boostFields = lensBoost.getBoostFields(["Instance"])
+
+        then:
+        boostFields == [
+                'comment^200', 'hasTitle._str^200', '_str^100', 'publication.agent._str^10', 'value^10'
+        ]
+    }
+}

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -176,7 +176,7 @@ class QueryTreeSpec extends Specification {
         ]))
 
         expect:
-        qt.collectGivenTypes() == [v1.string(), v3.string()] as Set
+        qt.collectTypes() == [v1.string(), v3.string()] as Set
     }
 
     def "collect given types"() {
@@ -189,7 +189,7 @@ class QueryTreeSpec extends Specification {
         ]))
 
         expect:
-        qt.collectGivenTypes() == ['type1', 'type3'] as Set
+        qt.collectTypes() == ['type1', 'type3'] as Set
     }
 
     def "get top level free text as string"() {


### PR DESCRIPTION
Boost same fields in Libris Search as in the cataloging.

- Code adapted from mainly [ESQueryLensBoost.groovy](https://github.com/libris/librisxl/blob/fef5958a9eb6798500d2f59f49748ab997323807/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy) and some parts from [ESQuery.groovy](https://github.com/libris/librisxl/blob/fef5958a9eb6798500d2f59f49748ab997323807/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy). Should produce exactly the same boosted fields.
- Set `_debug=esScore` to include scores + explanation in the API response. Works with both the "old" query style (using  `q` param) and the "new"  (`_q`). Thought it might facilitate working with improved relevance.
- Use `_boost` for custom boosting, e.g. `_boost=hasTitle.mainTitle^200,prefLabel^100...`.
- A bug was discovered in the existing code: When computing boosting from cards a field would not be boosted if another field containing the same nested subfield was already boosted. E.g. boosting `publication.year` would block `production.year` from being boosted. See fix: bdb3d0847be69881a58361dad22f19a801ee63dd.