### PR TITLE
fix(rest): sameAs redirect when exists deleted doc with same id

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -338,9 +338,14 @@ class Crud extends HttpServlet {
 
         Document doc = whelk.storage.load(id, version)
         if (doc) {
-            return new Tuple2(doc, null)
+            if (!doc.deleted) {
+                return new Tuple2(doc, null)
+            }
+            else {
+                result = new Tuple2(doc, null)
+            }
         }
-
+        
         // we couldn't find the document directly, so we look it up using the
         // identifiers table instead
         switch (whelk.storage.getIdType(id)) {


### PR DESCRIPTION
sameAs should redirect to the main id for the entity. 

This fixes the issue that a deleted (merged) doc with the same id would give 410 DELETED instead