### PR TITLE
Bugfix/delete referenced by bulk job

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2773,8 +2773,7 @@ class PostgreSQLComponent {
                 def allow = JsonLd.ALLOW_LINK_TO_DELETED + (jsonld?.cascadingDeleteRelations() ?: Collections.EMPTY_SET)
                 def referencedBy = followDependers(identifier, allow)
                 if (!referencedBy.isEmpty()) {
-                    def referencedByStr = referencedBy.collect { shortId, path -> "$shortId at $path" }.join(', ')
-                    throw new RuntimeException("Deleting depended upon records is not allowed. Referenced by: $referencedByStr")
+                    throw new RuntimeException("Deleting depended upon records is not allowed.")
                 }
             }
 

--- a/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/merge.groovy
@@ -27,15 +27,14 @@ selectByIds([deprecateId]) { obsolete ->
 }
 
 selectByIds(dependsOnObsolete) { depender ->
-    if (depender.doc.getThingType() == JOB_TYPE) {
-        return
-    }
-
     List<List> modifiedListPaths = []
     def modified = DocumentUtil.traverse(depender.graph) { value, path ->
         // TODO: What if there are links to a record uri?
         if (path && path.last() == ID_KEY && obsoleteThingUris.contains(value)) {
             path.dropRight(1).with {
+                if (it.last() == DEPRECATE_KEY) {
+                    return
+                }
                 if (it.last() instanceof Integer) {
                     modifiedListPaths.add(it.dropRight(1))
                 }


### PR DESCRIPTION
https://libris.kb.se/katalogisering/8tgnxg2q6d26k657 failed due to the term to deprecate (https://id.kb.se/term/barn/%C3%85lderdomshem) being referenced in another `bulk:Job` which prevented the term from being deleted. We should not exclude all links in `bulk:Job` from relinking but rather exclude links in `bulk:depŕecate`specifically.

Also fixed the error message which I think was very confusing, see https://libris.kb.se/_bulk-change/reports/8tgnxg2q6d26k657-2024-12-11T133742/ERRORS.txt. Only `k4rz49t1h5nfxls5 at bulk:changeSpec.bulk:matchForm.instanceOf.subject` is of interest, the rest are just records linking to k4rz49t1h5nfxls5 (directly or indirectly). This information is already available via "Används i" in the cat client anyway.