### PR TITLE
Don't throw exception when encountering invalid query terms

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
@@ -1,5 +1,6 @@
 package whelk.search2.querytree;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static whelk.JsonLd.TYPE_KEY;
@@ -11,6 +12,9 @@ public sealed interface InvalidKey {
     String key();
 
     default Map<String, Object> getDefinition() {
-        return Map.of(TYPE_KEY, "_Invalid", "label", key());
+        var m = new LinkedHashMap<String, Object>();
+        m.put(TYPE_KEY, "_Invalid");
+        m.put("label", key());
+        return m;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
@@ -5,16 +5,14 @@ import java.util.Map;
 
 import static whelk.JsonLd.TYPE_KEY;
 
-public sealed interface InvalidKey {
-    record UnrecognizedKey(String key) implements InvalidKey {}
-    record AmbiguousKey(String key) implements InvalidKey {}
+public sealed interface InvalidKey extends PropertyLike {
+    record UnrecognizedKey(String name) implements InvalidKey {}
+    record AmbiguousKey(String name) implements InvalidKey {}
 
-    String key();
-
-    default Map<String, Object> getDefinition() {
+    default Map<String, Object> definition() {
         var m = new LinkedHashMap<String, Object>();
         m.put(TYPE_KEY, "_Invalid");
-        m.put("label", key());
+        m.put("label", name());
         return m;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidKey.java
@@ -1,0 +1,16 @@
+package whelk.search2.querytree;
+
+import java.util.Map;
+
+import static whelk.JsonLd.TYPE_KEY;
+
+public sealed interface InvalidKey {
+    record UnrecognizedKey(String key) implements InvalidKey {}
+    record AmbiguousKey(String key) implements InvalidKey {}
+
+    String key();
+
+    default Map<String, Object> getDefinition() {
+        return Map.of(TYPE_KEY, "_Invalid", "label", key());
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidValue.java
@@ -1,0 +1,18 @@
+package whelk.search2.querytree;
+
+import java.util.Map;
+
+import static whelk.JsonLd.TYPE_KEY;
+
+sealed interface InvalidValue extends Value {
+    record ForbiddenValue(String string) implements InvalidValue {}
+    record AmbiguousValue(String string) implements InvalidValue {}
+
+    @Override
+    String string();
+
+    @Override
+    default Object description() {
+        return Map.of(TYPE_KEY, "_Invalid", "label", string());
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InvalidValue.java
@@ -1,5 +1,6 @@
 package whelk.search2.querytree;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static whelk.JsonLd.TYPE_KEY;
@@ -13,6 +14,9 @@ sealed interface InvalidValue extends Value {
 
     @Override
     default Object description() {
-        return Map.of(TYPE_KEY, "_Invalid", "label", string());
+        var m = new LinkedHashMap<String, Object>();
+        m.put(TYPE_KEY, "_Invalid");
+        m.put("label", string());
+        return m;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -26,7 +26,9 @@ public record Path(List<Object> path, Optional<String> nestedStem) {
     @Override
     public String toString() {
         return path.stream()
-                .map(x -> x instanceof Property ? ((Property) x).name() : (String) x)
+                .map(x -> x instanceof Property p
+                        ? p.name() :
+                        (x instanceof InvalidKey i ? i.key() : (String) x))
                 .map(this::substitute)
                 .collect(Collectors.joining("."));
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -26,9 +26,7 @@ public record Path(List<Object> path, Optional<String> nestedStem) {
     @Override
     public String toString() {
         return path.stream()
-                .map(x -> x instanceof Property p
-                        ? p.name() :
-                        (x instanceof InvalidKey i ? i.key() : (String) x))
+                .map(x -> x instanceof PropertyLike p ? p.name() : (String) x)
                 .map(this::substitute)
                 .collect(Collectors.joining("."));
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -47,14 +47,12 @@ public record PathValue(Path path, Operator operator, Value value) implements No
         var propertyChainAxiom = new LinkedList<>();
 
         for (int i = getPath().size() - 1; i >= 0; i--) {
-            var property = Optional.of(getPath().get(i))
-                    .filter(x -> x instanceof Property)
-                    .map(Property.class::cast);
-
-            if (property.isPresent()) {
+            if (getPath().get(i) instanceof Property property) {
                 propertyChainAxiom.push(i > 0 && getPath().get(i - 1).equals(JsonLd.REVERSE_KEY)
-                        ? Map.of("inverseOf", property.get().definition())
-                        : property.get().definition());
+                        ? Map.of("inverseOf", property.definition())
+                        : property.definition());
+            } else if (getPath().get(i) instanceof InvalidKey invalid) {
+                propertyChainAxiom.push(invalid.getDefinition());
             }
         }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -47,12 +47,10 @@ public record PathValue(Path path, Operator operator, Value value) implements No
         var propertyChainAxiom = new LinkedList<>();
 
         for (int i = getPath().size() - 1; i >= 0; i--) {
-            if (getPath().get(i) instanceof Property property) {
+            if (getPath().get(i) instanceof PropertyLike property) {
                 propertyChainAxiom.push(i > 0 && getPath().get(i - 1).equals(JsonLd.REVERSE_KEY)
                         ? Map.of("inverseOf", property.definition())
                         : property.definition());
-            } else if (getPath().get(i) instanceof InvalidKey invalid) {
-                propertyChainAxiom.push(invalid.getDefinition());
             }
         }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -9,12 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static whelk.search2.Disambiguate.RDF_TYPE;
 
-public class Property {
+public class Property implements PropertyLike {
     public enum DomainCategory {
         ADMIN_METADATA,
         WORK,

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyLike.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyLike.java
@@ -1,0 +1,8 @@
+package whelk.search2.querytree;
+
+import java.util.Map;
+
+public interface PropertyLike {
+    String name();
+    Map<String, Object> definition();
+}

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Value.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Value.java
@@ -1,6 +1,6 @@
 package whelk.search2.querytree;
 
-public sealed interface Value permits Link, Literal, VocabTerm {
+public sealed interface Value permits Link, Literal, InvalidValue, VocabTerm {
     String string();
 
     Object description();


### PR DESCRIPTION
Proceed with the query in the usual way (we won't get any hits though), however mark the invalid parts in `search.mapping` like this:
```
{
    "@type": "_Invalid",
    "label": "theInvalidInputString"
}
```
This can apply to both keys and values. So if we type for example `type:Kalle x:y subject:horses` we get
```
"search": {
    "mapping": [
      {
        "and": [
          {
            "property": {
              "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
              "@type": "ObjectProperty",
              "labelByLang": {
                "en": "type",
                "sv": "typ"
              }
            },
            "equals": {
              "@type": "_Invalid",
              "label": "Kalle"
            },
            "up": {
              "@id": "/find?_i=&_q=x:y+subject:horses&_limit=200"
            }
          },
          {
            property": {
              "@type": "_Invalid",
              "label": "x"
            },
            "equals": "y",
            "up": {
              "@id": "/find?_i=&_q=%22rdf:type%22:Kalle+subject:horses&_limit=200"
            }
          },
          {
            "property": {
              "@id": "https://id.kb.se/vocab/subject",
              "@type": "ObjectProperty",
               ...
            },
            "equals": "horses",
            "up": {
              "@id": "/find?_i=&_q=%22rdf:type%22:Kalle+x:y&_limit=200"
            }
          }
        ],
        "up": {
          "@id": "/find?_i=&_q=*&_limit=200"
        }
      }
    ]
  }
```
since `x` is an invalid key and `Kalle` is and invalid value for the property `rdf:type`.

Eventually we may need more details about why a certain string is invalid and, consequently, also a more expressive model. Let's see. Stick with the temporary `_Invalid` type for now.