### PR TITLE
Feature/vocab guided query expansion

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -102,7 +102,7 @@ public class SearchUtils2 {
             }
         }
 
-        queryDsl.put("aggs", Aggs.buildAggQuery(statsRepr, disambiguate, queryTree.getQueryBaseType(disambiguate), queryUtil::getNestedPath));
+        queryDsl.put("aggs", Aggs.buildAggQuery(statsRepr, disambiguate, queryTree.collectRulingTypes(disambiguate), queryUtil::getNestedPath));
         queryDsl.put("track_total_hits", true);
 
         if (queryParams.debug.contains(QueryParams.Debug.ES_SCORE)) {
@@ -115,10 +115,6 @@ public class SearchUtils2 {
     }
 
     private Map<String, Object> getEsQuery(QueryTree queryTree, List<String> boostFields) {
-        if (!boostFields.isEmpty()) {
-            return queryTree.toEs(queryUtil, disambiguate, boostFields);
-        }
-        boostFields = queryUtil.esBoost.getBoostFields(queryTree.collectTypes());
         return addConstantBoosts(queryTree.toEs(queryUtil, disambiguate, boostFields));
     }
 

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -60,7 +60,6 @@ public class SearchUtils2 {
         }
 
         qTree.addFilters(queryParams, appParams);
-        qTree.setOutsetType(disambiguate);
 
         Map<String, Object> esQueryDsl = getEsQueryDsl(qTree, queryParams, appParams.statsRepr);
 
@@ -103,7 +102,7 @@ public class SearchUtils2 {
             }
         }
 
-        queryDsl.put("aggs", Aggs.buildAggQuery(statsRepr, disambiguate, queryTree.getOutsetType(), queryUtil::getNestedPath));
+        queryDsl.put("aggs", Aggs.buildAggQuery(statsRepr, disambiguate, queryTree.getQueryBaseType(disambiguate), queryUtil::getNestedPath));
         queryDsl.put("track_total_hits", true);
 
         if (queryParams.debug.contains(QueryParams.Debug.ES_SCORE)) {

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -82,7 +82,7 @@ class JsonLd {
 
     private static Logger log = LogManager.getLogger(JsonLd.class)
 
-    public Map<String, Map> context
+    public Map<String, Object> context
     public Map displayData
     public Map<String, Map<String, Object>> vocabIndex
 

--- a/whelk-core/src/main/groovy/whelk/search2/Aggs.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Aggs.java
@@ -35,7 +35,7 @@ public class Aggs {
 
     public static Map<String, Object> buildAggQuery(AppParams.StatsRepr statsRepr,
                                                     Disambiguate disambiguate,
-                                                    String queryBaseType,
+                                                    Collection<String> types,
                                                     Function<String, Optional<String>> getNestedPath) {
         if (statsRepr.isEmpty()) {
             return Map.of(JsonLd.TYPE_KEY,
@@ -47,7 +47,7 @@ public class Aggs {
 
         for (AppParams.Slice slice : statsRepr.sliceList()) {
             Property property = slice.property();
-            Node expanded = property.expand(disambiguate, queryBaseType);
+            Node expanded = property.expand(disambiguate, types);
             List<Node> altPaths = expanded instanceof Or ? expanded.children() : List.of(expanded);
 
             for (Node n : altPaths) {

--- a/whelk-core/src/main/groovy/whelk/search2/Aggs.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Aggs.java
@@ -10,6 +10,7 @@ import whelk.search2.querytree.Property;
 import whelk.search2.querytree.PropertyValue;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +35,7 @@ public class Aggs {
 
     public static Map<String, Object> buildAggQuery(AppParams.StatsRepr statsRepr,
                                                     Disambiguate disambiguate,
-                                                    OutsetType outsetType,
+                                                    String queryBaseType,
                                                     Function<String, Optional<String>> getNestedPath) {
         if (statsRepr.isEmpty()) {
             return Map.of(JsonLd.TYPE_KEY,
@@ -46,7 +47,7 @@ public class Aggs {
 
         for (AppParams.Slice slice : statsRepr.sliceList()) {
             Property property = slice.property();
-            Node expanded = property.expand(disambiguate, outsetType);
+            Node expanded = property.expand(disambiguate, queryBaseType);
             List<Node> altPaths = expanded instanceof Or ? expanded.children() : List.of(expanded);
 
             for (Node n : altPaths) {

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -338,11 +338,6 @@ public class Disambiguate {
         getAsListOfMaps(propertyDefinition, "equivalentProperty")
                 .forEach(ep -> getDefinition(ep, whelk).ifPresent(inheritable::add));
 
-        getAsOptionalListOfMaps(propertyDefinition, "propertyChainAxiom")
-                .map(List::getFirst)
-                .flatMap(firstInChain -> getDefinition(firstInChain, whelk))
-                .ifPresent(inheritable::add);
-
         getAsListOfMaps(propertyDefinition, Rdfs.SUBPROPERTY_OF)
                 .forEach(superProp -> getDefinition(superProp, whelk).ifPresent(inheritable::add));
 

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -12,6 +12,7 @@ import whelk.search2.querytree.Property;
 import whelk.search2.querytree.VocabTerm;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -71,8 +72,8 @@ public class Disambiguate {
         this.jsonLd = whelk.getJsonld();
         this.vocab = jsonLd.vocabIndex;
         this.integralRelations = jsonLd.getCategoryMembers("integral");
-        this.domainByProperty = new HashMap<>();
-        this.rangeByProperty = new HashMap<>();
+        this.domainByProperty = new ConcurrentHashMap<>();
+        this.rangeByProperty = new ConcurrentHashMap<>();
         setAliasMappings();
         // FIXME: This should probably not be a static variable...
         if (freeTextDefinition.isEmpty()) {

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import static whelk.JsonLd.ID_KEY;
 import static whelk.JsonLd.TYPE_KEY;
+import static whelk.JsonLd.VOCAB_KEY;
 import static whelk.JsonLd.asList;
 import static whelk.search2.QueryUtil.loadThing;
 import static whelk.util.DocumentUtil.getAtPath;
@@ -177,8 +178,9 @@ public class Disambiguate {
         return fromVocab.isEmpty() ? loadThing(iri, whelk) : Optional.of(fromVocab);
     }
 
-    private static boolean isKbvTerm(Map<?, ?> termDefinition) {
-        return "https://id.kb.se/vocab/".equals(get(termDefinition, List.of(Rdfs.IS_DEFINED_BY, ID_KEY), ""));
+    private boolean isSystemVocabTerm(Map<?, ?> termDefinition) {
+        return get(termDefinition, List.of(Rdfs.IS_DEFINED_BY, ID_KEY), "")
+                .equals(jsonLd.context.get(VOCAB_KEY));
     }
 
     private boolean isMarc(String termKey) {
@@ -412,7 +414,7 @@ public class Disambiguate {
         this.ambiguousEnumAliases = new TreeMap<>();
 
         vocab.forEach((termKey, termDefinition) -> {
-            if (isKbvTerm(termDefinition)) {
+            if (isSystemVocabTerm(termDefinition)) {
                 if (isClass(termDefinition)) {
                     addAllMappings(termKey, classAliasMappings, ambiguousClassAliases);
                 } else if (isProperty(termDefinition)) {

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -121,39 +121,6 @@ public class Disambiguate {
         return rangeByProperty.get(property);
     }
 
-    public boolean isInRange(String property, String type) {
-        return jsonLd.getInRange(type).contains(property);
-    }
-
-    public String lowestCommonBaseType(Collection<String> types) {
-        List<List<List<String>>> trees = types.stream().map(Arrays::asList).map(Arrays::asList).toList();
-        while (true) {
-            for (List<List<String>> tree : trees) {
-                var typesAtLevel = tree.getLast();
-                var typesAtNextLevel = typesAtLevel.stream()
-                        .map(t -> getAtPath(vocab, List.of(t, Rdfs.SUBCLASS_OF, "*", ID_KEY)))
-                        .filter(Objects::nonNull)
-                        .flatMap(obj -> ((List<?>) obj).stream())
-                        .map(t -> jsonLd.toTermKey((String) t))
-                        .toList();
-                tree.add(typesAtNextLevel);
-            }
-            Set<String> commonBaseTypes = trees.stream()
-                    .map(tree -> tree.stream().flatMap(List::stream).collect(Collectors.toSet()))
-                    .reduce((a, b) -> a.stream().filter(b::contains).collect(Collectors.toSet()))
-                    .get();
-            if (commonBaseTypes.size() > 1) {
-                // TODO: Test if this is a possible case
-            }
-            if (!commonBaseTypes.isEmpty()) {
-                return commonBaseTypes.iterator().next();
-            }
-            if (trees.stream().map(List::getLast).noneMatch(Predicate.not(List::isEmpty))) {
-                return Rdfs.RESOURCE;
-            }
-        }
-    }
-
     public List<String> getIntegralRelationsForType(String type) {
         return integralRelations.stream()
                 .filter(prop -> getDomain(prop).stream().anyMatch(domain -> jsonLd.isSubClassOf(type, domain)))

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -12,21 +12,23 @@ import whelk.search2.querytree.Property;
 import whelk.search2.querytree.VocabTerm;
 
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static whelk.JsonLd.ID_KEY;
+import static whelk.JsonLd.TYPE_KEY;
 import static whelk.JsonLd.asList;
+import static whelk.search2.QueryUtil.loadThing;
 import static whelk.util.DocumentUtil.getAtPath;
 
 public class Disambiguate {
     // :category :heuristicIdentifier too broad...?
-    private static final Set<String> notatingProps = new HashSet<>(Arrays.asList("label", "prefLabel", "altLabel", "code", "librisQueryCode"));
+    private static final Set<String> notatingProps = Set.of("label", "prefLabel", "altLabel", "code", "librisQueryCode");
 
     private Whelk whelk;
     private JsonLd jsonLd;
-    private Map<String, Map<String, Object>> vocab;
+    private final Map<String, Map<String, Object>> vocab;
     private Map<String, List<String>> domainByProperty;
     private Map<String, List<String>> rangeByProperty;
 
@@ -39,12 +41,6 @@ public class Disambiguate {
 
     private Set<String> integralRelations;
 
-    private enum TermType {
-        CLASS,
-        PROPERTY,
-        ENUM
-    }
-
     public static final class Rdfs {
         public static final String RESOURCE = "Resource";
         public static final String RDF_TYPE = "rdf:type";
@@ -53,6 +49,18 @@ public class Disambiguate {
         private static final String RANGE = "range";
         private static final String SUBCLASS_OF = "subClassOf";
         private static final String SUBPROPERTY_OF = "subPropertyOf";
+        private static final String IS_DEFINED_BY = "isDefinedBy";
+    }
+
+    private static final class Owl {
+        private static final String PROPERTY_CHAIN_AXIOM = "propertyChainAxiom";
+        private static final String RESTRICTION = "Restriction";
+        private static final String ON_PROPERTY = "onProperty";
+        private static final String HAS_VALUE = "hasValue";
+        private static final String EQUIVALENT_CLASS = "equivalentClass";
+        private static final String EQUIVALENT_PROPERTY = "equivalentProperty";
+        private static final String OBJECT_PROPERTY = "ObjectProperty";
+        private static final String DATATYPE_PROPERTY = "DatatypeProperty";
     }
 
     public static Map<String, Object> freeTextDefinition = Collections.emptyMap();
@@ -64,7 +72,7 @@ public class Disambiguate {
         this.integralRelations = jsonLd.getCategoryMembers("integral");
         this.domainByProperty = new HashMap<>();
         this.rangeByProperty = new HashMap<>();
-        setAliasMappings(whelk);
+        setAliasMappings();
         // FIXME: This should probably not be a static variable...
         if (freeTextDefinition.isEmpty()) {
             freeTextDefinition = getDefinition("textQuery");
@@ -72,11 +80,8 @@ public class Disambiguate {
     }
 
     // For test
-    public Disambiguate(Map<String, Object> data) {
-        // TODO: Load data to use for testing methods depending on this class
-        if (data.containsKey("vocab")) {
-            this.vocab = getVocab(data);
-        }
+    public Disambiguate(Map<String, Map<String, Object>> vocab) {
+        this.vocab = vocab;
     }
 
     public Optional<String> mapToProperty(String alias) {
@@ -103,8 +108,8 @@ public class Disambiguate {
         return ambiguousEnumAliases.getOrDefault(alias, Collections.emptySet());
     }
 
-    static public boolean isLdKey(String s) {
-        return JsonLd.LD_KEYS.contains(s);
+    public Map<String, Object> getDefinition(String termKey) {
+        return vocab.getOrDefault(termKey, Collections.emptyMap());
     }
 
     public List<String> getDomain(String property) {
@@ -127,6 +132,18 @@ public class Disambiguate {
                 .toList();
     }
 
+    public Set<String> getSubclasses(String type) {
+        return jsonLd.getSubClasses(type);
+    }
+
+    public Set<String> getSuperclasses(String type) {
+        return getSuperclasses(type, jsonLd);
+    }
+
+    public Object getChip(String iri) {
+        return loadThing(iri, whelk).map(jsonLd::toChip).orElse(Collections.emptyMap());
+    }
+
     public boolean isVocabTerm(String property) {
         return jsonLd.isVocabTerm(property);
     }
@@ -135,301 +152,33 @@ public class Disambiguate {
         return Rdfs.RDF_TYPE.equals(property) || jsonLd.getSubProperties(Rdfs.RDF_TYPE).contains(property);
     }
 
-    public Set<String> getSubclasses(String type) {
-        return jsonLd.getSubClasses(type);
-    }
-
     public boolean isSubclassOf(String type, String baseType) {
         return jsonLd.isSubClassOf(type, baseType);
     }
 
+    static public boolean isLdKey(String s) {
+        return JsonLd.LD_KEYS.contains(s);
+    }
+    
     public Node expandChainAxiom(Property property) {
-        List<Node> pathValueList = new ArrayList<>();
+        return _expandChainAxiom(property);
+    }
 
-        List<Object> path = new ArrayList<>();
+    private String getQueryCode(String property) {
+        return (String) getDefinition(property).get("librisQueryCode");
+    }
 
-        for (Map<?, ?> prop : getAsListOfMaps(property.definition(), "propertyChainAxiom")) {
-            var propKey = getLinkIri(prop).map(jsonLd::toTermKey);
-            if (propKey.isPresent()) {
-                path.add(new Property(propKey.get(), this));
-                continue;
-            }
-
-            propKey = getAsOptionalListOfMaps(prop, JsonLd.SUB_PROPERTY_OF)
-                    .map(List::getFirst)
-                    .flatMap(Disambiguate::getLinkIri)
-                    .map(jsonLd::toTermKey);
-
-            if (propKey.isEmpty()) {
-                throw new RuntimeException("Failed to expand chain axiom for property " + property);
-            }
-
-            path.add(new Property(propKey.get(), this));
-
-            for (Map<?, ?> r : getAsListOfMaps(prop, JsonLd.RANGE)) {
-                getLinkIri(r).map(jsonLd::toTermKey)
-                        .filter(vocab::containsKey)
-                        .ifPresent(term -> pathValueList.add(new PathValue(
-                                new Path(path).append(new Property(Rdfs.RDF_TYPE, this)),
-                                null,
-                                new VocabTerm(term, getDefinition(term))
-                        )));
-
-                for (Map<?, ?> sc : getAsListOfMaps(r, Rdfs.SUBCLASS_OF)) {
-                    if ("Restriction".equals(sc.get(JsonLd.TYPE_KEY))) {
-                        var onProperty = getAsOptionalMap(sc, "onProperty")
-                                .flatMap(Disambiguate::getLinkIri)
-                                .map(jsonLd::toTermKey)
-                                .map(p -> new Property(p, this));
-                        var hasValue = getAsOptionalMap(sc, "hasValue")
-                                .flatMap(Disambiguate::getLinkIri)
-                                .map(iri -> {
-                                            var termKey = jsonLd.toTermKey(iri);
-                                            return vocab.containsKey(termKey)
-                                                    ? new VocabTerm(termKey, getDefinition(termKey))
-                                                    : new Link(iri, getChip(iri));
-                                        }
-                                );
-                        if (onProperty.isPresent() && hasValue.isPresent()) {
-                            pathValueList.add(new PathValue(new Path(path).append(onProperty.get()), null, hasValue.get()));
-                        }
-                    }
-                }
-            }
+    private Optional<Map<?, ?>> getDefinition(Map<?, ?> link, Whelk whelk) {
+        var iri = get(link, ID_KEY, "");
+        if (iri.isEmpty()) {
+            return Optional.empty();
         }
-
-        pathValueList.add(new PathValue(path, null, null));
-
-        return pathValueList.size() == 1 ? pathValueList.getFirst() : new And(pathValueList);
-    }
-
-    private void setAliasMappings(Whelk whelk) {
-        this.propertyAliasMappings = new TreeMap<>();
-        this.ambiguousPropertyAliases = new TreeMap<>();
-        this.classAliasMappings = new TreeMap<>();
-        this.ambiguousClassAliases = new TreeMap<>();
-        this.enumAliasMappings = new TreeMap<>();
-        this.ambiguousEnumAliases = new TreeMap<>();
-
-        for (String termKey : vocab.keySet()) {
-            var termDefinition = vocab.get(termKey);
-
-            if (isKbvTerm(termDefinition)) {
-                if (isClass(termDefinition)) {
-                    addAllMappings(termDefinition, termKey, TermType.CLASS, whelk);
-                } else if (isProperty(termDefinition)) {
-                    addAllMappings(termDefinition, termKey, TermType.PROPERTY, whelk);
-                }
-            }
-
-            if (isMarc(termKey) && isProperty(termDefinition)) {
-                addMapping(termKey, termKey, TermType.PROPERTY);
-                addMapping(jsonLd.toTermId(termKey), termKey, TermType.PROPERTY);
-            }
-
-            if (isEnum(termDefinition)) {
-                addAllMappings(termDefinition, termKey, TermType.ENUM, whelk);
-            }
-
-            if (Rdfs.RDF_TYPE.equals(termKey)) {
-                addMapping(JsonLd.TYPE_KEY, termKey, TermType.PROPERTY);
-                addAllMappings(termDefinition, termKey, TermType.PROPERTY, whelk);
-            }
-        }
-
-        for (var m : ambiguousPropertyAliases.entrySet()) {
-            var alias = m.getKey();
-            var mappedProps = m.getValue();
-            for (String prop : mappedProps) {
-                if (getQueryCode(prop).filter(alias.toUpperCase()::equals).isPresent()) {
-                    propertyAliasMappings.put(alias, prop);
-                }
-                if (alias.equals(prop.toLowerCase())) {
-                    propertyAliasMappings.put(alias, prop);
-                }
-            }
-        }
-
-        for (var m : ambiguousClassAliases.entrySet()) {
-            var alias = m.getKey();
-            var mappedClasses = m.getValue();
-            for (String cls : mappedClasses) {
-                if (alias.equals(cls.toLowerCase())) {
-                    classAliasMappings.put(alias, cls);
-                }
-            }
-        }
-
-        for (var m : ambiguousEnumAliases.entrySet()) {
-            var alias = m.getKey();
-            var mappedEnums = m.getValue();
-            for (String e : mappedEnums) {
-                if (alias.equals(e.toLowerCase())) {
-                    enumAliasMappings.put(alias, e);
-                }
-            }
-        }
-    }
-
-    private void addAllMappings(Map<?, ?> termDefinition, String termKey, TermType termType, Whelk whelk) {
-        addMapping(termKey, termKey, termType);
-        addMappings(termDefinition, termKey, termType);
-        addEquivTermMappings(termDefinition, termKey, termType, whelk);
-    }
-
-    private void addEquivTermMappings(Map<?, ?> termDefinition, String termKey, TermType termType, Whelk whelk) {
-        String mappingProperty = switch (termType) {
-            case CLASS, ENUM -> "equivalentClass";
-            case PROPERTY -> "equivalentProperty";
-        };
-
-        getAsListOfMaps(termDefinition, mappingProperty)
-                .forEach(ep ->
-                        getLinkIri(ep).ifPresent(equivPropId -> {
-                            String equivPropKey = jsonLd.toTermKey(equivPropId);
-                            if (!vocab.containsKey(equivPropKey)) {
-                                QueryUtil.loadThing(equivPropId, whelk).ifPresentOrElse(
-                                        (equivPropDef) ->
-                                                addMappings(equivPropDef, termKey, termType),
-                                        () -> {
-                                            addMapping(equivPropId, termKey, termType);
-                                            addMapping(toPrefixed(equivPropId), termKey, termType);
-                                        }
-                                );
-                            }
-                        }));
-    }
-
-    private List<String> findDomainOrRange(String property, String domainOrRange) {
-        var propertyDefinition = vocab.get(property);
-        if (propertyDefinition == null) {
-            return Collections.emptyList();
-        }
-        return findDomainOrRange(propertyDefinition, domainOrRange, whelk);
-    }
-
-    private List<String> findDomainOrRange(Map<?, ?> propertyDefinition, String domainOrRange, Whelk whelk) {
-        return findDomainOrRange(new LinkedList<>(List.of(propertyDefinition)), domainOrRange, whelk, new HashSet<>());
-    }
-
-    private List<String> findDomainOrRange(LinkedList<Map<?, ?>> queue, String domainOrRange, Whelk whelk, Set<Map<?, ?>> seenDefs) {
-        if (queue.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        var propertyDefinition = queue.pop();
-
-        seenDefs.add(propertyDefinition);
-
-        List<String> domainOrRangeIris = getDomainOrRangeIris(propertyDefinition, domainOrRange);
-
-        if (!domainOrRangeIris.isEmpty()) {
-            return domainOrRangeIris.stream().map(jsonLd::toTermKey).toList();
-        }
-
-        queue.addAll(collectInheritable(propertyDefinition, whelk).stream().filter(Predicate.not(seenDefs::contains)).toList());
-
-        return findDomainOrRange(queue, domainOrRange, whelk, seenDefs);
-    }
-
-    List<Map<?, ?>> collectInheritable(Map<?, ?> propertyDefinition, Whelk whelk) {
-        List<Map<?, ?>> inheritable = new ArrayList<>();
-
-        getAsListOfMaps(propertyDefinition, "equivalentProperty")
-                .forEach(ep -> getDefinition(ep, whelk).ifPresent(inheritable::add));
-
-        getAsListOfMaps(propertyDefinition, Rdfs.SUBPROPERTY_OF)
-                .forEach(superProp -> getDefinition(superProp, whelk).ifPresent(inheritable::add));
-
-        return inheritable;
-    }
-
-    private Optional<String> getQueryCode(String property) {
-        return Optional.ofNullable((Map<?, ?>) vocab.get(property))
-                .map(propDef -> (String) propDef.get("librisQueryCode"));
-    }
-
-    private List<String> getDomainOrRangeIris(Map<?, ?> propertyDefinition, String domainOrRange) {
-        String prop = propertyDefinition.containsKey(domainOrRange) ? domainOrRange : domainOrRange + "Includes";
-        return get(propertyDefinition, List.of(prop, "*", ID_KEY), Collections.emptyList());
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> T get(Map<?, ?> m, List<Object> path, T defaultTo) {
-        return (T) getAtPath(m, path, defaultTo);
-    }
-
-    public Object getChip(String iri) {
-        return QueryUtil.loadThing(iri, whelk).map(jsonLd::toChip).orElse(Collections.emptyMap());
-    }
-
-    public Map<String, Object> getDefinition(String termKey) {
-        return vocab.getOrDefault(termKey, Collections.emptyMap());
-    }
-
-    private Optional<Map<?, ?>> getDefinition(Map<?, ?> node, Whelk whelk) {
-        return getLinkIri(node)
-                .flatMap(id -> {
-                            var fromVocab = Optional.ofNullable((Map<?, ?>) vocab.get(jsonLd.toTermKey(id)));
-                            return fromVocab.isPresent() ? fromVocab : QueryUtil.loadThing(id, whelk);
-                        }
-                );
-    }
-
-    private void addMappings(Map<?, ?> fromTermData, String toTermKey, TermType termType) {
-        String fromTermId = (String) fromTermData.get(ID_KEY);
-
-        addMapping(fromTermId, toTermKey, termType);
-        addMapping(toPrefixed(fromTermId), toTermKey, termType);
-
-        for (String prop : notatingProps) {
-            if (fromTermData.containsKey(prop)) {
-                addMapping((String) fromTermData.get(prop), toTermKey, termType);
-            }
-
-            String alias = (String) jsonLd.langContainerAlias.get(prop);
-
-            if (fromTermData.containsKey(alias)) {
-                Map<?, ?> byLang = (Map<?, ?>) fromTermData.get(alias);
-                for (String lang : jsonLd.locales) {
-                    List<?> values = asList(byLang.get(lang));
-                    values.forEach(v -> addMapping((String) v, toTermKey, termType));
-                }
-            }
-        }
-    }
-
-    private void addMapping(String from, String to, TermType termType) {
-        from = from.toLowerCase();
-
-        Map<String, String> aliasMappings = switch (termType) {
-            case CLASS -> classAliasMappings;
-            case PROPERTY -> propertyAliasMappings;
-            case ENUM -> enumAliasMappings;
-        };
-        Map<String, Set<String>> ambiguousAliases = switch (termType) {
-            case CLASS -> ambiguousClassAliases;
-            case PROPERTY -> ambiguousPropertyAliases;
-            case ENUM -> ambiguousEnumAliases;
-        };
-
-        if (ambiguousAliases.containsKey(from)) {
-            ambiguousAliases.get(from).add(to);
-        } else if (aliasMappings.containsKey(from)) {
-            if (aliasMappings.get(from).equals(to)) {
-                return;
-            }
-            ambiguousAliases.put(from, new HashSet<>(Arrays.asList(to, aliasMappings.remove(from))));
-        } else {
-            aliasMappings.put(from, to);
-        }
+        var fromVocab = get(vocab, jsonLd.toTermKey(iri), Map.of());
+        return fromVocab.isEmpty() ? loadThing(iri, whelk) : Optional.of(fromVocab);
     }
 
     private static boolean isKbvTerm(Map<?, ?> termDefinition) {
-        return getAsOptionalMap(termDefinition, "isDefinedBy")
-                .flatMap(Disambiguate::getLinkIri)
-                .filter("https://id.kb.se/vocab/"::equals)
-                .isPresent();
+        return "https://id.kb.se/vocab/".equals(get(termDefinition, List.of(Rdfs.IS_DEFINED_BY, ID_KEY), ""));
     }
 
     private boolean isMarc(String termKey) {
@@ -437,13 +186,13 @@ public class Disambiguate {
     }
 
     private boolean isClass(Map<?, ?> termDefinition) {
-        return getTypes(termDefinition).stream().anyMatch(type -> jsonLd.isSubClassOf(type, "Class"));
+        return getTypes(termDefinition).stream().anyMatch(type -> jsonLd.isSubClassOf((String) type, "Class"));
     }
 
     private boolean isEnum(Map<?, ?> termDefinition) {
         return getTypes(termDefinition).stream()
-                .map(type -> addString(getSuperclasses(type, jsonLd), type))
-                .flatMap(Set::stream)
+                .map(String.class::cast)
+                .flatMap(type -> Stream.concat(getSuperclasses(type, jsonLd).stream(), Stream.of(type)))
                 .map(jsonLd::getInRange)
                 .flatMap(Set::stream)
                 .filter(this::isProperty)
@@ -461,14 +210,14 @@ public class Disambiguate {
     }
 
     public static boolean isObjectProperty(Map<?, ?> termDefinition) {
-        return getTypes(termDefinition).stream().anyMatch("ObjectProperty"::equals);
+        return getTypes(termDefinition).stream().anyMatch(Owl.OBJECT_PROPERTY::equals);
     }
 
     private static boolean isDatatypeProperty(Map<?, ?> termDefinition) {
-        return getTypes(termDefinition).stream().anyMatch("DatatypeProperty"::equals);
+        return getTypes(termDefinition).stream().anyMatch(Owl.DATATYPE_PROPERTY::equals);
     }
 
-    private static List<String> getTypes(Map<?, ?> termDefinition) {
+    private static List<?> getTypes(Map<?, ?> termDefinition) {
         return asList(termDefinition.get(JsonLd.TYPE_KEY));
     }
 
@@ -526,8 +275,109 @@ public class Disambiguate {
         return s;
     }
 
-    public Set<String> getSuperclasses(String cls) {
-        return getSuperclasses(cls, jsonLd);
+    private Node _expandChainAxiom(Property property) {
+        List<Node> pathValueList = new ArrayList<>();
+
+        List<Object> path = new ArrayList<>();
+
+        for (var prop : getAsList(property.definition(), Owl.PROPERTY_CHAIN_AXIOM)) {
+            String propIri = get(prop, ID_KEY, "");
+            if (!propIri.isEmpty()) {
+                path.add(new Property(jsonLd.toTermKey(propIri), this));
+                continue;
+            }
+
+            propIri = get(prop, List.of(Rdfs.SUBPROPERTY_OF, 0, ID_KEY), "");
+            if (propIri.isEmpty()) {
+                throw new RuntimeException("Failed to expand chain axiom for property " + property);
+            }
+            path.add(new Property(jsonLd.toTermKey(propIri), this));
+
+            getAsList(prop, List.of(Rdfs.RANGE, "*", ID_KEY)).stream()
+                    .map(rangeIri -> jsonLd.toTermKey((String) rangeIri))
+                    .map(rangeKey ->
+                            new PathValue(
+                                    new Path(path).append(new Property(Rdfs.RDF_TYPE, this)),
+                                    null,
+                                    new VocabTerm(rangeKey, getDefinition(rangeKey))
+                            )
+                    )
+                    .forEach(pathValueList::add);
+
+            getAsList(prop, Rdfs.RANGE).stream()
+                    .flatMap(r -> getAsList(r, Rdfs.SUBCLASS_OF).stream())
+                    .filter(superClass -> Owl.RESTRICTION.equals(get(superClass, TYPE_KEY, "")))
+                    .forEach(superClass -> {
+                                var onPropertyIri = get(superClass, List.of(Owl.ON_PROPERTY, ID_KEY), "");
+                                var hasValueIri = get(superClass, List.of(Owl.HAS_VALUE, ID_KEY), "");
+                                if (!onPropertyIri.isEmpty() && !hasValueIri.isEmpty()) {
+                                    var onPropertyKey = jsonLd.toTermKey(onPropertyIri);
+                                    var hasValueKey = jsonLd.toTermKey(hasValueIri);
+                                    var pathValue = new PathValue(
+                                            new Path(path).append(new Property(onPropertyKey, this)),
+                                            null,
+                                            vocab.containsKey(hasValueKey)
+                                                    ? new VocabTerm(hasValueKey, getDefinition(hasValueKey))
+                                                    : new Link(hasValueIri, getDefinition(hasValueKey))
+                                    );
+                                    pathValueList.add(pathValue);
+                                }
+                            }
+                    );
+        }
+
+        pathValueList.add(new PathValue(path, null, null));
+
+        return pathValueList.size() == 1 ? pathValueList.getFirst() : new And(pathValueList);
+    }
+
+    private List<String> findDomainOrRange(String property, String domainOrRange) {
+        var propertyDefinition = vocab.get(property);
+        if (propertyDefinition == null) {
+            return Collections.emptyList();
+        }
+        return findDomainOrRange(propertyDefinition, domainOrRange, whelk);
+    }
+
+    private List<String> findDomainOrRange(Map<?, ?> propertyDefinition, String domainOrRange, Whelk whelk) {
+        return findDomainOrRange(new LinkedList<>(List.of(propertyDefinition)), domainOrRange, whelk, new HashSet<>());
+    }
+
+    private List<String> findDomainOrRange(LinkedList<Map<?, ?>> queue, String domainOrRange, Whelk whelk, Set<Map<?, ?>> seenDefs) {
+        if (queue.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var propertyDefinition = queue.pop();
+
+        seenDefs.add(propertyDefinition);
+
+        List<String> domainOrRangeIris = getDomainOrRangeIris(propertyDefinition, domainOrRange);
+
+        if (!domainOrRangeIris.isEmpty()) {
+            return domainOrRangeIris.stream().map(jsonLd::toTermKey).filter(vocab::containsKey).toList();
+        }
+
+        queue.addAll(collectInheritable(propertyDefinition, whelk).stream().filter(Predicate.not(seenDefs::contains)).toList());
+
+        return findDomainOrRange(queue, domainOrRange, whelk, seenDefs);
+    }
+
+    List<Map<?, ?>> collectInheritable(Map<?, ?> propertyDefinition, Whelk whelk) {
+        List<Map<?, ?>> inheritable = new ArrayList<>();
+
+        getAsList(propertyDefinition, Owl.EQUIVALENT_PROPERTY)
+                .forEach(ep -> getDefinition((Map<?, ?>) ep, whelk).ifPresent(inheritable::add));
+
+        getAsList(propertyDefinition, Rdfs.SUBPROPERTY_OF)
+                .forEach(superProp -> getDefinition((Map<?, ?>) superProp, whelk).ifPresent(inheritable::add));
+
+        return inheritable;
+    }
+
+    private List<String> getDomainOrRangeIris(Map<?, ?> propertyDefinition, String domainOrRange) {
+        String p = propertyDefinition.containsKey(domainOrRange) ? domainOrRange : domainOrRange + "Includes";
+        return get(propertyDefinition, List.of(p, "*", ID_KEY), List.of());
     }
 
     private static Set<String> getSuperclasses(String cls, JsonLd jsonLd) {
@@ -536,29 +386,126 @@ public class Disambiguate {
         return new HashSet<>(superclasses);
     }
 
-    private static Set<String> addString(Set<String> set, String s) {
-        return Stream.concat(set.stream(), Stream.of(s)).collect(Collectors.toSet());
+    @SuppressWarnings("unchecked")
+    private static <T> T get(Object o, List<Object> path, T defaultTo) {
+        return (T) getAtPath(o, path, defaultTo);
     }
 
-    private static Optional<String> getLinkIri(Map<?, ?> m) {
-        return Optional.ofNullable((String) m.get(ID_KEY));
+    private static <T> T get(Object o, String key, T defaultTo) {
+        return get(o, List.of(key), defaultTo);
     }
 
-    private static List<Map<?, ?>> getAsListOfMaps(Map<?, ?> m, String property) {
-        return getAsOptionalListOfMaps(m, property).orElse(Collections.emptyList());
+    private static List<?> getAsList(Object o, List<Object> path) {
+        return asList(get(o, path, null));
     }
 
-    private static Optional<List<Map<?, ?>>> getAsOptionalListOfMaps(Map<?, ?> m, String property) {
-        return Optional.ofNullable((List<Map<?, ?>>) m.get(property));
+    private static List<?> getAsList(Object o, String key) {
+        return getAsList(o, List.of(key));
     }
 
-    private static Optional<Map<?, ?>> getAsOptionalMap(Map<?, ?> m, String property) {
-        return Optional.ofNullable((Map<?, ?>) m.get(property));
+    private void setAliasMappings() {
+        this.propertyAliasMappings = new TreeMap<>();
+        this.ambiguousPropertyAliases = new TreeMap<>();
+        this.classAliasMappings = new TreeMap<>();
+        this.ambiguousClassAliases = new TreeMap<>();
+        this.enumAliasMappings = new TreeMap<>();
+        this.ambiguousEnumAliases = new TreeMap<>();
+
+        vocab.forEach((termKey, termDefinition) -> {
+            if (isKbvTerm(termDefinition)) {
+                if (isClass(termDefinition)) {
+                    addAllMappings(termKey, classAliasMappings, ambiguousClassAliases);
+                } else if (isProperty(termDefinition)) {
+                    addAllMappings(termKey, propertyAliasMappings, ambiguousPropertyAliases);
+                }
+            }
+
+            if (isMarc(termKey) && isProperty(termDefinition)) {
+                addMapping(termKey, termKey, propertyAliasMappings, ambiguousPropertyAliases);
+                addMapping((String) termDefinition.get(ID_KEY), termKey, propertyAliasMappings, ambiguousPropertyAliases);
+            }
+
+            if (isEnum(termDefinition)) {
+                addAllMappings(termKey, enumAliasMappings, ambiguousEnumAliases);
+            }
+
+            if (Rdfs.RDF_TYPE.equals(termKey)) {
+                addMapping(JsonLd.TYPE_KEY, termKey, propertyAliasMappings, ambiguousPropertyAliases);
+                addAllMappings(termKey, propertyAliasMappings, ambiguousPropertyAliases);
+            }
+        });
+
+        BiConsumer<Map<String, Set<String>>, Map<String, String>> disambiguateAliases = (ambiguousAliases, aliasMappings) ->
+                ambiguousAliases.forEach((alias, mappedTerms) ->
+                        mappedTerms.stream()
+                                .filter(term -> alias.equals(term) || alias.toUpperCase().equals(getQueryCode(term)))
+                                .forEach(term -> aliasMappings.put(alias, term))
+                );
+
+        disambiguateAliases.accept(ambiguousClassAliases, classAliasMappings);
+        disambiguateAliases.accept(ambiguousPropertyAliases, propertyAliasMappings);
+        disambiguateAliases.accept(ambiguousEnumAliases, enumAliasMappings);
     }
 
-    private static Map<String, Map<String, Object>> getVocab(Map<String, Object> data) {
-        return ((Map<?, ?>) data.get("vocab")).entrySet()
-                .stream()
-                .collect(Collectors.toMap(e -> (String) e.getKey(), e -> QueryUtil.castToStringObjectMap(e.getValue())));
+    private void addAllMappings(String termKey, Map<String, String> aliasMappings, Map<String, Set<String>> ambiguousAliases) {
+        addMapping(termKey, termKey, aliasMappings, ambiguousAliases);
+        addMappings(termKey, aliasMappings, ambiguousAliases);
+        addEquivTermMappings(termKey, aliasMappings, ambiguousAliases);
+    }
+
+    private void addMappings(String termKey, Map<String, String> aliasMappings, Map<String, Set<String>> ambiguousAliases) {
+        Map<String, Object> termDefinition = getDefinition(termKey);
+        String termId = (String) termDefinition.get(ID_KEY);
+
+        addMapping(termId, termKey, aliasMappings, ambiguousAliases);
+        addMapping(toPrefixed(termId), termKey, aliasMappings, ambiguousAliases);
+
+        for (String prop : notatingProps) {
+            if (termDefinition.containsKey(prop)) {
+                addMapping((String) termDefinition.get(prop), termKey, aliasMappings, ambiguousAliases);
+            }
+
+            String alias = (String) jsonLd.langContainerAlias.get(prop);
+            if (termDefinition.containsKey(alias)) {
+                for (String lang : jsonLd.locales) {
+                    getAsList(termDefinition, List.of(alias, lang))
+                            .forEach(langStr -> addMapping((String) langStr, termKey, aliasMappings, ambiguousAliases));
+                }
+            }
+        }
+    }
+
+    private void addMapping(String from, String to, Map<String, String> aliasMappings, Map<String, Set<String>> ambiguousAliases) {
+        from = from.toLowerCase();
+        if (ambiguousAliases.containsKey(from)) {
+            ambiguousAliases.get(from).add(to);
+        } else if (aliasMappings.containsKey(from)) {
+            if (aliasMappings.get(from).equals(to)) {
+                return;
+            }
+            ambiguousAliases.put(from, new HashSet<>(Set.of(to, aliasMappings.remove(from))));
+        } else {
+            aliasMappings.put(from, to);
+        }
+    }
+
+    private void addEquivTermMappings(String termKey, Map<String, String> aliasMappings, Map<String, Set<String>> ambiguousAliases) {
+        String mappingProperty = isProperty(termKey) ? Owl.EQUIVALENT_PROPERTY : Owl.EQUIVALENT_CLASS;
+
+        getAsList(vocab, List.of(termKey, mappingProperty)).forEach(term -> {
+            String equivPropIri = get(term, ID_KEY, "");
+            if (!equivPropIri.isEmpty()) {
+                String equivPropKey = jsonLd.toTermKey(equivPropIri);
+                if (!vocab.containsKey(equivPropKey)) {
+                    loadThing(equivPropIri, whelk).ifPresentOrElse(
+                            (equivPropDef) -> addMappings(termKey, aliasMappings, ambiguousAliases),
+                            () -> {
+                                addMapping(equivPropIri, termKey, aliasMappings, ambiguousAliases);
+                                addMapping(toPrefixed(equivPropIri), termKey, aliasMappings, ambiguousAliases);
+                            }
+                    );
+                }
+            }
+        });
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/OutsetType.java
+++ b/whelk-core/src/main/groovy/whelk/search2/OutsetType.java
@@ -1,8 +1,0 @@
-package whelk.search2;
-
-//TODO: Abstract away the need for OutsetType
-public enum OutsetType {
-    INSTANCE,
-    WORK,
-    RESOURCE
-}

--- a/whelk-core/src/main/groovy/whelk/search2/Stats.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Stats.java
@@ -130,7 +130,6 @@ public class Stats {
                 sliceNode.put("dimension", property.name());
                 sliceNode.put("observation", observations);
                 sliceNode.put("maxItems", sliceParamsByProperty.get(property).size());
-//                property.getAlias(queryTree.getOutsetType()).ifPresent(a -> sliceNode.put("alias", a));
                 sliceByDimension.put(property.name(), sliceNode);
             }
         });

--- a/whelk-core/src/main/groovy/whelk/search2/Stats.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Stats.java
@@ -130,7 +130,7 @@ public class Stats {
                 sliceNode.put("dimension", property.name());
                 sliceNode.put("observation", observations);
                 sliceNode.put("maxItems", sliceParamsByProperty.get(property).size());
-                property.getAlias(queryTree.getOutsetType()).ifPresent(a -> sliceNode.put("alias", a));
+//                property.getAlias(queryTree.getOutsetType()).ifPresent(a -> sliceNode.put("alias", a));
                 sliceByDimension.put(property.name(), sliceNode);
             }
         });

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveBoolFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveBoolFilter.java
@@ -6,10 +6,11 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public record ActiveBoolFilter(String alias, Node filter, Map<?, ?> prefLabelByLang) implements Node {
     @Override
-    public Map<String, Object> toEs(List<String> boostedFields) {
+    public Map<String, Object> toEs() {
         throw new UnsupportedOperationException("Expand filter before converting to ES");
     }
 
@@ -23,8 +24,8 @@ public record ActiveBoolFilter(String alias, Node filter, Map<?, ?> prefLabelByL
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, String queryBaseType) {
-        return filter.expand(disambiguate, queryBaseType);
+    public Node expand(Disambiguate disambiguate, Collection<String> rulingTypes, Function<Collection<String>, Collection<String>> getBoostFields) {
+        return filter.expand(disambiguate, rulingTypes, getBoostFields);
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveBoolFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveBoolFilter.java
@@ -1,12 +1,11 @@
 package whelk.search2.querytree;
 
 import whelk.search2.Disambiguate;
-import whelk.search2.OutsetType;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 public record ActiveBoolFilter(String alias, Node filter, Map<?, ?> prefLabelByLang) implements Node {
     @Override
@@ -24,8 +23,8 @@ public record ActiveBoolFilter(String alias, Node filter, Map<?, ?> prefLabelByL
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, OutsetType outsetType) {
-        return filter.expand(disambiguate, outsetType);
+    public Node expand(Disambiguate disambiguate, String queryBaseType) {
+        return filter.expand(disambiguate, queryBaseType);
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
@@ -1,5 +1,7 @@
 package whelk.search2.querytree;
 
+import whelk.search2.Disambiguate;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,7 @@ public final class And extends Group {
         this(children, true);
     }
 
+    // For test only
     public And(List<Node> children, boolean flattenChildren) {
         this.children = flattenChildren ? flattenChildren(children) : children;
     }
@@ -42,6 +45,17 @@ public final class And extends Group {
     @Override
     public Map<String, Object> wrap(List<Map<String, Object>> esChildren) {
         return mustWrap(esChildren);
+    }
+
+    @Override
+    List<String> collectRulingTypes() {
+        return children().stream()
+                .filter(n -> n.isTypeNode() || (n instanceof Or && n.children().stream().allMatch(Node::isTypeNode)))
+                .flatMap(n -> n instanceof Or ? n.children().stream() : Stream.of(n))
+                .map(PropertyValue.class::cast)
+                .map(PropertyValue::value)
+                .map(Value::string)
+                .toList();
     }
 
     public boolean contains(Node node) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
@@ -62,10 +62,9 @@ public final class And extends Group {
     @Override
     boolean implies(Node a, Node b, BiFunction<Node, Node, Boolean> condition) {
         return switch (a) {
-            case Group g -> switch (b) {
-                case And and -> and.children().stream().allMatch(child -> implies(a, child, condition));
-                case Or or -> or.children().stream().anyMatch(child -> implies(a, child, condition));
-                default -> g.children().stream().anyMatch(child -> condition.apply(child, b));
+            case Group aGroup -> switch (b) {
+                case Group bGroup -> bGroup.children().stream().allMatch(child -> implies(aGroup, child, condition));
+                default -> aGroup.children().stream().anyMatch(child -> condition.apply(child, b));
             };
             default -> switch (b) {
                 case And and -> and.children().stream().allMatch(child -> condition.apply(a, child));

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -100,10 +100,7 @@ public sealed abstract class Group implements Node permits And, Or {
 
     @Override
     public String toString(boolean topLevel) {
-        String group = doMapToString(n -> n.toString(false))
-                .collect(Collectors.joining(delimiter()));
-
-        return topLevel ? group : "(" + group + ")";
+        return topLevel ? this.toString() : "(" + this + ")";
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -107,6 +107,12 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     @Override
+    public String toString() {
+        return doMapToString(n -> n.toString(false))
+                .collect(Collectors.joining(delimiter()));
+    }
+
+    @Override
     public Node reduceTypes(Disambiguate disambiguate) {
         BiFunction<Node, Node, Boolean> hasMoreSpecificTypeThan = (a, b) -> a.isTypeNode()
                 && b.isTypeNode()

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -2,9 +2,9 @@ package whelk.search2.querytree;
 
 import whelk.search2.Disambiguate;
 import whelk.search2.Operator;
-import whelk.search2.OutsetType;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -59,8 +59,8 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, OutsetType outsetType) {
-        return expandChildren(disambiguate, outsetType);
+    public Node expand(Disambiguate disambiguate, String queryBaseType) {
+        return expandChildren(disambiguate, queryBaseType);
     }
 
     @Override
@@ -175,8 +175,8 @@ public sealed abstract class Group implements Node permits And, Or {
         return n instanceof PathValue && ((PathValue) n).isNested();
     }
 
-    private Node expandChildren(Disambiguate disambiguate, OutsetType outsetType) {
-        return mapFilterAndReinstantiate(c -> c.expand(disambiguate, outsetType), Objects::nonNull);
+    private Node expandChildren(Disambiguate disambiguate, String queryBaseType) {
+        return mapFilterAndReinstantiate(c -> c.expand(disambiguate, queryBaseType), Objects::nonNull);
     }
 
     private List<Map<String, Object>> childrenToEs(List<String> boostedFields) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveBoolFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveBoolFilter.java
@@ -1,12 +1,10 @@
 package whelk.search2.querytree;
 
 import whelk.search2.Disambiguate;
-import whelk.search2.OutsetType;
-import whelk.search2.QueryUtil;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 public record InactiveBoolFilter(String alias) implements Node {
     @Override
@@ -20,7 +18,7 @@ public record InactiveBoolFilter(String alias) implements Node {
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, OutsetType outsetType) {
+    public Node expand(Disambiguate disambiguate, String queryBaseType) {
         return null;
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveBoolFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveBoolFilter.java
@@ -5,10 +5,11 @@ import whelk.search2.Disambiguate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public record InactiveBoolFilter(String alias) implements Node {
     @Override
-    public Map<String, Object> toEs(List<String> boostedFields) {
+    public Map<String, Object> toEs() {
         throw new UnsupportedOperationException("Query tree must not contain inactive filters");
     }
 
@@ -18,7 +19,7 @@ public record InactiveBoolFilter(String alias) implements Node {
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, String queryBaseType) {
+    public Node expand(Disambiguate disambiguate, Collection<String> rulingTypes, Function<Collection<String>, Collection<String>> getBoostFields) {
         return null;
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -46,8 +46,4 @@ public sealed interface Node permits ActiveBoolFilter, FreeText, Group, Inactive
     default boolean isTypeNode() {
         return false;
     }
-
-    default List<String> collectTypes(Disambiguate disambiguate) {
-        return List.of();
-    }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -2,8 +2,8 @@ package whelk.search2.querytree;
 
 import whelk.search2.Disambiguate;
 import whelk.search2.Operator;
-import whelk.search2.OutsetType;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +21,7 @@ public sealed interface Node permits ActiveBoolFilter, FreeText, Group, Inactive
         return toEs(Collections.emptyList());
     }
 
-    default Node expand(Disambiguate disambiguate, OutsetType outsetType) { return this; }
+    default Node expand(Disambiguate disambiguate, String queryBaseType) { return this; }
 
     default Node insertOperator(Operator operator) {
         return this;

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -11,17 +11,13 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public sealed interface Node permits ActiveBoolFilter, FreeText, Group, InactiveBoolFilter, PathValue, PropertyValue {
-    Map<String, Object> toEs(List<String> boostedFields);
+    Map<String, Object> toEs();
+
+    Node expand(Disambiguate disambiguate, Collection<String> rulingTypes, Function<Collection<String>, Collection<String>> getBoostFields);
 
     Map<String, Object> toSearchMapping(QueryTree qt, Map<String, String> nonQueryParams);
 
     String toString(boolean topLevel);
-
-    default Map<String, Object> toEs() {
-        return toEs(Collections.emptyList());
-    }
-
-    default Node expand(Disambiguate disambiguate, String queryBaseType) { return this; }
 
     default Node insertOperator(Operator operator) {
         return this;
@@ -41,5 +37,17 @@ public sealed interface Node permits ActiveBoolFilter, FreeText, Group, Inactive
 
     default List<Node> children() {
         return Collections.emptyList();
+    }
+
+    default Node reduceTypes(Disambiguate disambiguate) {
+        return this;
+    }
+
+    default boolean isTypeNode() {
+        return false;
+    }
+
+    default List<String> collectTypes(Disambiguate disambiguate) {
+        return List.of();
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
@@ -12,7 +12,12 @@ public final class Or extends Group {
     private final List<Node> children;
 
     public Or(List<Node> children) {
-        this.children = flattenChildren(children);
+        this(children, true);
+    }
+
+    // For test only
+    public Or(List<Node> children, boolean flattenChildren) {
+        this.children = flattenChildren ? flattenChildren(children) : children;
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
@@ -40,6 +40,11 @@ public final class Or extends Group {
     }
 
     @Override
+    List<String> collectRulingTypes() {
+        return List.of();
+    }
+
+    @Override
     public Group insertOperator(Operator operator) {
         return operator == Operator.NOT_EQUALS
                 ? new And(children).insertOperator(operator)

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
@@ -4,6 +4,7 @@ import whelk.search2.Operator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import static whelk.search2.QueryUtil.shouldWrap;
 
@@ -42,6 +43,20 @@ public final class Or extends Group {
     @Override
     List<String> collectRulingTypes() {
         return List.of();
+    }
+
+    @Override
+    boolean implies(Node a, Node b, BiFunction<Node, Node, Boolean> condition) {
+        return switch (a) {
+            case Group aGroup -> switch (b) {
+                case Group bGroup -> bGroup.children().stream().anyMatch(child -> implies(a, child, condition));
+                default -> aGroup.children().stream().anyMatch(child -> condition.apply(child, b));
+            };
+            default -> switch (b) {
+                case Group g -> g.children().stream().anyMatch(child -> condition.apply(a, child));
+                default -> condition.apply(a, b);
+            };
+        };
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static whelk.search2.Disambiguate.RDF_TYPE;
+import static whelk.search2.Disambiguate.Rdfs.RDF_TYPE;
 
 public record Path(List<Object> path, Optional<String> nestedStem) {
     // TODO: Get substitutions from context instead?

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -2,9 +2,11 @@ package whelk.search2.querytree;
 
 import whelk.JsonLd;
 import whelk.search.ESQuery;
+import whelk.search2.Disambiguate;
 import whelk.search2.Operator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -34,10 +36,15 @@ public record PathValue(Path path, Operator operator, Value value) implements No
     }
 
     @Override
-    public Map<String, Object> toEs(List<String> boostedFields) {
+    public Map<String, Object> toEs() {
         return path.nestedStem()
                 .map(this::toEsNested)
                 .orElseGet(this::getEs);
+    }
+
+    @Override
+    public Node expand(Disambiguate disambiguate, Collection<String> rulingTypes, Function<Collection<String>, Collection<String>> getBoostFields) {
+        throw new UnsupportedOperationException("");
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -44,7 +44,7 @@ public record PathValue(Path path, Operator operator, Value value) implements No
 
     @Override
     public Node expand(Disambiguate disambiguate, Collection<String> rulingTypes, Function<Collection<String>, Collection<String>> getBoostFields) {
-        throw new UnsupportedOperationException("");
+        return this;
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -111,8 +111,8 @@ public class Property {
     }
 
     private boolean isShortHand() {
-        // TODO: All short forms should be marked with :category :shortHand?
-        return definition.containsKey("propertyChainAxiom");
+        return ((List<?>) definition.getOrDefault("category", List.of())).stream()
+                .anyMatch(c -> Map.of(JsonLd.ID_KEY, "https://id.kb.se/vocab/shorthand").equals(c));
     }
 
     private Node getAlternativePaths(Node n, Disambiguate disambiguate, Collection<String> types) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static whelk.JsonLd.asList;
 import static whelk.search2.Disambiguate.Rdfs.RDF_TYPE;
 
 public class Property {
@@ -111,7 +112,7 @@ public class Property {
     }
 
     private boolean isShortHand() {
-        return ((List<?>) definition.getOrDefault("category", List.of())).stream()
+        return ((List<?>) asList(definition.get("category"))).stream()
                 .anyMatch(c -> Map.of(JsonLd.ID_KEY, "https://id.kb.se/vocab/shorthand").equals(c));
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static whelk.search2.Disambiguate.Rdfs.RDF_TYPE;
@@ -90,24 +89,6 @@ public class Property {
         }
 
         return expanded;
-    }
-
-    public Optional<String> getAlias(String outsetType) {
-        // FIXME
-        var alias = switch (outsetType) {
-            case "Instance" -> switch (name) {
-                case RDF_TYPE -> "instanceType";
-                case "instanceOfType" -> "workType";
-                default -> null;
-            };
-            default -> switch (name) {
-                case RDF_TYPE -> "workType";
-                case "hasInstanceType" -> "instanceType";
-                default -> null;
-            };
-        };
-
-        return Optional.ofNullable(alias);
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyValue.java
@@ -29,7 +29,6 @@ public record PropertyValue(Property property, Operator operator, Value value) i
         Map<String, Object> m = new LinkedHashMap<>();
 
         m.put("property", property.definition());
-//        property.getAlias(qt.getOutsetType()).ifPresent(a -> m.put("alias", a));
         m.put(operator.termKey, value.description());
         m.put("up", qt.makeUpLink(this, nonQueryParams));
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyValue.java
@@ -3,18 +3,16 @@ package whelk.search2.querytree;
 import whelk.JsonLd;
 import whelk.search2.Disambiguate;
 import whelk.search2.Operator;
-import whelk.search2.OutsetType;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.stream.Stream;
 
-import static whelk.search2.Disambiguate.RDF_TYPE;
+import static whelk.search2.Disambiguate.Rdfs.RESOURCE;
 import static whelk.search2.QueryUtil.quoteIfPhraseOrContainsSpecialSymbol;
 
 public record PropertyValue(Property property, Operator operator, Value value) implements Node {
@@ -32,7 +30,7 @@ public record PropertyValue(Property property, Operator operator, Value value) i
         Map<String, Object> m = new LinkedHashMap<>();
 
         m.put("property", property.definition());
-        property.getAlias(qt.getOutsetType()).ifPresent(a -> m.put("alias", a));
+//        property.getAlias(qt.getOutsetType()).ifPresent(a -> m.put("alias", a));
         m.put(operator.termKey, value.description());
         m.put("up", qt.makeUpLink(this, nonQueryParams));
 
@@ -40,16 +38,16 @@ public record PropertyValue(Property property, Operator operator, Value value) i
     }
 
     @Override
-    public Node expand(Disambiguate disambiguate, OutsetType outsetType) {
+    public Node expand(Disambiguate disambiguate, String queryBaseType) {
         return property.isRdfType()
                 ? buildTypeNode(value, disambiguate).insertOperator(operator)
-                : property.expand(disambiguate, outsetType)
+                : property.expand(disambiguate, queryBaseType)
                 .insertOperator(operator)
                 .insertValue(value);
     }
 
     public Node expand(Disambiguate disambiguate) {
-        return expand(disambiguate, OutsetType.RESOURCE);
+        return expand(disambiguate, RESOURCE);
     }
 
     @Override
@@ -72,18 +70,16 @@ public record PropertyValue(Property property, Operator operator, Value value) i
         };
     }
 
-    private static Node buildTypeNode(Value value, Disambiguate disambiguate) {
-        Set<String> altTypes = "Work".equals(value.string())
-                ? disambiguate.workTypes
-                : ("Instance".equals(value.string()) ? disambiguate.instanceTypes : Collections.emptySet());
+    private static Node buildTypeNode(Value type, Disambiguate disambiguate) {
+        Set<String> subtypes = disambiguate.getSubclasses(type.string());
 
-        if (altTypes.isEmpty()) {
-            return new PathValue(JsonLd.TYPE_KEY, null, value);
+        if (subtypes.isEmpty()) {
+            return new PathValue(JsonLd.TYPE_KEY, null, type);
         }
 
-        List<Node> altFields = altTypes.stream()
+        List<Node> altFields = Stream.concat(Stream.of(type.string()), subtypes.stream())
                 .sorted()
-                .map(type -> (Node) new PathValue(JsonLd.TYPE_KEY, null, new VocabTerm(type)))
+                .map(t -> (Node) new PathValue(JsonLd.TYPE_KEY, null, new VocabTerm(t)))
                 .toList();
 
         return new Or(altFields);

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ActiveBoolFilterSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ActiveBoolFilterSpec.groovy
@@ -9,13 +9,12 @@ import static whelk.search2.Disambiguate.Rdfs.RESOURCE
 class ActiveBoolFilterSpec extends Specification {
     def "expand"() {
         given:
-        def disambiguate = new Disambiguate(['vocab': [:]])
-        def outset = RESOURCE
+        def disambiguate = new Disambiguate([:])
         def excludeA = new ActiveBoolFilter('excludeA', pathV1, [:])
         def includeA = new ActiveBoolFilter('includeA', new InactiveBoolFilter('excludeA'), [:])
 
         expect:
-        excludeA.expand(disambiguate, outset) == pathV1
-        includeA.expand(disambiguate, outset) == null
+        excludeA.expand(disambiguate, [], x -> []) == pathV1
+        includeA.expand(disambiguate, [], x -> []) == null
     }
 }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ActiveBoolFilterSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ActiveBoolFilterSpec.groovy
@@ -2,15 +2,15 @@ package whelk.search2.querytree
 
 import spock.lang.Specification
 import whelk.search2.Disambiguate
-import whelk.search2.OutsetType
 
 import static DummyNodes.pathV1
+import static whelk.search2.Disambiguate.Rdfs.RESOURCE
 
 class ActiveBoolFilterSpec extends Specification {
     def "expand"() {
         given:
         def disambiguate = new Disambiguate(['vocab': [:]])
-        def outset = OutsetType.RESOURCE
+        def outset = RESOURCE
         def excludeA = new ActiveBoolFilter('excludeA', pathV1, [:])
         def includeA = new ActiveBoolFilter('includeA', new InactiveBoolFilter('excludeA'), [:])
 

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/AndSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/AndSpec.groovy
@@ -1,7 +1,6 @@
 package whelk.search2.querytree
 
 import spock.lang.Specification
-
 import static DummyNodes.and
 import static DummyNodes.or
 
@@ -13,6 +12,8 @@ import static DummyNodes.pathV5
 import static DummyNodes.orXY
 import static DummyNodes.andXY
 import static DummyNodes.andXYZ
+import static DummyNodes.type1
+import static DummyNodes.type2
 
 class AndSpec extends Specification {
     def "contains"() {
@@ -73,5 +74,18 @@ class AndSpec extends Specification {
         andXYZ                              | and([pathV2, pathV3]) | pathV1                | pathV1
         and([orXY, pathV3])                 | orXY                  | andXY                 | and([pathV3, pathV1, pathV2])
         and([orXY, pathV4, pathV5, pathV3]) | pathV4                | and([pathV1, pathV3]) | and([orXY, pathV5, pathV3, pathV1])
+    }
+
+    def "collect ruling types"() {
+        expect:
+        and.collectRulingTypes() == result
+
+        where:
+        and                                             | result
+        and([type1, pathV1])                            | ["T1"]
+        and([type1, type2, pathV1])                     | ["T1", "T2"]
+        and([pathV1, pathV2])                           | []
+        and([or([type1, type2]), pathV1])               | ["T1", "T2"]
+        and([or([type1, pathV1]), or([type2, pathV2])]) | []
     }
 }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/DummyNodes.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/DummyNodes.groovy
@@ -41,6 +41,9 @@ class DummyNodes {
 
     static def ft1 = new FreeText(Operator.EQUALS, 'ft1')
 
+    static def type1 = new PropertyValue(new Property("rdf:type"), Operator.EQUALS, new VocabTerm("T1"))
+    static def type2 = new PropertyValue(new Property("rdf:type"), Operator.EQUALS, new VocabTerm("T2"))
+
     static def ft(String s) {
         return new FreeText(eq, s)
     }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/GroupSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/GroupSpec.groovy
@@ -37,27 +37,27 @@ class GroupSpec extends Specification {
         ((Group) group).reduceByCondition { a, b -> (a == b) } == result
 
         where:
-        group                                                      | result
-        andXY                                                      | andXY
-        new And([pathV1, pathV1], false)                           | pathV1
-        and([pathV1, or([pathV1, pathV2])])                        | pathV1
-        or([pathV1, and([pathV1, pathV2])])                        | pathV1
-        and([pathV1, or([pathV2, pathV3])])                        | and([pathV1, or([pathV2, pathV3])])
-        or([pathV1, and([pathV2, pathV3])])                        | or([pathV1, and([pathV2, pathV3])])
-        and([pathV1, or([pathV1, pathV3, and([pathV3, pathV4])])]) | pathV1
-        or([pathV1, and([pathV1, pathV3, or([pathV3, pathV4])])])  | pathV1
-        and([pathV1, or([pathV2, pathV3, and([pathV3, pathV4])])]) | and([pathV1, or([pathV2, pathV3])])
-        or([pathV1, and([pathV2, pathV3, or([pathV3, pathV4])])])  | or([pathV1, and([pathV2, pathV3])])
-        and([pathV1, or([pathV2, pathV3, and([pathV1, pathV4])])]) | and([pathV1, or([pathV2, pathV3, and([pathV1, pathV4])])])
-        or([pathV1, and([pathV2, pathV3, or([pathV1, pathV4])])])  | or([pathV1, and([pathV2, pathV3, or([pathV1, pathV4])])])
-        and([pathV2, pathV3, or([pathV3, pathV4])])                | and([pathV2, pathV3])
-        or([pathV2, pathV3, and([pathV3, pathV4])])                | or([pathV2, pathV3])
-        and([or([pathV1, pathV2]), or([pathV3, pathV4])])          | and([or([pathV1, pathV2]), or([pathV3, pathV4])])
-        or([and([pathV1, pathV2]), and([pathV3, pathV4])])         | or([and([pathV1, pathV2]), and([pathV3, pathV4])])
-        and([or([pathV1, pathV2]), or([pathV3, pathV4]), pathV1])  | and([pathV1, or([pathV3, pathV4])])
-        or([and([pathV1, pathV2]), and([pathV3, pathV4]), pathV1]) | or([pathV1, and([pathV3, pathV4])])
-        and([or([pathV1, pathV2]), or([pathV2, pathV3])])          | or([pathV1, pathV2])
-        or([and([pathV1, pathV2]), and([pathV2, pathV3])])         | and([pathV1, pathV2])
-        or([and([pathV1, pathV2]), and([pathV1, pathV2])])         | and([pathV1, pathV2])
+        group                                                         | result
+        andXY                                                         | andXY
+        new And([pathV1, pathV1], false)                              | pathV1
+        and([pathV1, or([pathV1, pathV2])])                           | pathV1
+        or([pathV1, and([pathV1, pathV2])])                           | pathV1
+        and([pathV1, or([pathV2, pathV3])])                           | and([pathV1, or([pathV2, pathV3])])
+        or([pathV1, and([pathV2, pathV3])])                           | or([pathV1, and([pathV2, pathV3])])
+        and([pathV1, or([pathV1, pathV3, and([pathV3, pathV4])])])    | pathV1
+        or([pathV1, and([pathV1, pathV3, or([pathV3, pathV4])])])     | pathV1
+        and([pathV1, or([pathV2, pathV3, and([pathV3, pathV4])])])    | and([pathV1, or([pathV2, pathV3])])
+        or([pathV1, and([pathV2, pathV3, or([pathV3, pathV4])])])     | or([pathV1, and([pathV2, pathV3])])
+        and([pathV1, or([pathV2, pathV3, and([pathV1, pathV4])])])    | and([pathV1, or([pathV2, pathV3, and([pathV1, pathV4])])])
+        or([pathV1, and([pathV2, pathV3, or([pathV1, pathV4])])])     | or([pathV1, and([pathV2, pathV3, or([pathV1, pathV4])])])
+        and([pathV2, pathV3, or([pathV3, pathV4])])                   | and([pathV2, pathV3])
+        or([pathV2, pathV3, and([pathV3, pathV4])])                   | or([pathV2, pathV3])
+        and([or([pathV1, pathV2]), or([pathV3, pathV4])])             | and([or([pathV1, pathV2]), or([pathV3, pathV4])])
+        or([and([pathV1, pathV2]), and([pathV3, pathV4])])            | or([and([pathV1, pathV2]), and([pathV3, pathV4])])
+        and([or([pathV1, pathV2]), or([pathV3, pathV4]), pathV1])     | and([pathV1, or([pathV3, pathV4])])
+        or([and([pathV1, pathV2]), and([pathV3, pathV4]), pathV1])    | or([pathV1, and([pathV3, pathV4])])
+        and([or([pathV1, pathV2]), or([pathV2, pathV3])])             | and([or([pathV1, pathV2]), or([pathV2, pathV3])])
+        or([and([pathV1, pathV2]), and([pathV2, pathV3])])            | and([pathV1, pathV2])
+        new Or([and([pathV1, pathV2]), and([pathV1, pathV2])], false) | and([pathV1, pathV2])
     }
 }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -178,7 +178,7 @@ class QueryTreeSpec extends Specification {
         ]))
 
         expect:
-        qt.collectTypes() == [v1.string(), v3.string()] as Set
+        qt.collectRulingTypes() == [v1.string(), v3.string()] as Set
     }
 
     def "collect given types"() {
@@ -191,7 +191,7 @@ class QueryTreeSpec extends Specification {
         ]))
 
         expect:
-        qt.collectTypes() == ['type1', 'type3'] as Set
+        qt.collectRulingTypes() == ['type1', 'type3'] as Set
     }
 
     def "get top level free text as string"() {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -168,32 +168,6 @@ class QueryTreeSpec extends Specification {
         ])
     }
 
-    def "collect given types"() {
-        given:
-        def rdfType = new Property(RDF_TYPE)
-        QueryTree qt = new QueryTree(and([
-                propV(rdfType, eq, v1),
-                propV(rdfType, neq, v2),
-                or([pathV1, propV(rdfType, eq, v3)]),
-        ]))
-
-        expect:
-        qt.collectRulingTypes() == [v1.string(), v3.string()] as Set
-    }
-
-    def "collect given types"() {
-        given:
-        def rdfType = new Property(RDF_TYPE)
-        QueryTree qt = new QueryTree(and([
-                propV(rdfType, eq, new VocabTerm('type1')),
-                propV(rdfType, neq, new VocabTerm('type2')),
-                or([pathV1, propV(rdfType, eq, new VocabTerm('type3'))]),
-        ]))
-
-        expect:
-        qt.collectRulingTypes() == ['type1', 'type3'] as Set
-    }
-
     def "get top level free text as string"() {
         expect:
         new QueryTree(tree).getTopLevelFreeText() == result

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -33,6 +33,8 @@ import static DummyNodes.pathV1
 import static DummyNodes.pathV2
 import static DummyNodes.pathV3
 
+import static whelk.search2.Disambiguate.Rdfs.RDF_TYPE
+
 
 class QueryTreeSpec extends Specification {
     def "to search mapping"() {
@@ -168,7 +170,7 @@ class QueryTreeSpec extends Specification {
 
     def "collect given types"() {
         given:
-        def rdfType = new Property(Disambiguate.RDF_TYPE)
+        def rdfType = new Property(RDF_TYPE)
         QueryTree qt = new QueryTree(and([
                 propV(rdfType, eq, v1),
                 propV(rdfType, neq, v2),
@@ -181,7 +183,7 @@ class QueryTreeSpec extends Specification {
 
     def "collect given types"() {
         given:
-        def rdfType = new Property(Disambiguate.RDF_TYPE)
+        def rdfType = new Property(RDF_TYPE)
         QueryTree qt = new QueryTree(and([
                 propV(rdfType, eq, new VocabTerm('type1')),
                 propV(rdfType, neq, new VocabTerm('type2')),


### PR DESCRIPTION
Depends on https://github.com/libris/definitions/pull/508 and https://github.com/libris/lxlviewer/pull/1194.

The main objective with this is to get rid of obviously bad hardcodings and make the whole query expansion machinery more consistent. Apart from some general cleanup/refactoring the main improvements are:

- Finding the correct full path(s) for a property does no longer depend on [OutsetType](https://github.com/libris/librisxl/blob/bb09334681e8304f5733f3b25339d893f177db2b/whelk-core/src/main/groovy/whelk/search2/OutsetType.java) or [DomainCategory](https://github.com/libris/librisxl/blob/bb09334681e8304f5733f3b25339d893f177db2b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java#L16). Instead we check for properties in the category `:integral` that are applicable to the queried type(s). 
Example query: `type:Work yearPublished:x`
There are three `:integral` properties (`:translationOf`, `:exactMatch`, `:hasInstance`) applicable to `:Work` which, if we didn't know the domain of `:yearPublished`, would give us these alternative paths for `:yearPublished`:
     -  `translationOf.yearPublished`
     -  `exactMatch.yearPublished`
     -  `hasInstance.yearPublished`
We can however ignore both `:translationOf` and `:exactMatch` since we know that `:yearPublished :domain :Instance` and `:Instance` is not in range of `:translationOf` and `:exactMatch`, i.e. we won't find `:yearPublished` on any resource that these properties point to. So the only path that will be checked is `hasInstance.yearPublished` (`@reverse.instanceOf.publication.year` when fully expanded).
- Both property expansion and field boosting depend on which type of resource is queried, however only the types within the same group are relevant. Before we just collected all types that appeared _anywhere_ in the query tree. This change enables grouped queries with different types while still getting the property expansion and free text boosting right. E.g.
`(type:Work x) OR (type:Instance p1:v1) OR (type:Agent p2:v2)`
where field boosting for `x` is based on the `:Work` type and expansion of `p1` and `p2` is based on `:Instance` and `:Agent` respectively.
- Redundant types within the same group are removed: 
https://github.com/libris/librisxl/blob/8d3fa034902e69b0f2213df01cc8f3d3e3d3259d/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java#L110 
If for example the query is `type:(Electronic Instance)` then `Instance` is removed. Just like in the old search:
https://github.com/libris/librisxl/blob/bb09334681e8304f5733f3b25339d893f177db2b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy#L440
- Rely on marker `:category :shorthand` in definition for knowing which properties should be expanded via `owl:propertyChainAxiom`. a16fcb3450fa36b18d0011f6d3075f550bdce11b
- Don't inherit domain/range from propertyChainAxiom. Add these explicitly to short forms where needed instead, see https://github.com/libris/definitions/pull/508.
- Search all subclasses by default for all types: https://github.com/libris/librisxl/blob/8d3fa034902e69b0f2213df01cc8f3d3e3d3259d/whelk-core/src/main/groovy/whelk/search2/querytree/PropertyValue.java#L76
We only did this for Work and Instance before (hardcoded).
Eventually we'll need to make this optional.
- Using alias for instance/work type was such a bad and confusing solution that I decided to just bin it (d69a3b2d1cfa187a0d127eda70dc6d624b7823eb). Mapping `hasInstanceType` to `Format` (https://github.com/libris/lxlviewer/pull/1194) is enough to get the filter headers right at least when searching for works which is most important at this point. We can figure something out for instance search later.
- The whole `Disambiguate` class was also a mess so I decided to give it a proper makeover. At least is less messy now.

Can't guarantee that this won't break anything. Planned to add more tests but ran out of time. _Seems_ to work when I've tested myself.