### PR TITLE
fix(jsonld): restore only links, not entire cards, after applying lens

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -1089,7 +1089,11 @@ class JsonLd {
             if (!it.isEmpty()) {
                 def key = it[0]
                 if (thing.containsKey(key) && !cardOrChip.containsKey(key)) {
-                    cardOrChip[key] = thing[key]
+                    if (thing[key] instanceof Map) {
+                        cardOrChip[key] = ((Map) thing[key]).subMap([ID_KEY])
+                    } else if (thing[key] instanceof List) {
+                        cardOrChip[key] = ((List) thing[key]).collect { ((Map) it).subMap([ID_KEY]) }.grep()
+                    }
                 }
             }
         }


### PR DESCRIPTION
To prevent e.g. full instance cards from being indexed in hasTitle.source.