### PR TITLE
Feature/lxl 4610 allow dead links in bulk change spec

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.groovy
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
+
 import static whelk.rest.api.CrudUtils.ETag
 import static whelk.util.http.HttpTools.getBaseUri
 import static whelk.util.http.HttpTools.sendResponse
@@ -841,16 +842,10 @@ class Crud extends HttpServlet {
         } else if (doc && doc.deleted) {
             throw new OtherStatusException("Document has been deleted.", HttpServletResponse.SC_GONE)
         } else {
-            def referencedBy = whelk.storage.followDependers(doc.getShortId(), JsonLd.ALLOW_LINK_TO_DELETED + jsonld.cascadingDeleteRelations())
-            if (!referencedBy.isEmpty()) {
-                def referencedByStr = referencedBy.collect { shortId, path -> "$shortId at $path" }.join(', ')
-                throw new OtherStatusException("This record may not be deleted, because it is referenced by other records: " + referencedByStr, HttpServletResponse.SC_FORBIDDEN)
-            } else {
-                log.debug("Removing resource at ${doc.getShortId()}")
-                String activeSigel = request.getHeader(XL_ACTIVE_SIGEL_HEADER)
-                whelk.remove(doc.getShortId(), "xl", activeSigel)
-                response.setStatus(HttpServletResponse.SC_NO_CONTENT)
-            }
+            log.debug("Removing resource at ${doc.getShortId()}")
+            String activeSigel = request.getHeader(XL_ACTIVE_SIGEL_HEADER)
+            whelk.remove(doc.getShortId(), "xl", activeSigel)
+            response.setStatus(HttpServletResponse.SC_NO_CONTENT)
         }
     }
 

--- a/server-common/src/main/groovy/whelk/util/http/HttpTools.groovy
+++ b/server-common/src/main/groovy/whelk/util/http/HttpTools.groovy
@@ -107,8 +107,10 @@ class HttpTools {
         switch(e) {
             case BadRequestException:
             case ModelValidationException:
-            case LinkValidationException:
                 return HttpServletResponse.SC_BAD_REQUEST
+
+            case LinkValidationException:
+                return HttpServletResponse.SC_FORBIDDEN
 
             case NotFoundException:
                 return HttpServletResponse.SC_NOT_FOUND

--- a/whelk-core/src/main/java/whelk/exception/LinkValidationException.java
+++ b/whelk-core/src/main/java/whelk/exception/LinkValidationException.java
@@ -4,4 +4,16 @@ public class LinkValidationException extends Exception {
     public LinkValidationException(String msg) {
         super(msg);
     }
+
+    public static class IncomingLinksException extends LinkValidationException {
+        public IncomingLinksException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class OutgoingLinksException extends LinkValidationException {
+        public OutgoingLinksException(String msg) {
+            super(msg);
+        }
+    }
 }

--- a/whelktool/src/main/groovy/whelk/datatool/form/ModifiedThing.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/ModifiedThing.groovy
@@ -66,8 +66,8 @@ class ModifiedThing {
                     try {
                         executeModification(matchingNode, property, removeList, addList)
                     } catch (Exception e) {
-                        throw new Exception("Failed to modify ${thing[ID_KEY]} at path ${cfn.propertyPath + property}: " +
-                                "${e.getMessage()}")
+                        def msg = "Failed to modify ${thing[ID_KEY]} at path ${cfn.propertyPath + property}: ${e.getMessage()}"
+                        throw e instanceof IllegalModificationException ? new IllegalModificationException(msg) : new Exception(msg)
                     }
                 }
             }
@@ -135,7 +135,7 @@ class ModifiedThing {
                         addRecursive((Map) current, (String) k, asList(v).collect { transform.newAddValue(it) })
                     }
                 } else {
-                    throw new Exception("Property $property is not repeatable.")
+                    throw new IllegalModificationException("Property $property is not repeatable.")
                 }
             }
         }
@@ -172,5 +172,11 @@ class ModifiedThing {
         node[property] = current.size() == 1 && !repeatableTerms.contains(property)
                 ? current.first()
                 : current
+    }
+
+    class IllegalModificationException extends Exception {
+        IllegalModificationException(String msg) {
+            super(msg)
+        }
     }
 }

--- a/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
@@ -1,8 +1,11 @@
 import whelk.Document
 import whelk.datatool.form.MatchForm
 
+import static whelk.exception.LinkValidationException.IncomingLinksException
 import static whelk.JsonLd.RECORD_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY
+
+PrintWriter failed = getReportWriter("failed-to-delete.txt")
 
 Map matchForm = parameters.get(MATCH_FORM_KEY)
 
@@ -10,7 +13,13 @@ MatchForm mf = new MatchForm(matchForm, getWhelk())
 
 selectByForm(mf) {
     if(mf.matches(getFramedThing(it.doc))) {
-        it.scheduleDelete(loud: isLoudAllowed)
+        it.scheduleDelete(loud: isLoudAllowed, onError: { e ->
+            if (e instanceof IncomingLinksException) {
+                failed.println("Failed to delete $it.doc.shortId: ${e.getMessage()}")
+            } else {
+                throw e
+            }
+        })
     }
 }
 

--- a/whelktool/src/main/resources/bulk-change-scripts/update.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/update.groovy
@@ -14,8 +14,11 @@ Map targetForm = parameters.get(TARGET_FORM_KEY)
 Transform transform = new Transform(matchForm, targetForm, getWhelk())
 
 selectByForm(transform.matchForm) {
-    if(modify(transform, it.doc, it.whelk)) {
-        it.scheduleSave(loud: isLoudAllowed)
+    try {
+        if (modify(transform, it.doc, it.whelk)) {
+            it.scheduleSave(loud: isLoudAllowed)
+        }
+    } catch (ModifiedThing.IllegalModificationException ignored) {
     }
 }
 

--- a/whelktool/src/test/groovy/whelk/datatool/form/ModifiedThingSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/form/ModifiedThingSpec.groovy
@@ -32,7 +32,7 @@ class ModifiedThingSpec extends Specification {
         new ModifiedThing(before, transform, repeatable)
 
         then:
-        thrown Exception
+        thrown ModifiedThing.IllegalModificationException
 
         where:
         spec << specs.findAll { it["before"] && it['shouldFailWithException'] }


### PR DESCRIPTION
To be able to delete records referenced in a bulk change specification, allow any property inside a `bulk:ChangeSpec` (i.e. the object of `bulk:changeSpec` to hold links to deleted resources. We already have a similar mechanism for exact paths, see https://github.com/libris/librisxl/blob/a56f059e2780e3863dfd6e35139fc2cd371d11e8/whelk-core/src/main/groovy/whelk/JsonLd.groovy#L59).
This should not however be hardcoded but rather defined in the vocab (TODO).

See https://kbse.atlassian.net/browse/LXL-4610 for more info.

I sneaked in another commit too (a56f059) that is unrelated to the above. When the data in a record is not compatible with the operations specified in a `bulk:ChangeSpec` of a `bulk:Update`, the record is just ignored and won't be affected by the job. This can happen for example when trying to add another value to a property that is not repeatable.