### PR TITLE
fix(bulk): Skip Sparql when an id list was given for the top level node

### DIFF
--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -203,8 +203,9 @@ class WhelkTool {
             log "Select by form"
         }
 
-        var sparqlPattern = matchForm.getSparqlPattern(whelk.jsonld.context)
-        var ids = whelk.sparqlQueryClient.queryIdsByPattern(sparqlPattern)
+        var ids = matchForm.getThingIds().isEmpty()
+                ? whelk.sparqlQueryClient.queryIdsByPattern(matchForm.getSparqlPattern(whelk.jsonld.context))
+                : matchForm.getThingIds()
 
         selectByIds(ids, process, batchSize, silent)
     }

--- a/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
@@ -78,6 +78,10 @@ class MatchForm {
         return insertTypeMappings(insertIdMappings(insertVars(ttl)))
     }
 
+    Set<String> getThingIds() {
+        return formBNodeIdToResourceIds[getThingTmpId()] ?: [] as Set
+    }
+
     static List<String> dropIndexes(List path) {
         return path.findAll { it instanceof String } as List<String>
     }


### PR DESCRIPTION
This means no limit on number of records per job when using id list. We could set a number but I think the id list itself should be enough limitation. 

When uploading id list for a specific property, e.g. itemOf, we'll still use Sparql so those lists should be limited to a few thousand ids. We probably want to discard too long lists and inform the user automatically but I guess at this point it's enough that they are aware of limitation.

https://kbse.atlassian.net/browse/LXL-4620