### PR TITLE
Add basic support for Fresnel Format vocabulary

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -30,6 +30,7 @@ class JsonLd {
     public static final String REVERSE_KEY = "@reverse"
     // JSON-LD 1.1
     public static final String PREFIX_KEY = "@prefix"
+    public static final String NONE_KEY = "@none"
 
     public static final String DISPLAY_KEY = "dataDisplay"
     public static final String THING_KEY = "mainEntity"
@@ -119,7 +120,9 @@ class JsonLd {
     private Map<String, Set<String>> categories
     private Map<String, Set<String>> inRange
 
+    // x -> xByLang
     public Map langContainerAlias = [:]
+    // xByLang -> x
     public Map langContainerAliasInverted
 
     /**
@@ -967,7 +970,7 @@ class JsonLd {
                      it.endsWith('ByLang') && ((Map<String, ?>) thing.get(it))?.keySet()?.any{ it in languagesToKeep } 
                  })
             }
-            if (isAlternateSubProperty(it)) {
+            if (isAlternateRangeRestriction(it)) {
                 // alternateProperties with locally defined subProperty with narrower range.
                 // Example: {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
                 // The correct RDF semantics would be to match range against all subclasses.
@@ -1073,10 +1076,10 @@ class JsonLd {
         }
         if (lens) {
             List propertiesToKeep = (List) lens.get("showProperties")
-                    .collect { prop -> 
+                    .collect { prop ->
                         isAlternateProperties(prop) 
-                                ? prop[ALTERNATE_PROPERTIES].collect { isAlternateSubProperty(it) ? it[Rdfs.SUB_PROPERTY_OF] : it }
-                                : prop 
+                                ? prop[ALTERNATE_PROPERTIES].collect { isAlternateRangeRestriction(it) ? it[Rdfs.SUB_PROPERTY_OF] : it }
+                                : prop
                     }
                     .flatten()
                     .unique()
@@ -1161,7 +1164,7 @@ class JsonLd {
                         else if (a instanceof List) {
                             a.each { if (thing[it]) result[it] = thing[it] }
                         }
-                        else if (isAlternateSubProperty(a) && thing[a[Rdfs.SUB_PROPERTY_OF]]) {
+                        else if (isAlternateRangeRestriction(a) && thing[a[Rdfs.SUB_PROPERTY_OF]]) {
                             result[a[Rdfs.SUB_PROPERTY_OF]] = thing[a[Rdfs.SUB_PROPERTY_OF]]
                         }
                     }
@@ -1173,12 +1176,13 @@ class JsonLd {
         }
     }
     
-    private static boolean isAlternateProperties(def p) {
+    static boolean isAlternateProperties(def p) {
         p instanceof Map && p.size() == 1 && p[ALTERNATE_PROPERTIES]
     }
-    
-    private static boolean isAlternateSubProperty(def p) {
-        p instanceof Map && p[Rdfs.SUB_PROPERTY_OF] && p[Rdfs.RANGE]
+
+    static boolean isAlternateRangeRestriction(def p) {
+            p instanceof Map && p[Rdfs.SUB_PROPERTY_OF] && p[Rdfs.RANGE]
+
     }
 
     Map getLensFor(Map thing, Map lensGroup) {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -16,7 +16,6 @@ import whelk.util.DocumentUtil
 import whelk.util.Unicode
 
 import java.util.concurrent.LinkedBlockingQueue
-import java.util.function.Function
 
 import static whelk.FeatureFlags.Flag.INDEX_BLANK_WORKS
 import static whelk.JsonLd.asList
@@ -572,10 +571,8 @@ class ElasticSearch {
     /**
      * @return ISNIs with with four groups of four digits separated by space
      */
-    private static Collection<String> getFormattedIsnis(Collection<String> isnis) {
-        isnis.findAll{ it.size() == 16 }.collect{isni ->
-            isni.split("").collate(4).collect{ it.join() }.join(" ")
-        }
+    static Collection<String> getFormattedIsnis(Collection<String> isnis) {
+        isnis.findAll{ it.size() == 16 }.collect { Unicode.formatIsni(it) }
     }
 
     Map query(Map jsonDsl) {

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -761,6 +761,7 @@ public class FresnelUtil {
             public static String CONTENT_BEFORE = "_contentBefore";
             public static String STYLE = "_style";
             public static String LABEL = "_label";
+            public static String SCRIPTS = "_scripts";
         }
 
         String contentBefore;
@@ -948,17 +949,12 @@ public class FresnelUtil {
 
         public Object asJsonLd() {
             var result = new HashMap<String, Object>();
-            /*
-            super.serialize(result);
-            if (result.isEmpty()) {
-                return unwrapSingle(value);
-            } else {
-                result.put(JsonLd.VALUE_KEY, unwrapSingle(value));
-                return result;
-            }
 
-             */
-            return result;
+            scripts.forEach((code, decorated) -> {
+                result.put(code.code,  decorated.asJsonLd());
+            });
+
+            return Map.of(Fmt.SCRIPTS, result);
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -255,6 +255,10 @@ public class FresnelUtil {
         public String langAliasFor() {
             return (String) jsonLd.langContainerAliasInverted.get(name);
         }
+
+        boolean isTypeVocabTerm() {
+            return jsonLd.isVocabTerm(name);
+        }
     }
 
     // FIXME naming
@@ -289,7 +293,7 @@ public class FresnelUtil {
                 else if (JsonLd.ID_KEY.equals(p.name)) {
                     id = (String) value;
                 }
-                else if (jsonLd.isVocabTerm(p.name)) {
+                else if (p.isTypeVocabTerm()) {
                     if (value instanceof List<?> list) {
                         orderedProps.add(new Property(p.name, list.stream().map(this::mapVocabTerm).toList()));
                     }

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -1,0 +1,1005 @@
+package whelk.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import whelk.JsonLd;
+import whelk.JsonLd.Rdfs;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static whelk.util.FresnelUtil.LangCode.ORIGINAL_SCRIPT_FIRST;
+
+// https://www.w3.org/2005/04/fresnel-info/manual/
+
+// TODO fallback style for things that fall outside the class hierarchy?
+// TODO defer language selection?
+// TODO bad data - blank nodes without type?
+
+public class FresnelUtil {
+
+    public enum LensLevel {
+        Full(List.of("full", "cards")),
+        Card(List.of("cards")),
+        Chip(List.of("chips")),
+        Token(List.of("tokens", "chips"));
+
+        final List<String> groups;
+
+        LensLevel(List<String> groups) {
+            this.groups = groups;
+        }
+    }
+
+    // https://www.w3.org/2005/04/fresnel-info/manual/
+    static class Fresnel {
+        public static String Format = "fresnel:Format";
+        public static String Group = "fresnel:Group";
+        public static String Lens = "fresnel:Lens";
+        public static String classFormatDomain = "fresnel:classFormatDomain";
+        public static String contentAfter = "fresnel:contentAfter";
+        public static String contentBefore = "fresnel:contentBefore";
+        public static String contentFirst = "fresnel:contentFirst";
+        public static String contentLast = "fresnel:contentLast";
+        public static String extends_ = "fresnel:extends";
+        public static String group = "fresnel:group";
+        public static String propertyFormat = "fresnel:propertyFormat";
+        public static String propertyFormatDomain = "fresnel:propertyFormatDomain";
+        public static String propertyStyle = "fresnel:propertyStyle";
+        public static String resourceFormat = "fresnel:resourceFormat";
+        public static String resourceStyle = "fresnel:resourceStyle";
+        public static String super_ = "fresnel:super";
+        public static String valueFormat = "fresnel:valueFormat";
+        public static String valueStyle = "fresnel:valueStyle";
+
+        // these are used without prefix in display.jsonld
+        // we currently we just treat everything as plain JSON keys there
+        public static String showProperties = "showProperties";
+        public static String alternateProperties = "alternateProperties";
+
+        public static String WILD_PROPERTY = "*";
+    }
+
+    // https://github.com/libris/definitions/blob/develop/source/vocab/base.ttl
+    static class Base {
+        public static String Resource = "Resource";
+        public static String StructuredValue = "StructuredValue";
+        public static String Identity = "Identity";
+    }
+
+    private static final Logger logger = LogManager.getLogger(FresnelUtil.class);
+    private static final String RDF_TYPE = "rdf:type";
+
+    //TODO load from display.jsonld
+    private static final Map<?, ?> DEFAULT_LENS = Map.of(
+            JsonLd.TYPE_KEY, Fresnel.Lens,
+            Fresnel.showProperties, List.of(
+                    Map.of(Fresnel.alternateProperties, List.of(
+                            // TODO this is the expanded form with xByLang like in JsonLd
+                            "prefLabel", "prefLabelByLang", "label", "labelByLang", "name", "nameByLang", "@id"
+                    ))
+            )
+    );
+
+    JsonLd jsonLd;
+    Formats formats;
+
+    FresnelUtil(JsonLd jsonLd) {
+        this.jsonLd = jsonLd;
+        this.formats = new Formats(getUnsafe(jsonLd.displayData, "formatters", null));
+    }
+
+    public Lensed applyLens(Object thing, LensLevel lens) {
+        // TODO
+        if (!isTypedNode(thing)) {
+            throw new IllegalArgumentException("Thing is not typed node: " + thing);
+        }
+
+        return (Lensed) applyLens(thing, lens, null);
+    }
+
+    public Decorated format(Lensed lensed, LangCode locale) {
+        var f = new Formatter(locale);
+        return switch(lensed) {
+            case Node n -> f.displayDecorate(n);
+            case TransliteratedNode n -> f.displayDecorate(n);
+        };
+    }
+
+    private Object applyLens(
+            Object value,
+            LensLevel lensLevel,
+            LangCode selectedLang
+    ) {
+        if (!(value instanceof Map<?, ?> thing)) {
+            // literal
+            return value;
+        }
+
+        List<LangCode> scripts = selectedLang == null ? scriptAlternatives(thing) : Collections.emptyList();
+        if (!scripts.isEmpty()) {
+            TransliteratedNode n = new TransliteratedNode();
+            for (var script : scripts) {
+                n.add(script, (Node) applyLens(thing, lensLevel, script));
+            }
+            return n;
+        }
+
+        var result = new Node(lensLevel, selectedLang);
+        var lens = findLens(thing, lensLevel);
+
+        @SuppressWarnings("unchecked")
+        var showProperties = (List<Object>) lens.get(Fresnel.showProperties);
+        showProperties = Stream.concat(Stream.of(JsonLd.TYPE_KEY, JsonLd.ID_KEY), showProperties.stream()).toList();
+        for (var p : showProperties) {
+            if (JsonLd.isAlternateProperties(p)) {
+                for (var alternative : alternatives(p)) {
+                    if (JsonLd.isAlternateRangeRestriction(alternative)) {
+                        // can never be language container
+                        var r = asRangeRestriction(alternative);
+                        var k = r.subPropertyOf;
+                        @SuppressWarnings("unchecked")
+                        var v = ((List<Object>) JsonLd.asList(thing.get(k)))
+                                .stream()
+                                .filter(n -> isTypedNode(n) && r.range.equals(asMap(n).get(JsonLd.TYPE_KEY)))
+                                .toList();
+
+                        if (!v.isEmpty()) {
+                            result.pick(Map.of(k, v), new PropertyKey(k));
+                            break;
+                        }
+                    }
+                    else if (alternative instanceof List<?> list) {
+                        // expanded lang alias, i.e. ["x", "xByLang"]
+                        var found = false;
+                        for (var k : list) {
+                            if (has(thing, (String) k)) {
+                                result.pick(thing, new PropertyKey((String) k));
+                                found = true;
+                            }
+                        }
+                        if (found) {
+                            break;
+                        }
+                    }
+                    else if (alternative instanceof String k) {
+                        if (has(thing, k)) {
+                            result.pick(thing, new PropertyKey(k));
+                            break;
+                        }
+                    }
+                }
+            }
+            else if (isInverseProperty(p)) {
+                // never language container
+                var i = asInverseProperty(p);
+                if (thing.get(JsonLd.REVERSE_KEY) instanceof Map<?, ?> r && r.containsKey(i.name)) {
+                    var v = r.get(i.name);
+                    result.pick(Map.of(i.inverseName, v), new PropertyKey(i.inverseName));
+                }
+            }
+            else if (p instanceof String k) {
+                if (has(thing, k)) {
+                    result.pick(thing, new PropertyKey(k));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    static class Format {
+        static final Format DEFAULT_FORMAT = new Format();
+
+        String id;
+        String group;
+        List<String> classFormatDomain;
+        List<String> propertyFormatDomain;
+        FormatDetails resourceFormat;
+        FormatDetails propertyFormat;
+        FormatDetails valueFormat;
+        Style resourceStyle;
+        Style propertyStyle;
+        Style valueStyle;
+
+        private Format() {
+            classFormatDomain = Collections.emptyList();
+            propertyFormatDomain = Collections.emptyList();
+            var emptyDetails = new FormatDetails(null, null, null, null);
+            resourceFormat = emptyDetails;
+            propertyFormat = emptyDetails;
+            valueFormat = emptyDetails;
+            var emptyStyle = new Style(Collections.emptyList());
+            resourceStyle = emptyStyle;
+            propertyStyle = emptyStyle;
+            valueStyle = emptyStyle;
+        }
+
+        public Format(Map<?,?> f) {
+            classFormatDomain = getUnsafe(f, Fresnel.classFormatDomain, Collections.emptyList());
+            propertyFormatDomain = getUnsafe(f, Fresnel.propertyFormatDomain, Collections.emptyList());
+        }
+
+        public static Format parse(Map<?,?> f) {
+            Format format = new Format(f);
+            format.classFormatDomain = getUnsafe(f, Fresnel.classFormatDomain, Collections.emptyList());
+            format.propertyFormatDomain = getUnsafe(f, Fresnel.propertyFormatDomain, Collections.emptyList());
+            format.resourceFormat = FormatDetails.parse(getUnsafe(f, Fresnel.resourceFormat, null));
+            format.propertyFormat = FormatDetails.parse(getUnsafe(f, Fresnel.propertyFormat, null));
+            format.valueFormat = FormatDetails.parse(getUnsafe(f, Fresnel.valueFormat, null));
+            format.resourceStyle = Style.parse(getUnsafe(f, Fresnel.resourceStyle, null));
+            format.propertyStyle = Style.parse(getUnsafe(f, Fresnel.propertyStyle, null));
+            format.valueStyle = Style.parse(getUnsafe(f, Fresnel.valueStyle, null));
+            return format;
+        }
+    }
+
+    class PropertyKey {
+        String name;
+
+        public PropertyKey(String name) {
+            this.name = name;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        boolean isLangAlias() {
+            return jsonLd.langContainerAliasInverted.containsKey(name);
+        }
+
+        public String langAliasFor() {
+            return (String) jsonLd.langContainerAliasInverted.get(name);
+        }
+    }
+
+    // FIXME naming
+    public sealed abstract class Lensed permits Node, TransliteratedNode {}
+
+    public final class Node extends Lensed {
+        record Property(String name, Object value) {}
+
+        LangCode selectedLang;
+        String id;
+        String type;
+        List<Property> orderedProps = new ArrayList<>();
+        LensLevel nextLensLevel;
+
+        Node(LensLevel lensLevel, LangCode selectedLang) {
+            this.nextLensLevel = subLens(lensLevel);
+            this.selectedLang = selectedLang;
+        }
+
+        void pick(Map<?, ?> thing, PropertyKey p) {
+            // TODO JsonLd class expands lang container aliases. Do we want that?
+
+            if (RDF_TYPE.equals(p.name)) {
+                var type = (String) first(thing.get(JsonLd.TYPE_KEY)); // TODO how to handle multiple types?
+                orderedProps.add(new Property(p.name, mapVocabTerm(type)));
+            }
+            else if (!p.isLangAlias() && thing.containsKey(p.name)) {
+                Object value = thing.get(p.name);
+                if (JsonLd.TYPE_KEY.equals(p.name)) {
+                    type = (String) first(value); // TODO how to handle multiple types?
+                }
+                else if (JsonLd.ID_KEY.equals(p.name)) {
+                    id = (String) value;
+                }
+                else if (jsonLd.isVocabTerm(p.name)) {
+                    if (value instanceof List<?> list) {
+                        orderedProps.add(new Property(p.name, list.stream().map(this::mapVocabTerm).toList()));
+                    }
+                    else {
+                        orderedProps.add(new Property(p.name, mapVocabTerm(value)));
+                    }
+                }
+                else {
+                    if (value instanceof List<?> list) {
+                        var values = list.stream().map(v -> applyLens(v, nextLensLevel, selectedLang)).toList();
+                        orderedProps.add(new Property(p.name, values));
+                    }
+                    else {
+                        orderedProps.add(new Property(p.name, applyLens(value, nextLensLevel, selectedLang)));
+                    }
+                }
+            }
+            else if (p.isLangAlias() && thing.containsKey(p.name)) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> langContainer = (Map<String, Object>) thing.get(p.name);
+                if (selectedLang != null) {
+                    // TODO should we remember here that these are script alts?
+                    if(langContainer.containsKey(selectedLang.code)) {
+                        orderedProps.add(new Property(p.langAliasFor(), langContainer.get(selectedLang.code)));
+                    }
+                } else {
+                    orderedProps.add(new Property(p.langAliasFor(), new LanguageContainer(langContainer)));
+                }
+            }
+        }
+
+        private Object mapVocabTerm(Object value) {
+            if (value instanceof String s) {
+                var def = jsonLd.vocabIndex.get(s);
+                return applyLens(def != null ? def : s, nextLensLevel, selectedLang);
+            } else {
+                // bad data
+                return applyLens(value, nextLensLevel, selectedLang);
+            }
+        }
+    }
+
+    public final class TransliteratedNode extends Lensed {
+        Map<LangCode, Node> transliterations = new HashMap<>();
+        void add(LangCode langCode, Node node) {
+            transliterations.put(langCode, node);
+        }
+    }
+
+    public static class LanguageContainer {
+        Map<LangCode, List<String>> languages = new HashMap<>();
+
+        public LanguageContainer(Map<?, ?> container) {
+            for (var e : container.entrySet()) {
+                @SuppressWarnings("unchecked")
+                List<Object> l = JsonLd.asList(e.getValue());
+                languages.put(new LangCode((String) e.getKey()), mapWithIndex(l, (v, i) -> (String) v));
+            }
+        }
+
+        public boolean isTransliterated() {
+            return languages.keySet().stream().anyMatch(LangCode::isTransliterated);
+        }
+    }
+
+    private boolean has(Map<?, ?> thing, String key) {
+        if (RDF_TYPE.equals(key)) {
+            return thing.containsKey(JsonLd.TYPE_KEY);
+        }
+        return thing.containsKey(key);
+    }
+
+    private Map<?, ?> findLens(Map<?,?> thing, LensLevel lensLevel) {
+        for (var groupName : lensLevel.groups) {
+            @SuppressWarnings("unchecked")
+            var group = ((Map<String, Map<String,Object>>) jsonLd.displayData.get("lensGroups")).get(groupName);
+            @SuppressWarnings("unchecked")
+            var lens = (Map<String, Object>) jsonLd.getLensFor(thing, group);
+            if (lens != null) {
+                return  lens;
+            }
+        }
+
+        return DEFAULT_LENS;
+    }
+
+    private LensLevel subLens(LensLevel lensLevel) {
+        return switch (lensLevel) {
+            case Full -> LensLevel.Card;
+            case Card -> LensLevel.Chip;
+            case Chip, Token -> LensLevel.Token;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object> alternatives(Object alternateProperties) {
+        return (List<Object>) ((Map<String, Object>) alternateProperties).get(JsonLd.ALTERNATE_PROPERTIES);
+    }
+
+    private record RangeRestriction(String subPropertyOf, String range) {}
+
+    @SuppressWarnings("unchecked")
+    private RangeRestriction asRangeRestriction(Object o) {
+        Map<String, String> r = (Map<String, String>) o;
+        return new RangeRestriction(r.get(Rdfs.SUB_PROPERTY_OF), r.get(Rdfs.RANGE));
+    }
+
+    private List<LangCode> scriptAlternatives(Map<?,?> thing) {
+        var shouldBeGrouped = isTypedNode(thing) && (isStructuredValue(thing) || isIdentity(thing));
+
+        if (shouldBeGrouped) {
+            Set<String> codes = new HashSet<>();
+            thing.entrySet().stream()
+                    .filter(e -> e.getKey() instanceof String s
+                            && (new PropertyKey(s)).isLangAlias()
+                            && (new LanguageContainer(asMap(e.getValue()))).isTransliterated()
+                    )
+                    .forEach(e ->
+                            asMap(e.getValue()).keySet().forEach(k -> codes.add((String) k))
+                    );
+            return codes.stream().map(LangCode::new).toList();
+        }
+        // TODO
+        return Collections.emptyList();
+    }
+
+    private boolean isStructuredValue(Map<?,?> thing) {
+        return jsonLd.isSubClassOf((String) thing.get(JsonLd.TYPE_KEY), Base.StructuredValue);
+    }
+
+    private boolean isIdentity(Map<?,?> thing) {
+        return jsonLd.isSubClassOf((String) thing.get(JsonLd.TYPE_KEY), Base.Identity);
+    }
+
+    private boolean isInverseProperty(Object showProperty) {
+        return showProperty instanceof Map && ((Map<?, ?>) showProperty).containsKey("inverseOf");
+    }
+
+    private record InverseProperty(String name, String inverseName) {}
+
+    private InverseProperty asInverseProperty(Object showProperty) {
+        String p = (String) ((Map<?, ?>) showProperty).get("inverseOf");
+        return new InverseProperty(p, jsonLd.getInverseProperty(p));
+    }
+
+    public record LangCode(String code) {
+        public static final Comparator<LangCode> ORIGINAL_SCRIPT_FIRST = (a, b) -> {
+            if ((a.isTransliterated() && b.isTransliterated()) || (!a.isTransliterated() && !b.isTransliterated())) {
+                return a.code.compareTo(b.code);
+            } else if (a.isTransliterated()) {
+                return 1;
+            } else {
+                return -1;
+            }
+        };
+
+        public boolean isTransliterated() {
+             return code.contains("-t-");
+        }
+    }
+
+    private boolean isTypedNode(Object o) {
+        return o instanceof Map && ((Map<?, ?>) o).containsKey(JsonLd.TYPE_KEY);
+    }
+
+    private class Formatter {
+        LangCode locale;
+
+        Formatter (LangCode locale) {
+            this.locale = locale;
+        }
+
+        public Decorated displayDecorate(Node node) {
+            return formatResource(node, false, false);
+        }
+
+        public Decorated displayDecorate(TransliteratedNode node) {
+            return formatTransliterated(node, false, false);
+        }
+
+        private Decorated formatResource(Node node, boolean isFirst, boolean isLast) {
+            var result = new DecoratedNode();
+            result.type = node.type;
+            result.id = node.id;
+            result.fallback = node.id != null ? jsonLd.toTermKey(node.id) : ""; // TODO
+            result.display = formatProperties(node.orderedProps, node.type);
+            formats.resourceStyle(node.type).apply(result);
+            formats.resourceDetails(node.type).apply(result, isFirst, isLast);
+
+            return result;
+        }
+
+        private Decorated formatTransliterated(TransliteratedNode node, boolean isFirst, boolean isLast) {
+            var lang = new HashMap<LangCode, Decorated>();
+            for (var e : node.transliterations.entrySet()) {
+                lang.put(e.getKey(), formatResource(e.getValue(), isFirst, isLast));
+            }
+            return new DecoratedTransliterated(lang);
+        }
+
+        private List<Decorated> formatProperties(List<Node.Property> orderedProps, String className) {
+            return mapWithIndex(orderedProps,
+                    (p, ix) -> formatProperty(p, className, ix == 0, ix == orderedProps.size() - 1)
+            );
+        }
+
+        private Decorated formatProperty(Node.Property property, String className, boolean isFirst, boolean isLast) {
+            var result = new DecoratedProperty(property.name, formatValues(property.value, className, property.name));
+
+            formats.propertyStyle(className, property.name).apply(result);
+            // TODO implement _style sort() ?
+            formats.propertyDetails(className, property.name).apply(result, isFirst, isLast);
+            return result;
+        }
+
+        private List<Decorated> formatValues(Object value, String className, String propertyName) {
+            var val = unwrapSingle(value);
+            if (val instanceof LanguageContainer lang) {
+                // can never be inside array
+                return lang.isTransliterated()
+                        ? List.of(new DecoratedTransliterated(lang))
+                        : formatValues(pickLanguage(lang), className, propertyName);
+            }
+            else if (val instanceof List<?> list) {
+                return mapWithIndex(list,
+                        (v, ix) -> formatValueInArray(v, className, propertyName, ix == 0, ix == list.size() - 1));
+            } else {
+                return List.of(formatSingleValue(val, className, propertyName));
+            }
+        }
+
+        private Decorated formatSingleValue(Object value, String className, String propertyName) {
+            switch (value) {
+                case Node node -> {
+                    var isFirst = true;
+                    var isLast = true;
+                    var result = formatResource(node, isFirst, isLast);
+                    // TODO resource style vs value style???
+                    formats.valueDetails(className, propertyName).apply(result, isFirst, isLast);
+                    return result;
+                }
+                case TransliteratedNode node -> {
+                    var isFirst = true;
+                    var isLast = true;
+                    var result = formatTransliterated(node, isFirst, isLast);
+                    // TODO resource style vs value style???
+                    formats.valueDetails(className, propertyName).apply(result, isFirst, isLast);
+                    return result;
+                }
+                default -> {
+                    var result = new DecoratedLiteral(value);
+                    formats.valueStyle(className, propertyName).apply(result);
+                    return result;
+                }
+            }
+
+
+        }
+
+        private Decorated formatValueInArray(Object value,
+                                             String className,
+                                             String propertyName,
+                                             boolean isFirst,
+                                             boolean isLast) {
+            Decorated result = switch (value) {
+                case Node node -> formatResource(node, isFirst, isLast);
+                case TransliteratedNode node -> formatTransliterated(node, isFirst, isLast);
+                default -> {
+                    var r = new DecoratedLiteral(value);
+                    formats.valueStyle(className, propertyName).apply(r);
+                    yield r;
+                }
+            };
+            formats.valueDetails(className, propertyName).apply(result, isFirst, isLast);
+            return result;
+        }
+
+        private List<String> pickLanguage(LanguageContainer value) {
+            // TODO
+            // TODO handle missing
+            return value.languages.get(this.locale);
+        }
+    }
+
+    class Formats {
+        Map<String, Format> formatIndex = new HashMap<>();
+
+        public Formats (Map<String, Map<?, ?>> formats) {
+            parse(formats);
+        }
+
+        private void parse(Map<String, Map<?,?>> formats) {
+            if (formats == null) {
+                return;
+            }
+
+            for (var fd : formats.entrySet()) {
+                var f = fd.getValue();
+                if (!fd.getKey().equals(f.get(JsonLd.ID_KEY))) {
+                    logger.warn("Mismatch in format id: {} {}", fd.getKey(), f.get(JsonLd.ID_KEY));
+                }
+                if (!Fresnel.Format.equals(f.get(JsonLd.TYPE_KEY))) {
+                    logger.warn("Unknown type, skipping {}", f.get(JsonLd.TYPE_KEY));
+                    continue;
+                }
+                var format = Format.parse(f);
+                if (!format.classFormatDomain.isEmpty() && !format.propertyFormatDomain.isEmpty()) {
+                    for (var cls : format.classFormatDomain) {
+                        for (var p : format.propertyFormatDomain) {
+                            formatIndex.put(cls + "/" + p, format);
+                        }
+                    }
+                } else if (!format.classFormatDomain.isEmpty()) {
+                    for (var cls : format.classFormatDomain) {
+                        formatIndex.put(cls, format);
+                    }
+                } else if (!format.propertyFormatDomain.isEmpty()) {
+                    for (var p : format.propertyFormatDomain) {
+                        formatIndex.put(p, format);
+                    }
+                }
+            }
+        }
+
+        FormatDetails resourceDetails(String className) {
+            return findFormat(className, f -> f.resourceFormat != null).resourceFormat;
+        }
+
+        FormatDetails propertyDetails(String className, String propertyName) {
+            return findFormat(className, propertyName, f -> f.propertyFormat != null).propertyFormat;
+        }
+
+        FormatDetails valueDetails(String className, String propertyName) {
+            return findFormat(className, propertyName, f -> f.valueFormat != null).valueFormat;
+        }
+
+        Style resourceStyle(String className) {
+            return findFormat(className, f -> f.resourceStyle != null).resourceStyle;
+        }
+
+        Style propertyStyle(String className, String propertyName) {
+            return findFormat(className, propertyName, f -> f.propertyStyle != null).propertyStyle;
+        }
+
+        Style valueStyle(String className, String propertyName) {
+            return findFormat(className, propertyName, f -> f.valueStyle != null).valueStyle;
+        }
+
+        private Format findFormat(String className, Predicate<Format> predicate) {
+            // TODO precompute / memoize formats for base classes ?
+            List<String> classes = new ArrayList<>();
+            classes.add(className);
+            jsonLd.getSuperClasses(className, classes);
+            for (String cls : classes) {
+                if (formatIndex.containsKey(cls) && predicate.test(formatIndex.get(cls))) {
+                    return formatIndex.get(cls);
+                }
+            }
+            return Format.DEFAULT_FORMAT;
+        }
+
+        private Format findFormat(String className, String propertyName, Predicate<Format> predicate) {
+            List<String> classes = new ArrayList<>();
+            classes.add(className);
+            jsonLd.getSuperClasses(className, classes);
+            for (String cls : classes) {
+                var ix = cls + "/" + propertyName;
+                if (formatIndex.containsKey(ix) && predicate.test(formatIndex.get(ix))) {
+                    return formatIndex.get(ix);
+                }
+            }
+            if (formatIndex.containsKey(propertyName) && predicate.test(formatIndex.get(propertyName))) {
+                return formatIndex.get(propertyName);
+            }
+            for (String cls : classes) {
+                var ix = cls + "/" + Fresnel.WILD_PROPERTY;
+                if (formatIndex.containsKey(ix) && predicate.test(formatIndex.get(ix))) {
+                    return formatIndex.get(ix);
+                }
+            }
+            return Format.DEFAULT_FORMAT;
+        }
+    }
+
+    private static <T, U> List<U> mapWithIndex(List<T> list, BiFunction<T, Integer, U> mapper) {
+        var result = new ArrayList<U>(list.size());
+        for (int ix = 0; ix < list.size(); ix++) {
+            result.add(mapper.apply(list.get(ix), ix));
+        }
+        return result;
+    }
+
+    record FormatDetails(String contentBefore, String contentAfter, String contentFirst, String contentLast) {
+        public void apply(Decorated result,
+                          boolean isFirst,
+                          boolean isLast) {
+            if (isFirst && contentBefore != null) {
+                if (!"".equals(contentFirst)) {
+                    // TODO decide if we should generate contentBefore or contentFirst here
+                    result.contentBefore = contentFirst;
+                }
+            } else if (contentBefore != null && !contentBefore.isEmpty()) {
+                result.contentBefore = contentBefore;
+            }
+
+            if (isLast && contentLast != null) {
+                if (!contentLast.isEmpty()) {
+                    // TODO decide if we should generate contentAfter or contentLast here
+                    result.contentAfter = contentLast;
+                }
+            } else if (contentAfter != null && !contentAfter.isEmpty()) {
+                result.contentAfter = contentAfter;
+            }
+        }
+
+        public static FormatDetails parse(Map<String, String> d) {
+            if (d == null) {
+                return null;
+            }
+            return new FormatDetails(
+                    d.get(Fresnel.contentBefore),
+                    d.get(Fresnel.contentAfter),
+                    d.get(Fresnel.contentFirst),
+                    d.get(Fresnel.contentLast)
+            );
+        }
+    }
+
+    record Style(List<String> styles) {
+
+        // TODO refactor? JsonLd is only needed for displayType()
+        public void apply(Decorated result) {
+            var s = new ArrayList<String>();
+            for (String style : styles) {
+                //if (STYLERS.containsKey(style)) {
+                if (style.endsWith("()")) {
+                    applyFunction(result, style);
+                } else {
+                    s.add(style);
+                }
+            }
+            result.style = s;
+        }
+
+        public static Style parse(List<String> styles) {
+            if (styles == null) {
+                return null;
+            }
+            return new Style(styles);
+        }
+
+        private void applyFunction(Decorated result, String name) {
+            if (name.equals("isniGroupDigits()")) {
+                if (result instanceof DecoratedLiteral literal) {
+                    literal.value = switch (literal.value) {
+                        case String s -> Unicode.formatIsni(s);
+                        case List<?> list -> list.stream()
+                                .filter(s -> s instanceof String)
+                                .map(s -> Unicode.formatIsni((String) s))
+                                .toList();
+                        default -> literal.value;
+                    };
+                }
+            }
+        }
+    }
+
+    public sealed static abstract class Decorated permits DecoratedLiteral, DecoratedNode, DecoratedProperty, DecoratedTransliterated {
+        public static class Fmt {
+            public static String DISPLAY = "_display";
+            public static String CONTENT_AFTER = "_contentAfter";
+            public static String CONTENT_BEFORE = "_contentBefore";
+            public static String STYLE = "_style";
+            public static String LABEL = "_label";
+        }
+
+        String contentBefore;
+        String contentAfter;
+        List<String> style;
+        List<String> label; // TODO rename?
+
+        int lastLen = 0;
+
+        public String asString() {
+            return printTo(new StringBuilder()).toString();
+        }
+
+        abstract StringBuilder printTo(StringBuilder s);
+
+        protected void before(StringBuilder s) {
+            lastLen = s.length();
+            if (contentBefore != null) {
+                s.append(contentBefore);
+            }
+        }
+
+        protected void after(StringBuilder s) {
+            if (s.length() == lastLen + (contentBefore == null ? 0 : contentBefore.length())) {
+                s.setLength(lastLen); // produced empty string -> erase contentBefore
+            } else if (contentAfter != null) {
+                s.append(contentAfter);
+            }
+        }
+
+        abstract Object asJsonLd();
+
+        protected void asJsonLd(Map<String, Object> result) {
+            if (contentBefore != null) {
+                result.put(Fmt.CONTENT_BEFORE, contentBefore);
+            }
+            if (contentAfter != null) {
+                result.put(Fmt.CONTENT_AFTER, contentAfter);
+            }
+            if (style != null && !style.isEmpty()) {
+                result.put(Fmt.STYLE, style);
+            }
+            if (label != null && !label.isEmpty()) {
+                result.put(Fmt.LABEL, label);
+            }
+        }
+    }
+
+    public final static class DecoratedNode extends Decorated {
+        String type;
+        String id;
+        String fallback;
+
+        List<Decorated> display;
+
+        @Override
+        StringBuilder printTo(StringBuilder s) {
+            before(s);
+            if (!display.isEmpty()) {
+                display.forEach(decorated -> decorated.printTo(s));
+            } else {
+                s.append(fallback);
+            }
+            after(s);
+            return s;
+        }
+
+        public Object asJsonLd() {
+            var result = new HashMap<String, Object>();
+            result.put(JsonLd.TYPE_KEY, type);
+            if (id != null) {
+                result.put(JsonLd.ID_KEY, id);
+            }
+            result.put(Fmt.DISPLAY, display.stream().map(Decorated::asJsonLd).toList());
+
+            super.asJsonLd(result);
+            return result;
+        }
+    }
+
+    public final static class DecoratedProperty extends Decorated {
+        String key;
+        List<Decorated> values; // TODO handle single value separately?
+
+        public DecoratedProperty(String key, List<Decorated> values) {
+            this.key = key;
+            this.values = values;
+        }
+
+        @Override
+        StringBuilder printTo(StringBuilder s) {
+            before(s);
+            values.forEach(decorated -> decorated.printTo(s));
+            after(s);
+            return s;
+        }
+
+        public Object asJsonLd() {
+            var result = new HashMap<String, Object>();
+            result.put(key, unwrapSingle(values.stream().map(Decorated::asJsonLd).toList()));
+            super.asJsonLd(result);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "DecoratedProperty{" +
+                    "key='" + key + '\'' +
+                    ", values=" + values +
+                    '}';
+        }
+    }
+
+    public final static class DecoratedLiteral extends Decorated {
+        Object value;
+
+        public DecoratedLiteral(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        StringBuilder printTo(StringBuilder s) {
+            before(s);
+            s.append(value);
+            after(s);
+            return s;
+        }
+
+        public Object asJsonLd() {
+            var result = new HashMap<String, Object>();
+            super.asJsonLd(result);
+            if (result.isEmpty()) {
+                return unwrapSingle(value);
+            } else {
+                result.put(JsonLd.VALUE_KEY, unwrapSingle(value));
+                return result;
+            }
+        }
+    }
+
+    public final static class DecoratedTransliterated extends Decorated {
+        // TODO
+        private static final String T_START = " ’";
+        private static final String T_END = "’";
+        private static final String T_BETWEEN = ", ";
+
+        Map<LangCode, Decorated> scripts;
+
+        public DecoratedTransliterated(Map<LangCode, Decorated> scripts) {
+            this.scripts = scripts;
+        }
+
+        public DecoratedTransliterated(LanguageContainer container) {
+            // TODO order
+            scripts = new HashMap<>();
+            for (var e : container.languages.entrySet()) {
+                // TODO MULTIPLE
+                var v = new DecoratedLiteral(String.join(" ", e.getValue()));
+                scripts.put(e.getKey(), v);
+            }
+        }
+
+        @Override
+        StringBuilder printTo(StringBuilder s) {
+            var codes = scripts.keySet().stream().sorted(ORIGINAL_SCRIPT_FIRST).toList();
+            before(s);
+            if (!codes.isEmpty()) {
+                scripts.get(codes.getFirst()).printTo(s);
+            }
+            if (codes.size() > 1) {
+                s.append(T_START);
+                for (int i = 0 ; i < codes.size() ; i++) {
+                    if (i > 0) {
+                        scripts.get(codes.get(i)).printTo(s);
+                        if (i < codes.size() - 2) {
+                            s.append(T_BETWEEN);
+                        }
+                    }
+                }
+                s.append(T_END);
+            }
+            after(s);
+            return s;
+        }
+
+        public Object asJsonLd() {
+            var result = new HashMap<String, Object>();
+            /*
+            super.serialize(result);
+            if (result.isEmpty()) {
+                return unwrapSingle(value);
+            } else {
+                result.put(JsonLd.VALUE_KEY, unwrapSingle(value));
+                return result;
+            }
+
+             */
+            return result;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getUnsafe(Map<?, ?> m, Object key, T defaultTo) {
+        return m.containsKey(key)
+                ? (T) m.get(key)
+                : defaultTo;
+    }
+
+    private static Object unwrapSingle(Object value) {
+        if (value instanceof List<?> list && list.size() == 1) {
+            return list.getFirst();
+        }
+        return value;
+    }
+
+    private static Object first(Object value) {
+        if (value instanceof List<?> list) {
+            if (!list.isEmpty()) {
+                return list.getFirst();
+            } else {
+               return null;
+            }
+        }
+        return value;
+    }
+
+    private static Map<?, ?> asMap(Object o) {
+        if (o instanceof Map<?, ?> m) {
+            return m;
+        }
+        return new HashMap<>();
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -223,13 +223,8 @@ public class FresnelUtil {
             valueStyle = emptyStyle;
         }
 
-        public Format(Map<?,?> f) {
-            classFormatDomain = getUnsafe(f, Fresnel.classFormatDomain, Collections.emptyList());
-            propertyFormatDomain = getUnsafe(f, Fresnel.propertyFormatDomain, Collections.emptyList());
-        }
-
         public static Format parse(Map<?,?> f) {
-            Format format = new Format(f);
+            Format format = new Format();
             format.classFormatDomain = getUnsafe(f, Fresnel.classFormatDomain, Collections.emptyList());
             format.propertyFormatDomain = getUnsafe(f, Fresnel.propertyFormatDomain, Collections.emptyList());
             format.resourceFormat = FormatDetails.parse(getUnsafe(f, Fresnel.resourceFormat, null));

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -295,7 +295,8 @@ public class FresnelUtil {
                 }
                 else if (p.isTypeVocabTerm()) {
                     if (value instanceof List<?> list) {
-                        orderedProps.add(new Property(p.name, list.stream().map(this::mapVocabTerm).toList()));
+                        var values = list.stream().map(this::mapVocabTerm).toList();
+                        orderedProps.add(new Property(p.name, values));
                     }
                     else {
                         orderedProps.add(new Property(p.name, mapVocabTerm(value)));

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -77,7 +77,6 @@ public class FresnelUtil {
     }
 
     private static final Logger logger = LogManager.getLogger(FresnelUtil.class);
-    private static final String RDF_TYPE = "rdf:type";
 
     //TODO load from display.jsonld
     private static final Map<?, ?> DEFAULT_LENS = Map.of(
@@ -283,7 +282,7 @@ public class FresnelUtil {
         void pick(Map<?, ?> thing, PropertyKey p) {
             // TODO JsonLd class expands lang container aliases. Do we want that?
 
-            if (RDF_TYPE.equals(p.name)) {
+            if (Rdfs.RDF_TYPE.equals(p.name)) {
                 var type = (String) first(thing.get(JsonLd.TYPE_KEY)); // TODO how to handle multiple types?
                 orderedProps.add(new Property(p.name, mapVocabTerm(type)));
             }
@@ -362,7 +361,7 @@ public class FresnelUtil {
     }
 
     private boolean has(Map<?, ?> thing, String key) {
-        if (RDF_TYPE.equals(key)) {
+        if (Rdfs.RDF_TYPE.equals(key)) {
             return thing.containsKey(JsonLd.TYPE_KEY);
         }
         return thing.containsKey(key);

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -679,14 +679,6 @@ public class FresnelUtil {
         }
     }
 
-    private static <T, U> List<U> mapWithIndex(List<T> list, BiFunction<T, Integer, U> mapper) {
-        var result = new ArrayList<U>(list.size());
-        for (int ix = 0; ix < list.size(); ix++) {
-            result.add(mapper.apply(list.get(ix), ix));
-        }
-        return result;
-    }
-
     record FormatDetails(String contentBefore, String contentAfter, String contentFirst, String contentLast) {
         public void apply(Decorated result,
                           boolean isFirst,
@@ -1000,5 +992,13 @@ public class FresnelUtil {
             return m;
         }
         return new HashMap<>();
+    }
+
+    private static <T, U> List<U> mapWithIndex(List<T> list, BiFunction<T, Integer, U> mapper) {
+        var result = new ArrayList<U>(list.size());
+        for (int ix = 0; ix < list.size(); ix++) {
+            result.add(mapper.apply(list.get(ix), ix));
+        }
+        return result;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -290,4 +290,13 @@ class Unicode {
 
         return d[rows-1][cols-1]
     }
+
+    /**
+     * @return ISNI with with four groups of four digits separated by space
+     */
+    static String formatIsni(String isni)  {
+        isni.size() == 16
+                ? isni.split("").collate(4).collect{ it.join() }.join(" ")
+                : isni
+    }
 }

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -218,11 +218,11 @@ class FresnelUtilSpec extends Specification {
                 "note": ["NOTE 1", "NOTE 2"]
         ]
 
-        expect:
         var lensed = fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip)
         var result = fresnel.format(lensed, new FresnelUtil.LangCode('sv'))
-        println(result.asJsonLd())
-        println(result.asString())
+
+        expect:
+        result.asString() == "NOTATION • etikett • NOTE 1, NOTE 2 • Το νησι των θησαυρων ’To nisi ton thisavron’"
     }
 
     def "Heliogabalus"() {

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -10,6 +10,7 @@ import whelk.JsonLd
 /**
  * These tests mostly use context, vocab and display that are similar to KBV.
  * This in order to make the tests a little less abstract and more readable.
+ * Not sure if it makes it more confusing in the long run.
  */
 class FresnelUtilSpec extends Specification {
     static final Map CONTEXT_DATA = [

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -1,0 +1,380 @@
+package whelk.util
+
+import spock.lang.Specification
+import whelk.JsonLd
+
+// TODO test resourceStyle, propertyStyle, valueStyle
+// TODO test card, full
+// TODO test inverse properties
+
+/**
+ * These tests mostly use context, vocab and display that are similar to KBV.
+ * This in order to make the tests a little less abstract and more readable.
+ */
+class FresnelUtilSpec extends Specification {
+    static final Map CONTEXT_DATA = [
+            "@context": [
+                    "@vocab": "http://example.org/ns/",
+                    "pfx": "http://example.org/pfx/",
+                    "labelByLang": ["@id": "label", "@container": "@language"],
+                    "prefLabelByLang": ["@id": "prefLabel", "@container": "@language"],
+                    "mainTitleByLang": ["@id": "mainTitle", "@container": "@language"],
+                    "subtitleByLang": ["@id": "subtitle", "@container": "@language"],
+                    "partNameByLang": ["@id": "partName", "@container": "@language"],
+                    "partNumberByLang": ["@id": "partNumber", "@container": "@language"],
+                    "titleRemainderByLang": ["@id": "titleRemainder", "@container": "@language"],
+                    "responsibilityStatementByLang": ["@id": "responsibilityStatement", "@container": "@language"],
+
+                    "issuanceType": [ "@type": "@vocab" ],
+                    "langCodeBib": [ "@id": "code", "@type": "ISO639-2-B" ],
+
+            ]
+    ]
+
+    static final Map VOCAB_DATA = [
+            "@graph": [
+                    ["@id": "http://example.org/ns/Resource"],
+
+                    ["@id": "http://example.org/ns/Identity",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+
+                    ["@id": "http://example.org/ns/Thing",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+                    ["@id": "http://example.org/ns/Work",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+                    ["@id": "http://example.org/ns/StructuredValue",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+
+                    ["@id": "http://example.org/ns/Identifier",
+                     "subClassOf": [ ["@id": "http://example.org/ns/StructuredValue"] ]],
+
+                    ["@id": "http://example.org/ns/ISBN",
+                     "@type": "Class",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Identifier"] ]],
+                    ["@id": "http://example.org/ns/ISNI",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Identifier"] ]],
+                    ["@id": "http://example.org/ns/ORCID",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Identifier"] ]],
+                    ["@id": "http://example.org/ns/MatrixNumber",
+                     "@type": "Class",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Identifier"] ],
+                     "labelByLang": [ "en": "Audio matrix number", "sv": "Matrisnummer"],
+                    ],
+
+                    ["@id": "http://example.org/ns/Title",
+                     "subClassOf": [ ["@id": "http://example.org/ns/StructuredValue"] ]],
+                    ["@id": "http://example.org/ns/KeyTitle",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Title"] ]],
+                    ["@id": "http://example.org/ns/VariantTitle",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Title"] ]],
+
+                    ["@id": "http://example.org/ns/TitlePart",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+
+                    ["@id": "http://example.org/ns/Contribution",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+                    ["@id": "http://example.org/ns/PrimaryContribution",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Contribution"] ]],
+                    ["@id": "http://example.org/ns/Language",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ]],
+
+                    ["@id": "http://example.org/ns/Person",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Identity"] ]],
+
+                    ["@id": "http://example.org/ns/Serial",
+                     "@type": "Class",
+                     "subClassOf": [ ["@id": "http://example.org/ns/Resource"] ],
+                     "labelByLang": [ "en": "Serial", "sv": "Seriell resurs" ],
+                    ],
+
+                    ["@id": "http://example.org/ns/Publication",
+                     "subClassOf": ["@id": "http://example.org/ns/ProvisionActivity"]],
+                    ["@id": "http://example.org/pfx/SpecialPublication",
+                     "subClassOf": ["@id": "http://example.org/ns/Publication"]],
+
+                    ["@id": "http://example.org/ns/label", "@type": ["@id": "DatatypeProperty" ]],
+                    ["@id": "http://example.org/ns/prefLabel",
+                     "subPropertyOf": [ ["@id": "http://example.org/ns/label"] ]],
+                    ["@id": "http://example.org/ns/preferredLabel",
+                     "subPropertyOf": ["@id": "http://example.org/ns/prefLabel"]],
+                    ["@id": "http://example.org/ns/name",
+                     "subPropertyOf": ["@id": "http://example.org/ns/label"]]
+            ]
+    ]
+
+    static final Map DISPLAY_DATA = [
+            "@context": [
+
+            ],
+            "lensGroups": [
+                    "tokens":
+                            ["lenses": [
+                                    "Contribution": [
+                                            "@id": "Contribution-tokens",
+                                            "@type": "fresnel:Lens",
+                                            "classLensDomain": "Contribution",
+                                            "showProperties": [ "agent" ]
+                                    ],
+                            ]],
+                    "chips":
+                             ["lenses": [
+                                     "Contribution": [
+                                             "@id": "Contribution-chips",
+                                             "@type": "fresnel:Lens",
+                                             "classLensDomain": "Contribution",
+                                             "showProperties": [ "agent", "role" ]
+                                     ],
+                                     "Thing": ["showProperties": [
+                                             "notation",
+                                             "label",
+                                             "note",
+                                             "issuanceType",
+                                             ["alternateProperties": [
+                                                     "foo",
+                                                     ["subPropertyOf": "bar", "range": "Bar"],
+                                                     "title"
+                                             ]]
+                                     ]],
+                                     "Person": [
+                                             "@id": "Person-chips",
+                                             "@type": "fresnel:Lens",
+                                             "classLensDomain": "Person",
+                                             "showProperties": [ "familyName", "givenName", "name", "marc:numeration", "lifeSpan", "marc:titlesAndOtherWordsAssociatedWithAName", "fullerFormOfName" ]
+                                     ],
+                                     "Title": [
+                                             "@id": "Title-chips",
+                                             "@type": "fresnel:Lens",
+                                             "classLensDomain": "Title",
+                                             "showProperties": [ "mainTitle", "title", "subtitle", "titleRemainder", "partNumber", "partName", "hasPart" ]
+                                     ],
+                                     "TitlePart": [
+                                             "@id": "TitlePart-chips",
+                                             "@type": "fresnel:Lens",
+                                             "classLensDomain": "TitlePart",
+                                             "showProperties": ["partNumber", "partName"]
+                                     ],
+                                     "Identifier": [
+                                         "@id": "Identifier-chips",
+                                         "@type": "fresnel:Lens",
+                                         "classLensDomain": "Identifier",
+                                         "showProperties": [
+                                                 "rdf:type",
+                                                 ["alternateProperties": [ "value", "marc:hiddenValue" ]],
+                                                 "typeNote",
+                                                 "hasNote"
+                                         ]
+                                     ],
+                                     "Work": [
+                                         "@id": "Work-chips",
+                                         "@type": "fresnel:Lens",
+                                         "classLensDomain": "Work",
+                                         "showProperties": [
+                                                 ["alternateProperties": [
+                                                         ["subPropertyOf": "hasTitle", "range": "KeyTitle"],
+                                                         ["subPropertyOf": "hasTitle", "range": "Title"],
+                                                         "hasTitle"
+                                                 ]],
+                                                 "legalDate",
+                                                 "language",
+                                                 ["alternateProperties": [
+                                                         ["subPropertyOf": "contribution", "range": "PrimaryContribution"]
+                                                 ]],
+                                                 "version",
+                                                 "marc:arrangedStatementForMusic",
+                                                 "originDate"
+                                         ]
+                                     ],
+                             ]]
+                    ],
+            "formatters" : [
+                    'commaBeforeProperty-format': ['TODO': 'fullerFormOfName skrivs alltid med parenteser i libris nu, ska det vara så?', '@id': 'commaBeforeProperty-format', '@type': 'fresnel:Format', 'fresnel:propertyFormatDomain': ['lifeSpan', 'familyName', 'givenName', 'name', 'marc:numeration', 'lifeSpan', 'marc:titlesAndOtherWordsAssociatedWithAName', 'fullerFormOfName'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ', ', 'fresnel:contentFirst': '']],
+                    'subtitle-format': ['@id': 'subtitle-format', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['Title'], 'fresnel:propertyFormatDomain': ['subtitle', 'titleRemainder'], 'fresnel:propertyStyle': ['font-normal'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ' : ', 'fresnel:contentFirst': '']],
+                    'Title-qualifier-format': ['@id': 'Title-qualifier-format', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['Title'], 'fresnel:propertyFormatDomain': ['qualifier'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ' ', 'fresnel:contentFirst': '']],
+                    'transliteration': ['@id': 'transliteration', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['_Transliterated'], 'fresnel:propertyFormatDomain': ['_transliterations'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ' (', 'fresnel:contentFirst': '(', 'fresnel:contentAfter': ')', 'fresnel:contentLast': ')']],
+                    'default-separators': ['@id': 'default-separators', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['Resource'], 'fresnel:propertyFormatDomain': ['*'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ' • ', 'fresnel:contentFirst': ''], 'fresnel:valueFormat': ['fresnel:contentBefore': ', ', 'fresnel:contentFirst': '']],
+                    'Identifier-format': ['@id': 'Identifier-format', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['Identifier'], 'fresnel:resourceStyle': ['ext-link', 'displayType()', 'uriToId()']],
+                    'ISNI-digits-format': ['@id': 'ISNI-digits-format', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['ISNI', 'ORCID'], 'fresnel:propertyFormatDomain': ['value'], 'fresnel:valueStyle': ['isniGroupDigits()']],
+                    'Identifier-value-format': ['@id': 'Identifier-value-format', '@type': 'fresnel:Format', 'fresnel:classFormatDomain': ['Identifier'], 'fresnel:propertyFormatDomain': ['value'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ' ', 'fresnel:contentFirst': '']],
+                    'hasTitle-format': ['@id': 'hasTitle-format', '@type': 'fresnel:Format', 'fresnel:propertyFormatDomain': ['hasTitle'], 'fresnel:valueFormat': ['fresnel:contentBefore': ' = ', 'fresnel:contentFirst': '']],
+            ]
+    ]
+
+    // TODO JsonLd modifies DISPLAY_DATA every time it is loaded
+    static final var ld = new JsonLd(CONTEXT_DATA, DISPLAY_DATA, VOCAB_DATA)
+
+    def "format"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing = [
+                "@type": "Thing",
+                "notation": "NOTATION",
+                "labelByLang": ["sv": "etikett", "en": "label"],
+                "title": [
+                        "@type": "Title",
+                        "mainTitleByLang": [
+                                "el": "Το νησι των θησαυρων",
+                                "el-Latn-t-el-Grek-x0-btj": "To nisi ton thisavron"]],
+                "note": ["NOTE 1", "NOTE 2"]
+        ]
+
+        expect:
+        var lensed = fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip)
+        var result = fresnel.format(lensed, new FresnelUtil.LangCode('sv'))
+        println(result.asJsonLd())
+        println(result.asString())
+    }
+
+    def "Heliogabalus"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing = [
+                '@id':'https://libris-qa.kb.se/khw03jc347kgv4w#it',
+                'name':'Heliogabalus',
+                '@type':'Person',
+                'image':[['@id':'https://libris.kb.se/dataset/images/8d35730bbea96c833b7a54124eeecd9d.full.jpg']],
+                'sameAs':[['@id':'http://libris.kb.se/resource/auth/281943']],
+                'lifeSpan':'203-222',
+                'exactMatch':[['@id':'http://www.wikidata.org/entity/Q1762']],
+                'hasVariant':[['name':'Elagabalus', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['name':'Marcus Aurelius Antoninus', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['@type':'Person', 'lifeSpan':'203-222', 'givenName':'Varius Avitus', 'familyName':'Bassianus', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['name':'Héliogabale', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['name':'Elagabale', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['name':'El Gabal', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']], ['name':'Elagabalo', '@type':'Person', 'lifeSpan':'203-222', 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']]],
+                'description':['Romersk kejsare från 218; likviderad'],
+                'nationality':[['@id':'https://id.kb.se/nationality/xx']],
+                'identifiedBy':[['@type':'VIAF', 'value':'24583475'], ['@type':'ISNI', 'value':'0000000103407488']],
+                'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']
+        ]
+
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "Heliogabalus, 203-222, romersk kejsare"
+    }
+
+    def "complex title"() {
+        given:
+        var thing = [
+                '@type':'Title',
+                'mainTitle':'Teater-biblioteket',
+                'hasPart':[
+                        [
+                                '@type':'TitlePart',
+                                'partName':['En friare i lifsfara : skämt med sång i en akt'],
+                                'partNumber':['N:o 15']
+                        ]
+                ]
+        ]
+
+        var fresnel = new FresnelUtil(ld)
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "Teater-biblioteket • N:o 15 • En friare i lifsfara : skämt med sång i en akt"
+    }
+
+    def "group transliteration for structured value"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing = [
+                "@type"          : "Title",
+                "mainTitleByLang": [
+                        "grc"                            : "Νεφέλαι",
+                        "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"],
+                "subtitleByLang" : [
+                        "grc"                            : "Λυσιστράτη",
+                        "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]
+        ]
+
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "Νεφέλαι : Λυσιστράτη ’Nephelai : Lysistratē’"
+    }
+
+    def "showProperties rdf:type"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+
+        expect:
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+
+        where:
+        thing                                                  | locale | result
+        ['@type': 'ISBN', 'value': '9789174156065']            | 'sv'   | "ISBN 9789174156065"
+        ['@type': 'MatrixNumber', 'value': 'EMI 724352190508'] | 'sv'   | "Matrisnummer EMI 724352190508"
+        ['@type': 'MatrixNumber', 'value': 'EMI 724352190508'] | 'en'   | "Audio matrix number EMI 724352190508"
+    }
+
+    def "@type @vocab terms"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+
+        expect:
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+
+        where:
+        thing                                        | locale | result
+        ['@type': 'Thing', 'issuanceType': 'Serial'] | 'sv'   | 'Seriell resurs'
+        ['@type': 'Thing', 'issuanceType': 'Serial'] | 'en'   | 'Serial'
+    }
+
+
+    static var kt = ['@type': 'KeyTitle', 'mainTitle': 'key title']
+    static var kt2 = ['@type': 'KeyTitle', 'mainTitle': 'key title 2']
+    static var tt = ['@type': 'Title', 'mainTitle': 'title']
+    static var vt  = ['@type': 'VariantTitle', 'mainTitle': 'variant title']
+
+    def "alternateProperties + range restriction"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+
+        expect:
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+
+        where:
+        thing                                        | locale | result
+        ['@type': 'Work', 'hasTitle': [vt, tt, kt]]  | 'sv'   | 'key title'
+        ['@type': 'Work', 'hasTitle': [tt, kt, vt]]  | 'sv'   | 'key title'
+        ['@type': 'Work', 'hasTitle': [kt, vt, tt]]  | 'sv'   | 'key title'
+        ['@type': 'Work', 'hasTitle': [vt, tt]]      | 'sv'   | 'title'
+        ['@type': 'Work', 'hasTitle': [tt, vt]]      | 'sv'   | 'title'
+        ['@type': 'Work', 'hasTitle': [vt]]          | 'sv'   | 'variant title'
+        ['@type': 'Work', 'hasTitle': [tt, kt, kt2]] | 'sv'   | 'key title = key title 2'
+        ['@type': 'Work', 'hasTitle': [tt, kt2, kt]] | 'sv'   | 'key title 2 = key title'
+    }
+
+    def "isniGroupDigits()"() {
+        given:
+        var thing = [
+                '@type': 'ISNI',
+                'value': '0000000103407488'
+        ]
+
+        var fresnel = new FresnelUtil(ld)
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "ISNI 0000 0001 0340 7488"
+    }
+
+    def "chips vs tokens"() {
+        given:
+        var thing = [
+                '@type': 'Work',
+                'hasTitle': [
+                        ['@type': 'Title', 'mainTitle': 'Titel'],
+                        ['@type': 'Variant', 'mainTitle': 'variant title']
+                ],
+                'language' : [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': [ 'en': 'Swedish', 'sv': 'Svenska' ]],
+                ],
+                'contribution' : [
+                        ['@type': 'Contribution', 'role': 'translator', 'agent': [ '@type': 'Person', 'name': 'Överzet' ]],
+                        ['@type': 'PrimaryContribution', 'role': 'author', 'agent': [ '@type': 'Person', 'givenName': 'Namn', 'familyName': 'Namnsson', 'lifeSpan': "1972-"]],
+                ]
+        ]
+
+        var fresnel = new FresnelUtil(ld)
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "Titel • Svenska • Namnsson, Namn, 1972-"
+    }
+}

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -374,7 +374,6 @@ class FresnelUtilSpec extends Specification {
 
         var fresnel = new FresnelUtil(ld)
         var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
-
         expect:
         result.asString() == "Titel • Svenska • Namnsson, Namn, 1972-"
     }


### PR DESCRIPTION
Add basic support for the [format part of the Fresnel vocabulary](https://www.w3.org/2005/04/fresnel-info/manual/#stylecore). 

The immediate goal is "arbitrary data" -> "plain chip string with punctuation/separators". 
```
FresnelUtil f = ...
Decorated d = f.format(f.applyLens(data, lens), locale)
String s = d.asString()
```
`Decorated` is the same data structure that is used in lxl-web for, aka "decorated data".
It can also be used as a base for rendering richer formats, e.g. HTML.
(There are some differences to how transliterated strings are represented. This should be aligned when we are happy with it.)

This can be used for formatting data in e.g.
- `computedLabel` in API responses
- Record summaries in CXZ emails
- `_str` and `sortKeyByLang` in elastic index

FresnelUtil is basically as transcription of [xl.ts in lxl-web](https://github.com/libris/lxlviewer/blob/develop/lxl-web/src/lib/utils/xl.ts) but became more object oriented.

The intermediate structure after applying lenses "`Lensed`" should probably be refactored. 
I will probably split FrenelUtil over multiple files.