### PR TITLE
Add the --ignoreHistory flag to the batch import.

### DIFF
--- a/batchimport/src/main/java/whelk/importer/Merge.java
+++ b/batchimport/src/main/java/whelk/importer/Merge.java
@@ -110,11 +110,19 @@ public class Merge {
         List<Object> temp = new ArrayList<>(path);
         List<Object> trueTemp = new ArrayList<>(truePath);
 
-        Ownership owner = history.getOwnership(truePath);
+        Ownership owner = null;
+        if (history != null) {
+            owner = history.getOwnership(truePath);
+        }
 
         while (!temp.isEmpty() && !trueTemp.isEmpty()) {
             if (m_pathAddRules.containsKey(temp)) {
                 //System.err.println("  found rule! :" + temp + " matching true path: " + trueTemp + " existing owner is: " + owner);
+
+                if (history == null) {
+                    // There's a rule saying were allowed to add here, and we've been told to ignore all history (it was set to null), so we're good.
+                    return true;
+                }
 
                 Map prioMap = m_pathAddRules.get(temp);
                 if (prioMap == null) // No priority list given for this rule = anyone may add (unless hand-edited)!
@@ -162,15 +170,17 @@ public class Merge {
             // Determine (the maximum) priority for any part of the already existing subtree (below 'path')
             int basePriorityHere = 0;
             boolean baseContainsHandEdits = false;
-            Set<Ownership> baseOwners = baseHistory.getSubtreeOwnerships(truePath);
-            for (Ownership baseOwnership : baseOwners) {
-                if (baseOwnership.m_manualEditTime != null)
-                    baseContainsHandEdits = true;
-                String baseAgent = baseOwnership.m_systematicEditor;
-                if (replacePriority.get(baseAgent) != null) {
-                    int priority = (Integer) replacePriority.get(baseAgent);
-                    if (priority > basePriorityHere)
-                    basePriorityHere = priority;
+            if (baseHistory != null) {
+                Set<Ownership> baseOwners = baseHistory.getSubtreeOwnerships(truePath);
+                for (Ownership baseOwnership : baseOwners) {
+                    if (baseOwnership.m_manualEditTime != null)
+                        baseContainsHandEdits = true;
+                    String baseAgent = baseOwnership.m_systematicEditor;
+                    if (replacePriority.get(baseAgent) != null) {
+                        int priority = (Integer) replacePriority.get(baseAgent);
+                        if (priority > basePriorityHere)
+                            basePriorityHere = priority;
+                    }
                 }
             }
 

--- a/batchimport/src/main/java/whelk/importer/Parameters.java
+++ b/batchimport/src/main/java/whelk/importer/Parameters.java
@@ -30,6 +30,7 @@ class Parameters
     private boolean forceUpdate = false;
     private final HashMap<String, Set<String>> specialRules = new HashMap<>();
     private Path mergeRuleFilePath = null;
+    private boolean ignoreHistory = false;
 
     Path getPath() { return path; }
     INPUT_FORMAT getFormat() { return format; }
@@ -47,6 +48,7 @@ class Parameters
     boolean getForceUpdate() { return forceUpdate; }
     HashMap<String, Set<String>> getSpecialRules() { return specialRules; }
     Path getMergeRuleFile() { return mergeRuleFilePath; }
+    boolean getIgnoreHistory() { return ignoreHistory; }
 
 
     enum INPUT_FORMAT
@@ -168,9 +170,15 @@ class Parameters
         System.err.println();
         System.err.println("--replaceHold If this flag is set, matching holding records will be replaced.");
         System.err.println();
-        System.err.println("--mergeBibUsing Bibliographic records can be \"partially uppated\" (merged) with incoming");
+        System.err.println("--mergeBibUsing Bibliographic records can be \"partially updated\" (merged) with incoming");
         System.err.println("              records according to some specified set of rules.");
         System.err.println("              Using this option, a file containing such merge rules can be specified.");
+        System.err.println();
+        System.err.println("--ignoreHistory When using --mergeBibUsing, the \"ownership\" of various parts of the record");
+        System.err.println("              is taken into account. Hand edited things remain locked, and there can be an");
+        System.err.println("              order of priority with regards to \"whose\" edits we trust more. But when this");
+        System.err.println("              flag is specified, we ignore the existing history of all records, and apply");
+        System.err.println("              merge rules, as if all existing data had the lowest possible priority (0).");
         System.err.println();
         System.err.println("--changedBy   A string to use as descriptionCreator (MARC 040) for imported records.");
         System.err.println("              This parameter must be specified.");
@@ -326,6 +334,9 @@ class Parameters
                 break;
             case "--forceUpdate":
                 forceUpdate = true;
+                break;
+            case "--ignoreHistory":
+                ignoreHistory = true;
                 break;
             default:
                 throw new IllegalArgumentException(parameter);

--- a/batchimport/src/main/java/whelk/importer/XL.java
+++ b/batchimport/src/main/java/whelk/importer/XL.java
@@ -175,7 +175,10 @@ class XL
                 Document incoming = convertToRDF(incomingMarcRecord, idToMerge);
                 if (m_parameters.getReadOnly()) {
                     Document existing = m_whelk.getDocument(idToMerge);
-                    History existingHistory = new History(m_whelk.getStorage().loadDocumentHistory(existing.getShortId()), m_whelk.getJsonld());
+                    History existingHistory = null;
+                    if (!m_parameters.getIgnoreHistory()) {
+                        existingHistory = new History(m_whelk.getStorage().loadDocumentHistory(existing.getShortId()), m_whelk.getJsonld());
+                    }
                     m_merge.merge(existing, incoming, m_parameters.getChangedBy(), existingHistory);
                     System.out.println("info: Would now (if --live had been specified) have written the following json-ld to whelk as a merged record:\n"
                             + existing.getDataAsString());

--- a/batchimport/src/test/groovy/whelk/importer/MergeSpec.groovy
+++ b/batchimport/src/test/groovy/whelk/importer/MergeSpec.groovy
@@ -172,6 +172,51 @@ class MergeSpec extends Specification {
         ]]
     }
 
+    def "do replace a hand edit, if we're ignoring existing history (passing as null)"() {
+        given:
+        def ld = new JsonLd(CONTEXT_DATA, [:], VOCAB_DATA)
+        def versions = [
+                ['changedBy': 'sigel1',
+                 'changedIn': 'batch import',
+                 'data':
+                         ['@graph': [
+                                 ['modified': '2022-02-01T12:00:00Z'],
+                                 ['a': "something"]
+                         ]]
+                ],
+                ['changedBy': 'sigel2',
+                 'changedIn': 'xl',
+                 'data':
+                         ['@graph': [
+                                 ['modified': '2022-02-02T12:00:00Z'],
+                                 ['a': "something second"]
+                         ]]
+                ]
+        ].collect { change ->
+            new DocumentVersion(new Document(change.data), change.changedBy, change.changedIn)
+        }
+        def incoming = new Document( (Map)
+                ['@graph': [
+                        ['modified': '2022-03-01T12:00:00Z'],
+                        ['a': "something third"]
+                ]]
+        )
+        Document base = versions.last().doc
+        Merge merge = new Merge(
+                [
+                        "rules": [
+                                ["operation": "replace", "path": ["@graph",1,"a"], "priority": ["sigel1": 1, "sigel2": 2, "sigel3": 3]]
+                        ]
+                ]
+        )
+        merge.merge(base, incoming, "sigel3", null)
+        expect:
+        base.data == ['@graph': [
+                ['modified': '2022-02-02T12:00:00Z'],
+                ['a': "something third"]
+        ]]
+    }
+
     def "simple add"() {
         given:
         def ld = new JsonLd(CONTEXT_DATA, [:], VOCAB_DATA)
@@ -284,6 +329,43 @@ class MergeSpec extends Specification {
         base.data == ['@graph': [
                 ['modified': '2022-02-01T12:00:00Z'],
                 ['a': "something"]
+        ]]
+    }
+
+    def "add with lower priority, but ignoring history"() {
+        given:
+        def ld = new JsonLd(CONTEXT_DATA, [:], VOCAB_DATA)
+        def versions = [
+                ['changedBy': 'sigel1',
+                 'changedIn': 'batch import',
+                 'data':
+                         ['@graph': [
+                                 ['modified': '2022-02-01T12:00:00Z'],
+                                 ['a': "something"]
+                         ]]
+                ]
+        ].collect { change ->
+            new DocumentVersion(new Document(change.data), change.changedBy, change.changedIn)
+        }
+        def incoming = new Document( (Map)
+                ['@graph': [
+                        ['modified': '2022-03-01T12:00:00Z'],
+                        ['b': "something else"]
+                ]]
+        )
+        Document base = versions.last().doc
+        Merge merge = new Merge(
+                [
+                        "rules": [
+                                ["operation": "add_if_none", "path": ["@graph",1], "priority": ["sigel1": 2, "sigel2": 1]]
+                        ]
+                ]
+        )
+        merge.merge(base, incoming, "sigel2", null)
+        expect:
+        base.data == ['@graph': [
+                ['modified': '2022-02-01T12:00:00Z'],
+                ['a': "something", 'b': "something else"]
         ]]
     }
 


### PR DESCRIPTION
This is not to beused in any automatic flows, but for special operations it is sometimes usefull to be able to override/ignore the existing record history, to merge/replace some incoming data that you know is good.