### PR TITLE
Always load selection directly from Postgres when given ID list in bulk change specification

### DIFF
--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -203,12 +203,12 @@ class WhelkTool {
             log "Select by form"
         }
 
-        var ids = matchForm.getIdsForSelection()
+        var ids = matchForm.getIdSelection()
         if (ids.isEmpty()) {
-            var pathToIds = matchForm.getIdsForSelectionByPath()
+            var pathToIds = matchForm.getIdListsForPaths()
             ids = pathToIds.isEmpty()
                     ? whelk.sparqlQueryClient.queryIdsByPattern(matchForm.getSparqlPattern(whelk.jsonld.context))
-                    : idLoader.loadShortIdsByIdsAtPaths(pathToIds)
+                    : idLoader.loadIdsByLinksAtPaths(pathToIds)
         }
 
         selectByIds(ids, process, batchSize, silent)

--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -203,9 +203,13 @@ class WhelkTool {
             log "Select by form"
         }
 
-        var ids = matchForm.getThingIds().isEmpty()
-                ? whelk.sparqlQueryClient.queryIdsByPattern(matchForm.getSparqlPattern(whelk.jsonld.context))
-                : matchForm.getThingIds()
+        var ids = matchForm.getIdsForSelection()
+        if (ids.isEmpty()) {
+            var pathToIds = matchForm.getIdsForSelectionByPath()
+            ids = pathToIds.isEmpty()
+                    ? whelk.sparqlQueryClient.queryIdsByPattern(matchForm.getSparqlPattern(whelk.jsonld.context))
+                    : idLoader.loadShortIdsByIdsAtPaths(pathToIds)
+        }
 
         selectByIds(ids, process, batchSize, silent)
     }

--- a/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
@@ -20,6 +20,7 @@ import static whelk.component.SparqlQueryClient.GRAPH_VAR
 import static whelk.converter.JsonLDTurtleConverter.toTurtleNoPrelude
 import static whelk.util.DocumentUtil.getAtPath
 import static whelk.util.LegacyIntegrationTools.getMarcCollectionInHierarchy
+import static whelk.datatool.util.IdLoader.Id
 
 class MatchForm {
     private static final DocumentComparator comparator = new DocumentComparator()
@@ -40,7 +41,7 @@ class MatchForm {
     // For looking up where in the form a certain blank node is located
     Map<String, List> formBNodeIdToPath
     // For looking up resource ids (if given in bulk:hasId) associated with a certain blank node in the form
-    Map<String, Set<String>> formBNodeIdToResourceIds
+    Map<String, Map<String, Id>> formBNodeIdToResourceIds
     // For looking up subtypes of a type appearing in the form
     Map<String, Set<String>> baseTypeToSubtypes
 
@@ -75,11 +76,17 @@ class MatchForm {
 
         String ttl = toTurtleNoPrelude([record, thing], context)
 
-        return insertTypeMappings(insertIdMappings(insertVars(ttl)))
+        return insertTypeMappings(insertVars(ttl))
     }
 
-    Set<String> getThingIds() {
-        return formBNodeIdToResourceIds[getThingTmpId()] ?: [] as Set
+    Map<String, List<String>> getIdsForSelectionByPath() {
+        return formBNodeIdToResourceIds.collectEntries{ bNodeId, idMap ->
+            [dropIndexes(formBNodeIdToPath[bNodeId]).join("."), idMap.values().collect { it.shortId() }]
+        }
+    }
+
+    List<String> getIdsForSelection() {
+        return formBNodeIdToResourceIds[getThingTmpId()]?.values().collect { it.shortId() }
     }
 
     static List<String> dropIndexes(List path) {
@@ -164,7 +171,7 @@ class MatchForm {
     }
 
     private boolean idMatches(Map formBNode, Map bNode) {
-        def ids = formBNodeIdToResourceIds[formBNode[BNODE_ID]]
+        def ids = formBNodeIdToResourceIds[formBNode[BNODE_ID]]?.keySet()
         return ids ? ids.contains(bNode[ID_KEY]) : true
     }
 
@@ -188,9 +195,6 @@ class MatchForm {
                 if (node[TYPE_KEY] == ANY_TYPE) {
                     node.remove(TYPE_KEY)
                 }
-                if (formBNodeIdToResourceIds.containsKey(bNodeId)) {
-                    node[ID_KEY] = bNodeId
-                }
                 node.remove(MATCHING_MODE)
                 return new DocumentUtil.Nop()
             }
@@ -207,10 +211,6 @@ class MatchForm {
                 ("<" + getThingTmpId() + ">") : getVar(getThingTmpId()),
                 ("<" + getRecordTmpId() + ">"): getVar(getRecordTmpId())
         ]
-
-        formBNodeIdToResourceIds.keySet().each { _id ->
-            substitutions.put("<" + _id + ">", getVar(_id))
-        }
 
         def sparqlPattern = ttl.replace(substitutions)
 
@@ -234,13 +234,6 @@ class MatchForm {
         return sparqlPattern
     }
 
-    private String insertIdMappings(String sparqlPattern) {
-        def valuesClauses = formBNodeIdToResourceIds.collect { _id, ids ->
-            "VALUES ${getVar(_id)} { <${ids.join("> <")}> }\n"
-        }.join()
-        return valuesClauses + sparqlPattern
-    }
-
     private String getVar(String bNodeId) {
         return bNodeId == getRecordTmpId()
                 ? "?$GRAPH_VAR"
@@ -255,8 +248,8 @@ class MatchForm {
         return getAtPath(form, [RECORD_KEY, BNODE_ID], "TEMP_ID")
     }
 
-    static Map<String, Set<String>> collectFormBNodeIdToResourceIds(Map form, Whelk whelk) {
-        Map<String, Set<String>> nodeIdMappings = [:]
+    static Map<String, Map<String, Id>> collectFormBNodeIdToResourceIds(Map form, Whelk whelk) {
+        Map<String, Map<String, Id>> nodeIdMappings = [:]
 
         IdLoader idLoader = whelk ? new IdLoader(whelk.storage) : null
 
@@ -277,7 +270,7 @@ class MatchForm {
                         IdLoader.isXlShortId(it)
                                 ? Document.BASE_URI.toString() + it + Document.HASH_IT
                                 : (looksLikeIri(it) ? it : null)
-                    } as Set<String>
+                    }.collectEntries { [it, null] } as Map<String, Id>
                     return
                 }
 
@@ -292,7 +285,10 @@ class MatchForm {
                         || isInRange("AdminMetadata")
 
                 nodeIdMappings[nodeId] = idLoader.loadAllIds(xlShortIds)
-                        .collect { isRecord ? it.recordIri() : it.thingIri() } as Set<String>
+                        .collectEntries {
+                            // The key here is the IRI as it appears in the data
+                            [isRecord ? it.recordIri() : it.thingIri(), it]
+                        } as Map<String, Id>
 
                 return new DocumentUtil.Nop()
             }

--- a/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/MatchForm.groovy
@@ -79,14 +79,17 @@ class MatchForm {
         return insertTypeMappings(insertVars(ttl))
     }
 
-    Map<String, List<String>> getIdsForSelectionByPath() {
+    // If there is an ID list associated with the top level node, then that specifies the record selection.
+    List<String> getIdSelection() {
+        return formBNodeIdToResourceIds[getThingTmpId()]?.values().collect { it.shortId() }
+    }
+
+    // There can be multiple ID lists, each associated with a different path.
+    // This specifies the selection by saying that every record must, at each path, link to any of the associated IDs.
+    Map<String, List<String>> getIdListsForPaths() {
         return formBNodeIdToResourceIds.collectEntries{ bNodeId, idMap ->
             [dropIndexes(formBNodeIdToPath[bNodeId]).join("."), idMap.values().collect { it.shortId() }]
         }
-    }
-
-    List<String> getIdsForSelection() {
-        return formBNodeIdToResourceIds[getThingTmpId()]?.values().collect { it.shortId() }
     }
 
     static List<String> dropIndexes(List path) {

--- a/whelktool/src/main/java/whelk/datatool/util/IdLoader.java
+++ b/whelktool/src/main/java/whelk/datatool/util/IdLoader.java
@@ -82,7 +82,13 @@ public class IdLoader {
                 .toList();
     }
 
-    public Collection<String> loadShortIdsByIdsAtPaths(Map<String, Collection<String>> pathToIds) {
+    /*
+    * Load short ids of records containing outgoing links matching those specified in pathToIds.
+    * Given (example):
+    * pathToIds = { "x.y": [ "IDx", "IDy", "IDz" ], "a.b": [ "IDa", "IDb", "IDc" ] }
+    * Load records in which x.y links to a resource in record "IDx", "IDy" or "IDz" (short IDs) and a.b to either "IDa", "IDb" or "IDc".
+    * */
+    public Collection<String> loadIdsByLinksAtPaths(Map<String, Collection<String>> pathToIds) {
         Set<String> matchingIds = new HashSet<>();
 
         for (var e : pathToIds.entrySet()) {

--- a/whelktool/src/main/java/whelk/datatool/util/IdLoader.java
+++ b/whelktool/src/main/java/whelk/datatool/util/IdLoader.java
@@ -12,14 +12,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 
 import static whelk.datatool.WhelkTool.DEFAULT_FETCH_SIZE;
@@ -87,6 +80,46 @@ public class IdLoader {
                 .map(id -> iriToShortId.getOrDefault(id, voyagerIdToXlShortId.getOrDefault(id, isXlShortId(id) ? id : null)))
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    public Collection<String> loadShortIdsByIdsAtPaths(Map<String, Collection<String>> pathToIds) {
+        Set<String> matchingIds = new HashSet<>();
+
+        for (var e : pathToIds.entrySet()) {
+            String path = e.getKey();
+            Collection<String> idsAtPath = e.getValue();
+
+            String q = """
+                    SELECT id
+                    FROM lddb__dependencies
+                    WHERE relation = ? AND dependsonid = ANY(?)
+                    """;
+
+            Function<ResultSet, Set<String>> collectResults = (rs) -> {
+                Set<String> ids = new HashSet<>();
+                try {
+                    while (rs.next()) {
+                        ids.add(rs.getString("id"));
+                    }
+                } catch (SQLException ignored) {
+                    return Collections.emptySet();
+                }
+                return ids;
+            };
+
+            try {
+                if (matchingIds.isEmpty()) {
+                    matchingIds = query(q, collectResults, Map.of(1, path, 2, idsAtPath));
+                } else {
+                    matchingIds.retainAll(query(q, collectResults, Map.of(1, path, 2, idsAtPath)));
+
+                }
+            } catch (SQLException ignored) {
+                return Collections.emptySet();
+            }
+        }
+
+        return matchingIds;
     }
 
     public static boolean isXlShortId(String id) {

--- a/whelktool/src/test/groovy/whelk/datatool/form/MatchFormSpec.groovy
+++ b/whelktool/src/test/groovy/whelk/datatool/form/MatchFormSpec.groovy
@@ -1,6 +1,7 @@
 package whelk.datatool.form
 
 import spock.lang.Specification
+import static whelk.datatool.util.IdLoader.Id
 
 class MatchFormSpec extends Specification {
     static Map context = [
@@ -15,7 +16,7 @@ class MatchFormSpec extends Specification {
     def "match data against form"() {
         given:
         def matchForm = new MatchForm([:])
-        matchForm.formBNodeIdToResourceIds = ["#1": ["https://libris.kb.se/x#it", "https://libris.kb.se/y#it"] as Set]
+        matchForm.formBNodeIdToResourceIds = ["#1": ["https://libris.kb.se/x#it": null, "https://libris.kb.se/y#it": null]] as Map<String, Map<String, Id>>
         matchForm.baseTypeToSubtypes = ["T": ["Tx", "Ty"] as Set]
 
         expect:
@@ -103,33 +104,6 @@ class MatchFormSpec extends Specification {
         given:
         def form = ['bulk:formBlankNodeId': '#1', 'p3': [['bulk:formBlankNodeId': '#2', 'p1': 'x'], ['bulk:formBlankNodeId': '#3', 'p2': 'y']]]
         def expectedPattern = "?graph :mainEntity ?1 .\n\n?1 :p3 ( [ :p1 \"x\" ] [ :p2 \"y\" ] ) ."
-
-        expect:
-        new MatchForm(form).getSparqlPattern(context) == expectedPattern
-    }
-
-    def "form to sparql pattern: id mappings"() {
-        given:
-        def recordIds = ['@type': 'bulk:AnyOf', 'value': ['https://libris.kb.se/x', 'https://libris.kb.se/y',
-                                                          'https://libris.kb.se/z']]
-        def thingIds = ['@type': 'bulk:AnyOf', 'value': ['https://libris.kb.se/x#it', 'https://libris.kb.se/y#it',
-                                                         'https://libris.kb.se/z#it']]
-        def values = ['@type': 'bulk:AnyOf', 'value': ['https://id.kb.se/x', 'https://id.kb.se/y',
-                                                       'https://id.kb.se/z#it']]
-
-        def form = [
-                'bulk:formBlankNodeId': '#1',
-                'bulk:hasId'          : thingIds,
-                'meta'                : ['bulk:formBlankNodeId': '#2', 'bulk:hasId': recordIds],
-                'p1'                  : ['bulk:formBlankNodeId': '#3', 'bulk:hasId': values]
-        ]
-
-        def expectedPattern = "VALUES ?1 { <https://libris.kb.se/x#it> <https://libris.kb.se/y#it> <https://libris.kb.se/z#it> }\n" +
-                "VALUES ?graph { <https://libris.kb.se/x> <https://libris.kb.se/y> <https://libris.kb.se/z> }\n" +
-                "VALUES ?3 { <https://id.kb.se/x> <https://id.kb.se/y> <https://id.kb.se/z#it> }\n" +
-                "?graph :mainEntity ?1 .\n" +
-                "\n" +
-                "?1 :p1 ?3 ."
 
         expect:
         new MatchForm(form).getSparqlPattern(context) == expectedPattern


### PR DESCRIPTION
Follow-up on https://github.com/libris/librisxl/pull/1554 as per discussion in https://kbse.atlassian.net/browse/LXL-4620. Works with multiple ID lists at different paths, see for example:
![bild](https://github.com/user-attachments/assets/540e643a-b112-4852-a8e9-a65e4bfa242b)
