### PR TITLE
Search: Include number of items of instances of works for sorting

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Embellisher.groovy
+++ b/whelk-core/src/main/groovy/whelk/Embellisher.groovy
@@ -35,7 +35,7 @@ class Embellisher {
         this.getCards = getCards
         this.getByReverseRelation = getByReverseRelation
         
-        def integral = jsonld.getCategoryMembers('integral')
+        def integral = jsonld.getCategoryMembers(JsonLd.Category.INTEGRAL)
         if (integral) {
             this.integralRelations = integral
             this.inverseIntegralRelations = integralRelations.collect{ jsonld.getInverseProperty(it) }.grep()

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -421,6 +421,13 @@ class ElasticSearch {
                 (JsonLd.TYPE_KEY) : 'PartialCollectionView',
                 'totalItems': incomingLinkCountByRelation.values().sum(0),
                 'totalItemsByRelation': incomingLinkCountByRelation,
+
+                // FIXME don't hardcode this
+                // TODO where should they be placed "_totalItemsByIndirectRelation"?
+                // TODO what should be the key "itemOf.instanceOf"?
+                '_totalItemsByIndirectRelation': [
+                        'itemOf.instanceOf': ((List) DocumentUtil.getAtPath(framed, ["@reverse", "instanceOf", "*", "@reverse", "itemOf", "*"], [])).size()
+                ],
         ]
 
         framed['_sortKeyByLang'] = whelk.jsonld.applyLensAsMapByLang(


### PR DESCRIPTION
Make it possible to sort works on number of holdings. 
For now, including this count is hardcoded.

Also fix a bug where adding an item (holding) to an instance wouldn't reindex the instance's linked work.
Even though items are now included with the work in the index. (So that works can be faceted on holdings)