### PR TITLE
fix(elasticsearch): Ignore doc length when scoring _all field

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -8,7 +8,13 @@
                 }
             },
             "number_of_shards": 15,
-            "number_of_replicas": 2
+            "number_of_replicas": 2,
+            "similarity": {
+                "bm25-ignore-length": {
+                    "type": "BM25",
+                    "b": 0
+                }
+            }
         },
         "index.query.default_field": "_all",
         "analysis": {
@@ -302,7 +308,8 @@
             "_all": {
                 "type": "text",
                 "store": false,
-                "analyzer": "softmatcher"
+                "analyzer": "softmatcher",
+                "similarity": "bm25-ignore-length"
             },
             "_es_id": {
                 "type": "keyword"


### PR DESCRIPTION
Sets the BM25 similarity option `b` ("Controls to what degree document length normalizes tf values") to 0 (default 0.75) specifically for the `_all` field. `_all` contains all kinds of things and without this we're effectively punishing records with a longer `_all` length.

https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-similarity.html#bm25

https://kbse.atlassian.net/browse/LWS-316