### PR TITLE
Bugfix/alternate props boost

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
@@ -2,6 +2,8 @@ package whelk.search
 
 import whelk.JsonLd
 
+import static whelk.JsonLd.asList
+
 /**
  * A utility to compute a list of boosted fields for ElasticSearch.
  * The fields are computed from lens definitions of chips ans cards. It is
@@ -71,7 +73,7 @@ class ESQueryLensBoost {
             if (dfn instanceof String) {
                 properties << dfn
             } else if (dfn instanceof Map) {
-                for (alt in dfn.alternateProperties) {
+                for (alt in asList(dfn.alternateProperties).flatten()) {
                     if (alt instanceof String) {
                         properties << alt
                     } else if (alt instanceof Map && alt.subPropertyOf) {

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -306,13 +306,15 @@ public class EsBoost {
             if (dfn instanceof String) {
                 properties.add((String) dfn);
             } else if (dfn instanceof Map) {
-                for (var alt : asList(((Map<?, ?>) dfn).get(ALTERNATE_PROPERTIES))) {
-                    if (alt instanceof String) {
-                        properties.add((String) alt);
-                    } else if (alt instanceof Map) {
-                        var subPropertyOf = ((Map<?, ?>) alt).get(SUB_PROPERTY_OF);
-                        if (subPropertyOf != null) {
-                            properties.add((String) subPropertyOf);
+                for (var ap : asList(((Map<?, ?>) dfn).get(ALTERNATE_PROPERTIES))) {
+                    for (var prop : asList(ap)) {
+                        if (prop instanceof String) {
+                            properties.add((String) prop);
+                        } else if (prop instanceof Map) {
+                            var subPropertyOf = ((Map<?, ?>) prop).get(SUB_PROPERTY_OF);
+                            if (subPropertyOf != null) {
+                                properties.add((String) subPropertyOf);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
For queries like `_q=abc type:T` or `q=abc&@type=T` "language container" properties appearing in `showProperties.alternateProperties` of `T`'s lens definition weren't boosted. The problem was that when looping through `showProperties.alternateProperties` property `p` has already been expanded to an array: `[ "p", "pByLang" ]` and this array was ignored. So for e.g. `Language`, having the following chips definition
```
"Language": {
          "@id": "Language-chips",
          "@type": "fresnel:Lens",
          "classLensDomain": "Language",
          "showProperties": [
            {"alternateProperties": ["prefLabel", "label", "code"]}
          ]
        }
``` 
only `code` was boosted since `alternateProperties` in this case is expanded to
 ```
{
    [ "prefLabel", "prefLabelByLang" ],
    [ "label", "labelByLang" ],
    "code"
}
``` 