### PR TITLE
(search2): Make stats optional in API response

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -97,7 +97,10 @@ public class SearchUtils2 {
             }
         }
 
-        queryDsl.put("aggs", buildAggQuery(statsRepr, whelk.getJsonld(), queryTree.collectRulingTypes(whelk.getJsonld()), queryUtil::getNestedPath));
+        if (!queryParams.skipStats) {
+            queryDsl.put("aggs", buildAggQuery(statsRepr, whelk.getJsonld(), queryTree.collectRulingTypes(whelk.getJsonld()), queryUtil::getNestedPath));
+        }
+
         queryDsl.put("track_total_hits", true);
 
         if (queryParams.debug.contains(QueryParams.Debug.ES_SCORE)) {
@@ -130,7 +133,9 @@ public class SearchUtils2 {
         view.put("search", Map.of("mapping", List.of(qt.toSearchMapping(queryParams.getNonQueryParams(0)))));
         view.putAll(Pagination.makeLinks(queryResult.numHits, queryUtil.maxItems(), freeText, fullQuery, queryParams));
         view.put("items", queryResult.collectItems(queryUtil.getApplyLensFunc(queryParams)));
-        view.put("stats", new Stats(whelk.getJsonld(), queryUtil, qt, queryResult, queryParams, appParams).build());
+        if (!queryParams.skipStats) {
+            view.put("stats", new Stats(whelk.getJsonld(), queryUtil, qt, queryResult, queryParams, appParams).build());
+        }
         if (!queryResult.spell.isEmpty()) {
             view.put("_spell", buildSpellSuggestions(queryResult, qt, queryParams.getNonQueryParams(0)));
         }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -29,6 +29,7 @@ public class QueryParams {
         public static final String DEBUG = "_debug";
         public static final String APP_CONFIG = "_appConfig";
         public static final String BOOST = "_boost";
+        public static final String STATS = "_stats";
     }
 
     public static class Debug {
@@ -50,6 +51,8 @@ public class QueryParams {
     public final String q;
     public final String i;
 
+    public final boolean skipStats;
+
     public QueryParams(Map<String, String[]> apiParameters) throws InvalidQueryException {
         this.sortBy = Sort.fromString(getOptionalSingleNonEmpty(ApiParams.SORT, apiParameters).orElse(""));
         this.object = getOptionalSingleNonEmpty(ApiParams.OBJECT, apiParameters).orElse(null);
@@ -63,6 +66,7 @@ public class QueryParams {
         this.boostFields = getMultiple(ApiParams.BOOST, apiParameters);
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
+        this.skipStats = getOptionalSingle(ApiParams.STATS, apiParameters).map("false"::equalsIgnoreCase).isPresent();
     }
 
     public Map<String, String> getNonQueryParams() {
@@ -97,6 +101,9 @@ public class QueryParams {
         }
         if (!boostFields.isEmpty()) {
             params.put(ApiParams.BOOST, String.join(",", boostFields));
+        }
+        if (skipStats) {
+            params.put(ApiParams.STATS, "false");
         }
         return params;
     }


### PR DESCRIPTION
Set `_stats=false` to exclude stats.