### PR TITLE
Feature/lxl 4610 cleanup

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -12,6 +12,7 @@ import whelk.component.PostgreSQLComponent.UpdateAgent
 import whelk.component.SparqlQueryClient
 import whelk.component.SparqlUpdater
 import whelk.converter.marc.MarcFrameConverter
+import whelk.exception.LinkValidationException
 import whelk.exception.StorageCreateFailedException
 import whelk.filter.LanguageLinker
 import whelk.exception.WhelkException
@@ -27,7 +28,6 @@ import java.time.Instant
 import java.time.ZoneId
 
 import static whelk.FeatureFlags.Flag.INDEX_BLANK_WORKS
-import static whelk.exception.LinkValidationException.IncomingLinksException
 
 /**
  * The Whelk is the root component of the XL system.
@@ -577,7 +577,7 @@ class Whelk {
         boolean isDependedUpon = storage.getIncomingLinkCountByIdAndRelation(doc.getShortId())
                 .any { relation, _ -> !JsonLd.isWeak(relation) }
         if (isDependedUpon) {
-            throw new IncomingLinksException("Record is referenced by other records")
+            throw new LinkValidationException("Record is referenced by other records")
         }
     }
 

--- a/whelk-core/src/main/java/whelk/exception/LinkValidationException.java
+++ b/whelk-core/src/main/java/whelk/exception/LinkValidationException.java
@@ -4,16 +4,4 @@ public class LinkValidationException extends Exception {
     public LinkValidationException(String msg) {
         super(msg);
     }
-
-    public static class IncomingLinksException extends LinkValidationException {
-        public IncomingLinksException(String msg) {
-            super(msg);
-        }
-    }
-
-    public static class OutgoingLinksException extends LinkValidationException {
-        public OutgoingLinksException(String msg) {
-            super(msg);
-        }
-    }
 }

--- a/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/delete.groovy
@@ -1,7 +1,7 @@
 import whelk.Document
 import whelk.datatool.form.MatchForm
+import whelk.exception.LinkValidationException
 
-import static whelk.exception.LinkValidationException.IncomingLinksException
 import static whelk.JsonLd.RECORD_KEY
 import static whelk.datatool.bulkchange.BulkJobDocument.MATCH_FORM_KEY
 
@@ -14,7 +14,7 @@ MatchForm mf = new MatchForm(matchForm, getWhelk())
 selectByForm(mf) {
     if(mf.matches(getFramedThing(it.doc))) {
         it.scheduleDelete(loud: isLoudAllowed, onError: { e ->
-            if (e instanceof IncomingLinksException) {
+            if (e instanceof LinkValidationException) {
                 failed.println("Failed to delete $it.doc.shortId: ${e.getMessage()}")
             } else {
                 throw e


### PR DESCRIPTION
Removed the check for outgoing links and cleaned up related code.

There is no point in checking for outgoing links to deleted records because once a record is deleted its main entity IRI gets removed from `lddb__identifiers` and thus we can't see if a record was ever present in lddb via its main entity IRI.

Also improved the error message for when trying to delete a referenced record a bit.