### PR TITLE
experimental(search): Index _topChipStr, _chipStr, _cardStr, _searchCardStr

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -13,6 +13,11 @@
                 "bm25-ignore-length": {
                     "type": "BM25",
                     "b": 0
+                },
+                "bm25-ignore-length-quick-saturation": {
+                    "type": "BM25",
+                    "b": 0,
+                    "k1": 0.1
                 }
             }
         },
@@ -446,11 +451,11 @@
                             "exact": {
                                 "type": "text",
                                 "analyzer": "standard",
-                                "similarity": "bm25-ignore-length"
+                                "similarity": "bm25-ignore-length-quick-saturation"
                             }
                         },
                         "analyzer": "softmatcher",
-                        "similarity": "bm25-ignore-length",
+                        "similarity": "bm25-ignore-length-quick-saturation",
                         "type": "text",
                         "index": true
                     }

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -423,6 +423,40 @@
                 }
             },
             {
+                "str_template": {
+                    "match": ["_topChipStr"],
+                    "mapping": {
+                        "fields": {
+                            "exact": {
+                                "type": "text",
+                                "analyzer": "standard"
+                            }
+                        },
+                        "analyzer": "softmatcher",
+                        "type": "text",
+                        "index": true
+                    }
+                }
+            },
+            {
+                "str-ignore-length_template": {
+                    "match": ["_chipStr", "_cardStr", "_searchCardStr"],
+                    "mapping": {
+                        "fields": {
+                            "exact": {
+                                "type": "text",
+                                "analyzer": "standard",
+                                "similarity": "bm25-ignore-length"
+                            }
+                        },
+                        "analyzer": "softmatcher",
+                        "similarity": "bm25-ignore-length",
+                        "type": "text",
+                        "index": true
+                    }
+                }
+            },
+            {
                 "catchall_template": {
                     "match_mapping_type": "string",
                     "mapping": {

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -20,6 +20,7 @@ import whelk.filter.NormalizerChain
 import whelk.meta.WhelkConstants
 import whelk.search.ESQuery
 import whelk.search.ElasticFind
+import whelk.util.FresnelUtil
 import whelk.util.PropertyLoader
 import whelk.util.Romanizer
 
@@ -58,6 +59,7 @@ class Whelk {
     Map contextData
     JsonLd jsonld
 
+    FresnelUtil fresnelUtil
     MarcFrameConverter marcFrameConverter
     ResourceCache resourceCache
     ElasticFind elasticFind
@@ -227,6 +229,7 @@ class Whelk {
             elasticFind = new ElasticFind(new ESQuery(this))
             initDocumentNormalizers(elasticFind)
         }
+        this.fresnelUtil = new FresnelUtil(jsonld)
     }
 
     // FIXME: de-KBV/Libris-ify: some of these are KBV specific, is that a problem?

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -23,6 +23,7 @@ import static whelk.FeatureFlags.Flag.INDEX_BLANK_WORKS
 import static whelk.JsonLd.asList
 import static whelk.exception.UnexpectedHttpStatusException.isBadRequest
 import static whelk.exception.UnexpectedHttpStatusException.isNotFound
+import static whelk.util.FresnelUtil.Options.TAKE_ALL_ALTERNATE
 import static whelk.util.Jackson.mapper
 
 @Log
@@ -470,11 +471,11 @@ class ElasticSearch {
                 document.getThingInScheme() ? ['tokens', 'chips'] : ['chips'])
 
         try {
-            var chip = whelk.fresnelUtil.applyLens(framed, FresnelUtil.LensGroupName.Chip);
+            var chip = whelk.fresnelUtil.applyLens(framed, FresnelUtil.LensGroupName.Chip, TAKE_ALL_ALTERNATE);
             framed[TOP_CHIP_STR] = chip.firstProperty().asString()
             framed[CHIP_STR] = chip.asString()
-            framed[CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.CARD_ONLY).asString()
-            framed[SEARCH_CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.SEARCH_CARD_ONLY).asString()
+            framed[CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
+            framed[SEARCH_CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.SEARCH_CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
         } catch (Exception e) {
             log.error(e, e)
         }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -78,7 +78,10 @@ public record FreeText(TextQuery textQuery, Operator operator, String value, Col
         );
         boostedSoft.put(queryMode, bs);
 
-        var shouldClause = new ArrayList<>(Arrays.asList(boostedExact, boostedSoft, simpleQuery));
+        var shouldClause = boostFields.contains("no-default-field") // dont search index.query.default_field, i.e. _all
+            ? new ArrayList<>(List.of(boostedExact))
+            : new ArrayList<>(Arrays.asList(boostedExact, boostedSoft, simpleQuery));
+
         if (operator() == Operator.EQUALS) {
             return shouldWrap(shouldClause);
         }

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -646,6 +646,8 @@ public class FresnelUtil {
         return jsonLd.isSubClassOf(firstType(thing), Base.Identity);
     }
 
+
+
     private record InverseProperty(String name, String inverseName) implements PropertySelector {}
 
     public record LangCode(String code) {

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -6,13 +6,16 @@ import whelk.JsonLd;
 import whelk.JsonLd.Rdfs;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -21,27 +24,33 @@ import static whelk.util.FresnelUtil.LangCode.ORIGINAL_SCRIPT_FIRST;
 
 // https://www.w3.org/2005/04/fresnel-info/manual/
 
+// TODO handle subPropertyOf
+//   -- https://www.w3.org/2005/04/fresnel-info/fsl/#rdfsowl
+//   -- https://github.com/libris/definitions/blob/41b0ac7b7089974dc1d1c41f221c038f1353df75/source/vocab/display.jsonld#L171
 // TODO fallback style for things that fall outside the class hierarchy?
 // TODO defer language selection?
 // TODO bad data - blank nodes without type?
 
 public class FresnelUtil {
 
-    public enum LensLevel {
+    public enum LensGroupName {
         Full(List.of("full", "cards")),
         Card(List.of("cards")),
         Chip(List.of("chips")),
-        Token(List.of("tokens", "chips"));
+        Token(List.of("tokens", "chips")),
+
+        SearchCard(List.of("search-cards", "cards")),
+        SearchChip(List.of("search-chips", "chips"));
 
         final List<String> groups;
 
-        LensLevel(List<String> groups) {
+        LensGroupName(List<String> groups) {
             this.groups = groups;
         }
     }
 
     // https://www.w3.org/2005/04/fresnel-info/manual/
-    static class Fresnel {
+    public static class Fresnel {
         public static String Format = "fresnel:Format";
         public static String Group = "fresnel:Group";
         public static String Lens = "fresnel:Lens";
@@ -76,10 +85,13 @@ public class FresnelUtil {
         public static String Identity = "Identity";
     }
 
+    private record DerivedCacheKey(Object types, DerivedLens lens) {}
+    private record LensCacheKey(Object types, LensGroupName lensGroupName) {}
+
     private static final Logger logger = LogManager.getLogger(FresnelUtil.class);
 
     //TODO load from display.jsonld
-    private static final Map<?, ?> DEFAULT_LENS = Map.of(
+    private static final Map<String, Object> DEFAULT_LENS = Map.of(
             JsonLd.TYPE_KEY, Fresnel.Lens,
             Fresnel.showProperties, List.of(
                     Map.of(Fresnel.alternateProperties, List.of(
@@ -92,16 +104,35 @@ public class FresnelUtil {
     JsonLd jsonLd;
     Formats formats;
 
-    FresnelUtil(JsonLd jsonLd) {
+    private final Map<DerivedCacheKey, Lens> derivedLensCache = new ConcurrentHashMap<>();
+    private final Map<LensCacheKey, Lens> lensCache = new ConcurrentHashMap<>();
+
+    public FresnelUtil(JsonLd jsonLd) {
         this.jsonLd = jsonLd;
         this.formats = new Formats(getUnsafe(jsonLd.displayData, "formatters", null));
     }
 
-    public Lensed applyLens(Object thing, LensLevel lens) {
+    public Lensed applyLens(Object thing, LensGroupName lens) {
         // TODO
         if (!isTypedNode(thing)) {
             throw new IllegalArgumentException("Thing is not typed node: " + thing);
         }
+
+        return (Lensed) applyLens(thing, lens, null);
+    }
+
+    public Lensed applyLens(Object thing, DerivedLens derived) {
+        // TODO
+        if (!(thing instanceof Map<?, ?> t)) {
+            throw new IllegalArgumentException("Thing is not typed node: " + thing);
+        }
+
+        var types = t.get(JsonLd.TYPE_KEY);
+        var lens = derivedLensCache.computeIfAbsent(new DerivedCacheKey(types, derived), k -> {
+            var base = findLens(t, derived.base);
+            var minus = derived.minus.stream().map(l -> findLens(t, l)).toList();
+            return base.minus(minus, derived.subLens);
+        });
 
         return (Lensed) applyLens(thing, lens, null);
     }
@@ -116,7 +147,21 @@ public class FresnelUtil {
 
     private Object applyLens(
             Object value,
-            LensLevel lensLevel,
+            LensGroupName lensGroupName,
+            LangCode selectedLang
+    ) {
+        if (!(value instanceof Map<?, ?> thing)) {
+            // literal
+            return value;
+        }
+        var lens = findLens(thing, lensGroupName);
+
+        return applyLens(value, lens, selectedLang);
+    }
+
+    private Object applyLens(
+            Object value,
+            Lens lens,
             LangCode selectedLang
     ) {
         if (!(value instanceof Map<?, ?> thing)) {
@@ -128,67 +173,62 @@ public class FresnelUtil {
         if (!scripts.isEmpty()) {
             TransliteratedNode n = new TransliteratedNode();
             for (var script : scripts) {
-                n.add(script, (Node) applyLens(thing, lensLevel, script));
+                n.add(script, (Node) applyLens(thing, lens, script));
             }
             return n;
         }
 
-        var result = new Node(lensLevel, selectedLang);
-        var lens = findLens(thing, lensLevel);
+        var result = new Node(lens, selectedLang);
 
-        @SuppressWarnings("unchecked")
-        var showProperties = (List<Object>) lens.get(Fresnel.showProperties);
-        showProperties = Stream.concat(Stream.of(JsonLd.TYPE_KEY, JsonLd.ID_KEY), showProperties.stream()).toList();
+        var showProperties = Stream.concat(Stream.of(new PropertyKey(JsonLd.TYPE_KEY), new PropertyKey(JsonLd.ID_KEY)), lens.showProperties().stream()).toList();
         for (var p : showProperties) {
-            if (JsonLd.isAlternateProperties(p)) {
-                for (var alternative : alternatives(p)) {
-                    if (JsonLd.isAlternateRangeRestriction(alternative)) {
-                        // can never be language container
-                        var r = asRangeRestriction(alternative);
-                        var k = r.subPropertyOf;
-                        @SuppressWarnings("unchecked")
-                        var v = ((List<Object>) JsonLd.asList(thing.get(k)))
-                                .stream()
-                                .filter(n -> isTypedNode(n) && r.range.equals(asMap(n).get(JsonLd.TYPE_KEY)))
-                                .toList();
-
-                        if (!v.isEmpty()) {
-                            result.pick(Map.of(k, v), new PropertyKey(k));
-                            break;
-                        }
+            switch (p) {
+                case PropertyKey k -> {
+                    if (k.isIn(thing)) {
+                        result.pick(thing, k);
                     }
-                    else if (alternative instanceof List<?> list) {
-                        // expanded lang alias, i.e. ["x", "xByLang"]
-                        var found = false;
-                        for (var k : list) {
-                            if (has(thing, (String) k)) {
-                                result.pick(thing, new PropertyKey((String) k));
-                                found = true;
+                }
+                case AlternateProperties a -> {
+                    alt: for (var alternative : a.alternatives) {
+                        switch (alternative) {
+                            case PropertyKey k -> {
+                                if (k.isIn(thing)) {
+                                    result.pick(thing, k);
+                                    break alt;
+                                }
+                            }
+                            case RangeRestriction r -> {
+                                // can never be language container
+                                var k = r.subPropertyOf;
+                                @SuppressWarnings("unchecked")
+                                var v = ((List<Object>) JsonLd.asList(thing.get(k)))
+                                        .stream()
+                                        .filter(n -> isTypedNode(n) && r.range.equals(asMap(n).get(JsonLd.TYPE_KEY)))
+                                        .toList();
+
+                                if (!v.isEmpty()) {
+                                    result.pick(Map.of(k, v), new PropertyKey(k));
+                                    break alt;
+                                }
+                            }
+                            default -> {
+
                             }
                         }
-                        if (found) {
-                            break;
-                        }
-                    }
-                    else if (alternative instanceof String k) {
-                        if (has(thing, k)) {
-                            result.pick(thing, new PropertyKey(k));
-                            break;
-                        }
                     }
                 }
-            }
-            else if (isInverseProperty(p)) {
-                // never language container
-                var i = asInverseProperty(p);
-                if (thing.get(JsonLd.REVERSE_KEY) instanceof Map<?, ?> r && r.containsKey(i.name)) {
-                    var v = r.get(i.name);
-                    result.pick(Map.of(i.inverseName, v), new PropertyKey(i.inverseName));
+                case InverseProperty i -> {
+                    // never language container
+                    if (thing.get(JsonLd.REVERSE_KEY) instanceof Map<?, ?> r && r.containsKey(i.name)) {
+                        var v = r.get(i.name);
+                        result.pick(Map.of(i.inverseName, v), new PropertyKey(i.inverseName));
+                    }
                 }
-            }
-            else if (p instanceof String k) {
-                if (has(thing, k)) {
-                    result.pick(thing, new PropertyKey(k));
+                case RangeRestriction ignored -> {
+                    // Not allowed here currently
+                }
+                case Unrecognized ignored -> {
+
                 }
             }
         }
@@ -237,7 +277,7 @@ public class FresnelUtil {
         }
     }
 
-    class PropertyKey {
+    final class PropertyKey implements PropertySelector {
         String name;
 
         public PropertyKey(String name) {
@@ -248,21 +288,61 @@ public class FresnelUtil {
             return name;
         }
 
-        boolean isLangAlias() {
-            return jsonLd.langContainerAliasInverted.containsKey(name);
+        boolean hasLangAlias() {
+            return jsonLd.langContainerAlias.containsKey(name);
         }
 
-        public String langAliasFor() {
-            return (String) jsonLd.langContainerAliasInverted.get(name);
+        public String langAlias() {
+            return (String) jsonLd.langContainerAlias.get(name);
         }
 
         boolean isTypeVocabTerm() {
             return jsonLd.isVocabTerm(name);
         }
+
+        private boolean isIn(Map<?, ?> thing) {
+            if (Rdfs.RDF_TYPE.equals(name)) {
+                return thing.containsKey(JsonLd.TYPE_KEY);
+            }
+            return thing.containsKey(name) || (hasLangAlias() && thing.containsKey(langAlias()));
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder s = new StringBuilder();
+            s.append(name);
+            if (hasLangAlias()) {
+                s.append(" (").append(langAlias()).append(")");
+            }
+            if (isTypeVocabTerm()) {
+                s.append(" (vocab)");
+            }
+            return s.toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            PropertyKey that = (PropertyKey) o;
+            return Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(name);
+        }
     }
 
     // FIXME naming
-    public sealed abstract class Lensed permits Node, TransliteratedNode {}
+    public sealed abstract class Lensed permits Node, TransliteratedNode {
+        public String asString() {
+            return printTo(new StringBuilder()).toString();
+        }
+
+        public abstract Lensed firstProperty();
+
+        protected abstract StringBuilder printTo(StringBuilder s);
+    }
 
     public final class Node extends Lensed {
         record Property(String name, Object value) {}
@@ -271,10 +351,10 @@ public class FresnelUtil {
         String id;
         String type;
         List<Property> orderedProps = new ArrayList<>();
-        LensLevel nextLensLevel;
+        Lens lens;
 
-        Node(LensLevel lensLevel, LangCode selectedLang) {
-            this.nextLensLevel = subLens(lensLevel);
+        Node(Lens lens, LangCode selectedLang) {
+            this.lens = lens;
             this.selectedLang = selectedLang;
         }
 
@@ -282,10 +362,12 @@ public class FresnelUtil {
             // TODO JsonLd class expands lang container aliases. Do we want that?
 
             if (Rdfs.RDF_TYPE.equals(p.name)) {
-                var type = (String) first(thing.get(JsonLd.TYPE_KEY)); // TODO how to handle multiple types?
+                var type = firstType(thing); // TODO how to handle multiple types?
                 orderedProps.add(new Property(p.name, mapVocabTerm(type)));
+                return;
             }
-            else if (!p.isLangAlias() && thing.containsKey(p.name)) {
+
+            if (thing.containsKey(p.name)) {
                 Object value = thing.get(p.name);
                 if (JsonLd.TYPE_KEY.equals(p.name)) {
                     type = (String) first(value); // TODO how to handle multiple types?
@@ -304,35 +386,64 @@ public class FresnelUtil {
                 }
                 else {
                     if (value instanceof List<?> list) {
-                        var values = list.stream().map(v -> applyLens(v, nextLensLevel, selectedLang)).toList();
+                        var values = list.stream().map(v -> applyLens(v, lens.subLensGroup, selectedLang)).toList();
                         orderedProps.add(new Property(p.name, values));
                     }
                     else {
-                        orderedProps.add(new Property(p.name, applyLens(value, nextLensLevel, selectedLang)));
+                        orderedProps.add(new Property(p.name, applyLens(value, lens.subLensGroup, selectedLang)));
                     }
                 }
             }
-            else if (p.isLangAlias() && thing.containsKey(p.name)) {
+            if (p.hasLangAlias() && thing.containsKey(p.langAlias())) {
                 @SuppressWarnings("unchecked")
-                Map<String, Object> langContainer = (Map<String, Object>) thing.get(p.name);
+                Map<String, Object> langContainer = (Map<String, Object>) thing.get(p.langAlias());
                 if (selectedLang != null) {
                     // TODO should we remember here that these are script alts?
                     if(langContainer.containsKey(selectedLang.code)) {
-                        orderedProps.add(new Property(p.langAliasFor(), langContainer.get(selectedLang.code)));
+                        orderedProps.add(new Property(p.name(), langContainer.get(selectedLang.code)));
                     }
                 } else {
-                    orderedProps.add(new Property(p.langAliasFor(), new LanguageContainer(langContainer)));
+                    orderedProps.add(new Property(p.name(), new LanguageContainer(langContainer)));
                 }
+            }
+        }
+
+        @Override
+        public Node firstProperty() {
+            var result = new Node(lens, selectedLang);
+            result.id = id;
+            result.type = type;
+            result.orderedProps = orderedProps.isEmpty()
+                ? Collections.emptyList()
+                : List.of(orderedProps.getFirst());
+            return result;
+        }
+
+        @Override
+        protected StringBuilder printTo(StringBuilder s) {
+            orderedProps.forEach(prop -> printTo(s, prop.value));
+            return s;
+        }
+
+        private void printTo(StringBuilder s, Object value) {
+            if(!s.isEmpty() && s.charAt(s.length() - 1) != ' ') {
+                s.append(" ");
+            }
+            switch(value) {
+                case Collection<?> l -> l.forEach(v -> printTo(s, v));
+                case LanguageContainer l -> l.languages.values().forEach(v -> printTo(s, v));
+                case Lensed l -> l.printTo(s);
+                default -> s.append(value);
             }
         }
 
         private Object mapVocabTerm(Object value) {
             if (value instanceof String s) {
                 var def = jsonLd.vocabIndex.get(s);
-                return applyLens(def != null ? def : s, nextLensLevel, selectedLang);
+                return applyLens(def != null ? def : s, lens.subLensGroup, selectedLang);
             } else {
                 // bad data
-                return applyLens(value, nextLensLevel, selectedLang);
+                return applyLens(value, lens.subLensGroup, selectedLang);
             }
         }
     }
@@ -341,6 +452,24 @@ public class FresnelUtil {
         Map<LangCode, Node> transliterations = new HashMap<>();
         void add(LangCode langCode, Node node) {
             transliterations.put(langCode, node);
+        }
+
+        @Override
+        public Lensed firstProperty() {
+            var result = new TransliteratedNode();
+            transliterations.forEach((langCode, node) -> {
+                result.transliterations.put(langCode, node.firstProperty());
+            });
+            return result;
+        }
+
+        @Override
+        protected StringBuilder printTo(StringBuilder s) {
+            if(!s.isEmpty() && s.charAt(s.length() - 1) != ' ') {
+                s.append(" ");
+            }
+            transliterations.values().forEach(node -> node.printTo(s));
+            return s;
         }
     }
 
@@ -360,41 +489,129 @@ public class FresnelUtil {
         }
     }
 
-    private boolean has(Map<?, ?> thing, String key) {
-        if (Rdfs.RDF_TYPE.equals(key)) {
-            return thing.containsKey(JsonLd.TYPE_KEY);
-        }
-        return thing.containsKey(key);
-    }
+    private Lens findLens(Map<?,?> thing, LensGroupName lensGroupName) {
+        var types = thing.get(JsonLd.TYPE_KEY);
+        var cacheKey = new LensCacheKey(types, lensGroupName);
 
-    private Map<?, ?> findLens(Map<?,?> thing, LensLevel lensLevel) {
-        for (var groupName : lensLevel.groups) {
-            @SuppressWarnings("unchecked")
-            var group = ((Map<String, Map<String,Object>>) jsonLd.displayData.get("lensGroups")).get(groupName);
-            @SuppressWarnings("unchecked")
-            var lens = (Map<String, Object>) jsonLd.getLensFor(thing, group);
-            if (lens != null) {
-                return  lens;
+        return lensCache.computeIfAbsent(cacheKey, k -> {
+            for (var groupName : lensGroupName.groups) {
+                @SuppressWarnings("unchecked")
+                var group = ((Map<String, Map<String,Object>>) jsonLd.displayData.get("lensGroups")).get(groupName);
+                @SuppressWarnings("unchecked")
+                var lens = (Map<String, Object>) jsonLd.getLensFor(thing, group);
+                if (lens != null) {
+                    return new Lens(lens, subLens(lensGroupName));
+                }
             }
-        }
 
-        return DEFAULT_LENS;
+            return new Lens(DEFAULT_LENS, subLens(lensGroupName));
+        });
     }
 
-    private LensLevel subLens(LensLevel lensLevel) {
-        return switch (lensLevel) {
-            case Full -> LensLevel.Card;
-            case Card -> LensLevel.Chip;
-            case Chip, Token -> LensLevel.Token;
+    public class Lens {
+        private final LensGroupName subLensGroup;
+        private final List<PropertySelector> showProperties;
+
+        public Lens(Map<String, Object> lensDefinition, LensGroupName subLensGroup) {
+            this.subLensGroup = subLensGroup;
+
+            @SuppressWarnings("unchecked")
+            var showProperties = (List<Object>) lensDefinition.get(Fresnel.showProperties);
+            this.showProperties = parseShowProperties(showProperties);
+        }
+
+        private Lens(List<PropertySelector> showProperties, LensGroupName subLensGroup) {
+            this.showProperties = showProperties;
+            this.subLensGroup = subLensGroup;
+        }
+
+        List<PropertySelector> showProperties() {
+            return showProperties;
+        }
+
+        private List<PropertySelector> parseShowProperties(List<Object> showProperties) {
+            return showProperties.stream().map(p -> {
+                if (JsonLd.isAlternateProperties(p)) {
+                    return new AlternateProperties(alternatives(p));
+                }
+                if (p instanceof List<?> list) {
+                    // expanded lang alias, i.e. ["x", "xByLang"] inside alternateProperties
+                    // TODO remove expansion in jsonLd?
+                    if (list.size() == 2) {
+                        return new PropertyKey((String) list.getFirst());
+                    }
+                }
+                if (isInverseProperty(p)) {
+                    return asInverseProperty(p);
+                }
+                if (JsonLd.isAlternateRangeRestriction(p)) {
+                    return asRangeRestriction(p);
+                }
+                if (p instanceof String k) {
+                    // ignore langContainer aliases expanded by jsonld
+                    if (!jsonLd.langContainerAliasInverted.containsKey(k)) {
+                        return new PropertyKey(k);
+                    }
+                }
+                return new Unrecognized();
+            }).toList();
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<PropertySelector> alternatives(Object alternateProperties) {
+            var alternatives = (List<Object>) ((Map<String, Object>) alternateProperties).get(JsonLd.ALTERNATE_PROPERTIES);
+            return parseShowProperties(alternatives);
+        }
+
+        private boolean isInverseProperty(Object showProperty) {
+            return showProperty instanceof Map && ((Map<?, ?>) showProperty).containsKey("inverseOf");
+        }
+
+        private InverseProperty asInverseProperty(Object showProperty) {
+            String p = (String) ((Map<?, ?>) showProperty).get("inverseOf");
+            return new InverseProperty(p, jsonLd.getInverseProperty(p));
+        }
+
+        // TODO
+        Lens minus(Collection<Lens> minus, LensGroupName subLens) {
+            var keep = new ArrayList<>(showProperties);
+
+            for (var m : minus) {
+                keep.removeAll(m.showProperties);
+            }
+
+            return new Lens(keep, subLens);
+        }
+    }
+
+    public record DerivedLens(LensGroupName base, List<LensGroupName> minus, LensGroupName subLens) {
+
+    }
+
+    private static LensGroupName subLens(LensGroupName lensGroupName) {
+        return switch (lensGroupName) {
+            case Full -> LensGroupName.Card;
+            case Card -> LensGroupName.Chip;
+            case Chip, Token -> LensGroupName.Token;
+
+            case SearchCard -> LensGroupName.SearchChip;
+            case SearchChip -> LensGroupName.Token; // TODO ??
         };
     }
 
-    @SuppressWarnings("unchecked")
-    private List<Object> alternatives(Object alternateProperties) {
-        return (List<Object>) ((Map<String, Object>) alternateProperties).get(JsonLd.ALTERNATE_PROPERTIES);
+    private sealed interface PropertySelector permits PropertyKey, InverseProperty, AlternateProperties, RangeRestriction, Unrecognized {
+
     }
 
-    private record RangeRestriction(String subPropertyOf, String range) {}
+    private record AlternateProperties(List<PropertySelector> alternatives) implements PropertySelector {
+
+    }
+
+    private record Unrecognized() implements PropertySelector {
+
+    }
+
+    private record RangeRestriction(String subPropertyOf, String range) implements PropertySelector {}
 
     @SuppressWarnings("unchecked")
     private RangeRestriction asRangeRestriction(Object o) {
@@ -409,7 +626,7 @@ public class FresnelUtil {
             Set<String> codes = new HashSet<>();
             thing.entrySet().stream()
                     .filter(e -> e.getKey() instanceof String s
-                            && (new PropertyKey(s)).isLangAlias()
+                            && jsonLd.langContainerAliasInverted.containsKey(s)
                             && (new LanguageContainer(asMap(e.getValue()))).isTransliterated()
                     )
                     .forEach(e ->
@@ -422,23 +639,14 @@ public class FresnelUtil {
     }
 
     private boolean isStructuredValue(Map<?,?> thing) {
-        return jsonLd.isSubClassOf((String) thing.get(JsonLd.TYPE_KEY), Base.StructuredValue);
+        return jsonLd.isSubClassOf(firstType(thing), Base.StructuredValue);
     }
 
     private boolean isIdentity(Map<?,?> thing) {
-        return jsonLd.isSubClassOf((String) thing.get(JsonLd.TYPE_KEY), Base.Identity);
+        return jsonLd.isSubClassOf(firstType(thing), Base.Identity);
     }
 
-    private boolean isInverseProperty(Object showProperty) {
-        return showProperty instanceof Map && ((Map<?, ?>) showProperty).containsKey("inverseOf");
-    }
-
-    private record InverseProperty(String name, String inverseName) {}
-
-    private InverseProperty asInverseProperty(Object showProperty) {
-        String p = (String) ((Map<?, ?>) showProperty).get("inverseOf");
-        return new InverseProperty(p, jsonLd.getInverseProperty(p));
-    }
+    private record InverseProperty(String name, String inverseName) implements PropertySelector {}
 
     public record LangCode(String code) {
         public static final Comparator<LangCode> ORIGINAL_SCRIPT_FIRST = (a, b) -> {
@@ -458,6 +666,18 @@ public class FresnelUtil {
 
     private boolean isTypedNode(Object o) {
         return o instanceof Map && ((Map<?, ?>) o).containsKey(JsonLd.TYPE_KEY);
+    }
+
+    // TODO handle multiple types=
+    private String firstType(Map<?,?> thing) {
+        var types = thing.get(JsonLd.TYPE_KEY);
+        if (types instanceof String) {
+            return (String) types;
+        }
+        if (types instanceof List<?> l) {
+            return (String) l.getFirst();
+        }
+        throw new RuntimeException("Expected type/types, found " + types);
     }
 
     private class Formatter {
@@ -716,8 +936,6 @@ public class FresnelUtil {
     }
 
     record Style(List<String> styles) {
-
-        // TODO refactor? JsonLd is only needed for displayType()
         public void apply(Decorated result) {
             var s = new ArrayList<String>();
             for (String style : styles) {

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -185,7 +185,41 @@ class FresnelUtilSpec extends Specification {
                                                  "originDate"
                                          ]
                                      ],
-                             ]]
+                             ]],
+                    "cards":
+                            ["lenses": [
+                                    "Work": [
+                                            "@id": "Work-cards",
+                                            "@type": "fresnel:Lens",
+                                            "classLensDomain": "Work",
+                                            "showProperties": [
+                                                    ["alternateProperties": [
+                                                            ["subPropertyOf": "hasTitle", "range": "KeyTitle"],
+                                                            ["subPropertyOf": "hasTitle", "range": "Title"],
+                                                            "hasTitle"
+                                                    ]],
+                                                    "legalDate",
+                                                    "version",
+                                                    "marc:arrangedStatementForMusic",
+                                                    "originDate",
+                                                    "contribution",
+                                                    "language",
+                                                    "translationOf",
+                                                    "hasNotation",
+                                                    "hasVariant",
+                                                    "inCollection",
+                                                    "genreForm",
+                                                    "classification",
+                                                    "subject",
+                                                    "intendedAudience",
+                                                    "contentType",
+                                                    "dissertation",
+                                                    "cartographicAttributes",
+                                                    "isPartOf",
+                                                    ["inverseOf": "instanceOf"]
+                                            ]
+                                    ],
+                            ]]
                     ],
             "formatters" : [
                     'commaBeforeProperty-format': ['TODO': 'fullerFormOfName skrivs alltid med parenteser i libris nu, ska det vara så?', '@id': 'commaBeforeProperty-format', '@type': 'fresnel:Format', 'fresnel:propertyFormatDomain': ['lifeSpan', 'familyName', 'givenName', 'name', 'marc:numeration', 'lifeSpan', 'marc:titlesAndOtherWordsAssociatedWithAName', 'fullerFormOfName'], 'fresnel:propertyFormat': ['fresnel:contentBefore': ', ', 'fresnel:contentFirst': '']],
@@ -218,7 +252,7 @@ class FresnelUtilSpec extends Specification {
                 "note": ["NOTE 1", "NOTE 2"]
         ]
 
-        var lensed = fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip)
+        var lensed = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
         var result = fresnel.format(lensed, new FresnelUtil.LangCode('sv'))
 
         expect:
@@ -243,7 +277,7 @@ class FresnelUtilSpec extends Specification {
                 'marc:titlesAndOtherWordsAssociatedWithAName':['romersk kejsare']
         ]
 
-        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
 
         expect:
         result.asString() == "Heliogabalus, 203-222, romersk kejsare"
@@ -264,7 +298,7 @@ class FresnelUtilSpec extends Specification {
         ]
 
         var fresnel = new FresnelUtil(ld)
-        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
 
         expect:
         result.asString() == "Teater-biblioteket • N:o 15 • En friare i lifsfara : skämt med sång i en akt"
@@ -283,7 +317,7 @@ class FresnelUtilSpec extends Specification {
                         "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]
         ]
 
-        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
 
         expect:
         result.asString() == "Νεφέλαι : Λυσιστράτη ’Nephelai : Lysistratē’"
@@ -294,7 +328,7 @@ class FresnelUtilSpec extends Specification {
         var fresnel = new FresnelUtil(ld)
 
         expect:
-        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode(locale)).asString() == result
 
         where:
         thing                                                  | locale | result
@@ -308,7 +342,7 @@ class FresnelUtilSpec extends Specification {
         var fresnel = new FresnelUtil(ld)
 
         expect:
-        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode(locale)).asString() == result
 
         where:
         thing                                        | locale | result
@@ -327,7 +361,7 @@ class FresnelUtilSpec extends Specification {
         var fresnel = new FresnelUtil(ld)
 
         expect:
-        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode(locale)).asString() == result
+        fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode(locale)).asString() == result
 
         where:
         thing                                        | locale | result
@@ -349,7 +383,7 @@ class FresnelUtilSpec extends Specification {
         ]
 
         var fresnel = new FresnelUtil(ld)
-        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
 
         expect:
         result.asString() == "ISNI 0000 0001 0340 7488"
@@ -373,8 +407,40 @@ class FresnelUtilSpec extends Specification {
         ]
 
         var fresnel = new FresnelUtil(ld)
-        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensLevel.Chip), new FresnelUtil.LangCode('sv'))
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
         expect:
         result.asString() == "Titel • Svenska • Namnsson, Namn, 1972-"
+    }
+
+    def "derived lens"() {
+        given:
+        var thing = [
+                '@type': 'Work',
+                'hasTitle': [
+                        ['@type': 'Title', 'mainTitle': 'Titel'],
+                        ['@type': 'Variant', 'mainTitle': 'variant title']
+                ],
+                'language' : [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': [ 'en': 'Swedish', 'sv': 'Svenska' ]],
+                ],
+                'subject' : [
+                        ['@type': 'Topic', 'prefLabel': "Hästar"],
+                ],
+                'contribution' : [
+                        ['@type': 'Contribution', 'role': 'translator', 'agent': [ '@type': 'Person', 'name': 'Överzet' ]],
+                        ['@type': 'PrimaryContribution', 'role': 'author', 'agent': [ '@type': 'Person', 'givenName': 'Namn', 'familyName': 'Namnsson', 'lifeSpan': "1972-"]],
+                ]
+        ]
+
+        var fresnel = new FresnelUtil(ld)
+        var cardOnly = new FresnelUtil.DerivedLens(
+                FresnelUtil.LensGroupName.Card,
+                [FresnelUtil.LensGroupName.Chip],
+                FresnelUtil.LensGroupName.Token
+        )
+
+        var result = fresnel.applyLens(thing, cardOnly)
+        expect:
+        result.asString() == "Överzet Namnsson Namn 1972- Hästar"
     }
 }

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -418,7 +418,7 @@ class FresnelUtilSpec extends Specification {
                 '@type': 'Work',
                 'hasTitle': [
                         ['@type': 'Title', 'mainTitle': 'Titel'],
-                        ['@type': 'Variant', 'mainTitle': 'variant title']
+                        ['@type': 'VariantTitle', 'mainTitle': 'variant title']
                 ],
                 'language' : [
                         ['@type': 'Language', 'code': 'sv', 'labelByLang': [ 'en': 'Swedish', 'sv': 'Svenska' ]],
@@ -442,5 +442,32 @@ class FresnelUtilSpec extends Specification {
         var result = fresnel.applyLens(thing, cardOnly)
         expect:
         result.asString() == "Överzet Namnsson Namn 1972- Hästar"
+    }
+
+    def "take all alternate"() {
+        given:
+        var thing = [
+                '@type': 'Work',
+                'hasTitle': [
+                        ['@type': 'Title', 'mainTitle': 'Titel'],
+                        ['@type': 'VariantTitle', 'mainTitle': 'variant title']
+                ],
+                'language' : [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': [ 'en': 'Swedish', 'sv': 'Svenska' ]],
+                ],
+                'subject' : [
+                        ['@type': 'Topic', 'prefLabel': "Hästar"],
+                ],
+                'contribution' : [
+                        ['@type': 'Contribution', 'role': 'translator', 'agent': [ '@type': 'Person', 'name': 'Överzet' ]],
+                        ['@type': 'PrimaryContribution', 'role': 'author', 'agent': [ '@type': 'Person', 'givenName': 'Namn', 'familyName': 'Namnsson', 'lifeSpan': "1972-"]],
+                ]
+        ]
+        var fresnel = new FresnelUtil(ld)
+
+        var result = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Card, FresnelUtil.Options.TAKE_ALL_ALTERNATE)
+
+        expect:
+        result.asString() == "Titel Titel variant title Överzet translator Namnsson Namn 1972- author Svenska Swedish Hästar"
     }
 }


### PR DESCRIPTION
Add new fields to ES index for free text search.
This does not affect how searching works currently.

The long term plan is to replace searching every chip and card field with this. And to remove the `_all` field completely.

Each field contains a single string for every record. 
The string is just all values of the corresponding lens concatenated. 
The search-chip lens is applied to the values. (-> e.g. hasVariant for Person is included)
* `_chipStr` - chip
* `_cardStr` - card minus chips
* `_searchCardStr` - search-card minus card minus chip
* `_topChipStr` - the first property of chip (i.e. hasTitle for works). A bit obscure gives us what we want for now.

All fields have a corresponding `.exact` field.
All fields except `_topChipStr` have tweaked BM25 constants:
* `b 0` - ignore length -> more data in the record shouldn't be penalized 
* `k1 0.1` - saturate terms quickly. Repeated words should not contribute much to the score

For now, all properties from `alternateProperties` are included. 
This way we get for example `identifiedBy` (ISBN) in Instance chips with the current display definitions.
Same for all title variations.
We might replace this with a mechanism (fsl?) to pinpoint specific properties to be included instead.

Note that this does not cover everything we want to be able to search. Adjustments to lenses and possibly new lens groups or different handling of intergral properties will be needed. For example indirectlyIdentifiedBy on instances of works is not included. 

Example
https://beta.libris-qa.kb.se/s32jlnm3qldqd3h8#work-record
```
_topChipStr		Grisfesten
_chipStr		Grisfesten Grisfesten Svenska Swedish swe Persson Leif G. W.
_cardStr		Persson Leif G. W. Författare Author Skoog Helge Berättare Narrator Ljudböcker tal spoken word spoken word Grisfesten 9789176515099 9176515095
```

Use the `_boost` query parameter to experiment searching with the new fields and tweak boost values.
Example
`&_boost=_topChipStr^200,_topChipStr.exact^200,_chipStr^200,_chipStr.exact^200,_cardStr^50,_cardStr.exact^50,_searchCardStr^10,_searchCardStr.exact^10,no-default-field`

`no-default-field` in `_boost` disables searching `_all`.