### PR TITLE
fix(bulk): Load IDs from list only when necessary

### DIFF
--- a/housekeeping/src/main/groovy/whelk/housekeeping/BulkChangePreviewAPI.java
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/BulkChangePreviewAPI.java
@@ -93,8 +93,8 @@ public class BulkChangePreviewAPI extends HttpServlet {
             var result = makePreview(changes, offset, limit, id, preview.isFinished());
 
             var spec = preview.getSpec();
-            if (spec instanceof Specification.Update) {
-                result.put("changeSets", ((Specification.Update) spec).getTransform(whelk).getChangeSets());
+            if (spec instanceof Specification.Update update) {
+                result.put("changeSets", update.getTransform().getChangeSets());
             }
 
             // TODO support turtle etc?

--- a/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/form/Transform.groovy
@@ -33,8 +33,6 @@ class Transform {
         this.addedPaths = collectAddedPaths()
     }
 
-    // For testing only
-    @PackageScope
     Transform(Map matchForm, Map targetForm) {
         this(matchForm, targetForm, null)
     }

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/Specification.java
@@ -2,7 +2,7 @@ package whelk.datatool.bulkchange;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.io.IOUtils;
-import whelk.Whelk;
+
 import whelk.datatool.Script;
 import whelk.datatool.form.Transform;
 
@@ -35,8 +35,8 @@ public sealed interface Specification permits Specification.Create, Specificatio
             return s;
         }
 
-        public Transform getTransform(Whelk whelk) {
-            return new Transform(matchForm, targetForm, whelk);
+        public Transform getTransform() {
+            return new Transform(matchForm, targetForm);
         }
     }
 


### PR DESCRIPTION
When generating `changeSets` we are only interested in the diff between `matchForm` and `targetForm` and thus we don't need to bother with loading ID lists possibly contained in `matchForm`. Loading ID lists over and over for _every_ call to the bulk preview API is likely the reason for the heap space errors occurring lately.

The key fix is to not provide a `Whelk` instance here https://github.com/libris/librisxl/blob/e91e02ac236ae0b176262fc180139a22f4af3439/housekeeping/src/main/groovy/whelk/housekeeping/BulkChangePreviewAPI.java#L97 while the rest is to clarify a bit what's going on when loading IDs.

