### PR TITLE
Support custom field_value_factor function scoring via API

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -121,7 +121,8 @@ public class SearchUtils2 {
         }
         return Map.of("function_score",
                 Map.of("query", esQuery,
-                        "functions", fieldValueFactors.stream().map(EsBoost.FieldValueFactor::toEs).toList()));
+                        "functions", fieldValueFactors.stream().map(EsBoost.FieldValueFactor::toEs).toList(),
+                        "score_mode", "sum"));
     }
 
     private Map<String, Object> getPartialCollectionView(QueryResult queryResult,

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -398,4 +398,17 @@ public class EsBoost {
             "scopeNote^10",
             "keyword._str.exact^10"
     );
+
+    public record FieldValueFactor(String field, int factor, String modifier) {
+        public Map<String, Object> toEs() {
+            return Map.of("field_value_factor",
+                    Map.of("field", field,
+                            "factor", factor,
+                            "modifier", modifier));
+        }
+
+        public List<String> paramList() {
+            return List.of(field, Integer.toString(factor), modifier);
+        }
+    }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -180,9 +180,9 @@ public class QueryParams {
                     .map(s -> s.split(";"))
                     .map(fieldConfig -> {
                         String field = fieldConfig[0];
-                        int score = Integer.parseInt(fieldConfig[1]);
+                        int factor = Integer.parseInt(fieldConfig[1]);
                         String modifier = fieldConfig[2];
-                        return new EsBoost.FieldValueFactor(field, score, modifier);
+                        return new EsBoost.FieldValueFactor(field, factor, modifier);
                     })
                     .toList();
         } catch (Exception ignored) {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class QueryParams {
     private final static int DEFAULT_LIMIT = 200;
@@ -30,6 +31,7 @@ public class QueryParams {
         public static final String APP_CONFIG = "_appConfig";
         public static final String BOOST = "_boost";
         public static final String STATS = "_stats";
+        public static final String FN_SCORE = "_fnScore";
     }
 
     public static class Debug {
@@ -47,6 +49,7 @@ public class QueryParams {
     public final String lens;
     public final Spell spell;
     public final List<String> boostFields;
+    public final List<EsBoost.FieldValueFactor> fieldValueFactors;
 
     public final String q;
     public final String i;
@@ -67,6 +70,7 @@ public class QueryParams {
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
         this.skipStats = getOptionalSingle(ApiParams.STATS, apiParameters).map("false"::equalsIgnoreCase).isPresent();
+        this.fieldValueFactors = getEsFieldValueFactors(apiParameters);
     }
 
     public Map<String, String> getNonQueryParams() {
@@ -104,6 +108,13 @@ public class QueryParams {
         }
         if (skipStats) {
             params.put(ApiParams.STATS, "false");
+        }
+        if (!fieldValueFactors.isEmpty()) {
+            params.put(ApiParams.FN_SCORE,
+                    fieldValueFactors.stream()
+                            .map(f -> String.join(";", f.paramList()))
+                            .collect(Collectors.joining(","))
+            );
         }
         return params;
     }
@@ -160,6 +171,22 @@ public class QueryParams {
             return Integer.parseInt(s);
         } catch (NumberFormatException ignored) {
             return defaultTo;
+        }
+    }
+
+    private List<EsBoost.FieldValueFactor> getEsFieldValueFactors(Map<String, String[]> queryParameters) {
+        try {
+            return getMultiple(ApiParams.FN_SCORE, queryParameters).stream()
+                    .map(s -> s.split(";"))
+                    .map(fieldConfig -> {
+                        String field = fieldConfig[0];
+                        int score = Integer.parseInt(fieldConfig[1]);
+                        String modifier = fieldConfig[2];
+                        return new EsBoost.FieldValueFactor(field, score, modifier);
+                    })
+                    .toList();
+        } catch (Exception ignored) {
+            return List.of();
         }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
@@ -187,7 +187,7 @@ public class QueryResult {
             traverse(scoreExplanation, (value, path) -> {
                 if (value instanceof Map<?, ?> m) {
                     String description = (String) m.get("description");
-                    if (description.contains("[PerFieldSimilarity]")) {
+                    if (description.contains("[PerFieldSimilarity]") || description.startsWith("field value function:")) {
                         Double score = (Double) m.get("value");
                         if (score > 0) {
                             scorePerField.put(parseField(description), score);
@@ -223,6 +223,13 @@ public class QueryResult {
                     if (m.find()) {
                         return m.group();
                     }
+                }
+            } else if (description.startsWith("field value function:")) {
+                Matcher matcher = Pattern.compile("doc\\['[^ ]+']").matcher(description);
+                if (matcher.find()) {
+                    String match = matcher.group();
+                    String key = match.substring(match.indexOf("'") + 1);
+                    return key.substring(0, key.indexOf("'")) + ":N/A";
                 }
             }
             return description;


### PR DESCRIPTION
Example usage:
`_fnScore=reverseLinks.totalItemsByRelation.instanceOf;1000;log1p,reverseLinks.totalItemsByRelation.itemOf.instanceOf;1000;log1p`

![bild](https://github.com/user-attachments/assets/65946575-1707-4336-8cb0-2a47b767b437)
