### PR TITLE
experimental(search2): enable boosting on field value

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -80,7 +80,7 @@ public class SearchUtils2 {
     private Map<String, Object> getEsQueryDsl(QueryTree queryTree, QueryParams queryParams, AppParams.StatsRepr statsRepr) {
         var queryDsl = new LinkedHashMap<String, Object>();
 
-        queryDsl.put("query", getEsQuery(queryTree, queryParams.boostFields, queryParams.fieldValueFactors));
+        queryDsl.put("query", getEsQuery(queryTree, queryParams.boostFields, queryParams.esScoreFunctions));
         queryDsl.put("size", queryParams.limit);
         queryDsl.put("from", queryParams.offset);
         queryDsl.put("sort", (queryParams.sortBy == Sort.DEFAULT_BY_RELEVANCY && queryTree.isWild()
@@ -114,14 +114,14 @@ public class SearchUtils2 {
         return queryDsl;
     }
 
-    private Map<String, Object> getEsQuery(QueryTree queryTree, List<String> boostFields, List<EsBoost.FieldValueFactor> fieldValueFactors) {
+    private Map<String, Object> getEsQuery(QueryTree queryTree, List<String> boostFields, List<EsBoost.ScoreFunction> scoreFunctions) {
         Map<String, Object> esQuery = addConstantBoosts(queryTree.toEs(queryUtil, whelk.getJsonld(), boostFields));
-        if (fieldValueFactors.isEmpty()) {
+        if (scoreFunctions.isEmpty()) {
             return esQuery;
         }
         return Map.of("function_score",
                 Map.of("query", esQuery,
-                        "functions", fieldValueFactors.stream().map(EsBoost.FieldValueFactor::toEs).toList(),
+                        "functions", scoreFunctions.stream().map(EsBoost.ScoreFunction::toEs).toList(),
                         "score_mode", "sum",
                         "boost_mode", "sum"));
     }

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -404,7 +404,7 @@ public class EsBoost {
         List<String> paramList();
     }
 
-    public record FieldValueFactor(String field, int factor, String modifier, int missing, int weight) implements ScoreFunction {
+    public record FieldValueFactor(String field, float factor, String modifier, float missing, float weight) implements ScoreFunction {
         @Override
         public Map<String, Object> toEs() {
             return Map.of(
@@ -418,20 +418,20 @@ public class EsBoost {
 
         @Override
         public List<String> paramList() {
-            return List.of("fvf", field, Integer.toString(factor), modifier, Integer.toString(missing), Integer.toString(weight));
+            return List.of("fvf", field, Float.toString(factor), modifier, Float.toString(missing), Float.toString(weight));
         }
     }
 
-    public record MatchingFieldValue(String field, String value, int boost) implements ScoreFunction {
+    public record MatchingFieldValue(String field, String value, float boost) implements ScoreFunction {
         @Override
         public Map<String, Object> toEs() {
             return Map.of("script_score", Map.of(
-                            "script", String.format("doc['%s'].value == '%s' ? %d : 0", field, value, boost)));
+                            "script", String.format("doc['%s'].value == '%s' ? %f : 0", field, value, boost)));
         }
 
         @Override
         public List<String> paramList() {
-            return List.of("mfv", field, value, Integer.toString(boost));
+            return List.of("mfv", field, value, Float.toString(boost));
         }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -399,7 +399,13 @@ public class EsBoost {
             "keyword._str.exact^10"
     );
 
-    public record FieldValueFactor(String field, int factor, String modifier, int missing, int weight) {
+    public sealed interface ScoreFunction permits FieldValueFactor, MatchingFieldValue {
+        Map<String, Object> toEs();
+        List<String> paramList();
+    }
+
+    public record FieldValueFactor(String field, int factor, String modifier, int missing, int weight) implements ScoreFunction {
+        @Override
         public Map<String, Object> toEs() {
             return Map.of(
                     "field_value_factor", Map.of(
@@ -410,8 +416,22 @@ public class EsBoost {
                     "weight", weight);
         }
 
+        @Override
         public List<String> paramList() {
-            return List.of(field, Integer.toString(factor), modifier, Integer.toString(missing), Integer.toString(weight));
+            return List.of("fvf", field, Integer.toString(factor), modifier, Integer.toString(missing), Integer.toString(weight));
+        }
+    }
+
+    public record MatchingFieldValue(String field, String value, int boost) implements ScoreFunction {
+        @Override
+        public Map<String, Object> toEs() {
+            return Map.of("script_score", Map.of(
+                            "script", String.format("doc['%s'].value == '%s' ? %d : 0", field, value, boost)));
+        }
+
+        @Override
+        public List<String> paramList() {
+            return List.of("mfv", field, value, Integer.toString(boost));
         }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -2,11 +2,13 @@ package whelk.search2;
 
 import whelk.exception.InvalidQueryException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -49,7 +51,7 @@ public class QueryParams {
     public final String lens;
     public final Spell spell;
     public final List<String> boostFields;
-    public final List<EsBoost.FieldValueFactor> fieldValueFactors;
+    public final List<EsBoost.ScoreFunction> esScoreFunctions;
 
     public final String q;
     public final String i;
@@ -70,7 +72,7 @@ public class QueryParams {
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.i = getOptionalSingle(ApiParams.SIMPLE_FREETEXT, apiParameters).orElse("");
         this.skipStats = getOptionalSingle(ApiParams.STATS, apiParameters).map("false"::equalsIgnoreCase).isPresent();
-        this.fieldValueFactors = getEsFieldValueFactors(apiParameters);
+        this.esScoreFunctions = getEsScoreFunctions(apiParameters);
     }
 
     public Map<String, String> getNonQueryParams() {
@@ -109,9 +111,9 @@ public class QueryParams {
         if (skipStats) {
             params.put(ApiParams.STATS, "false");
         }
-        if (!fieldValueFactors.isEmpty()) {
+        if (!esScoreFunctions.isEmpty()) {
             params.put(ApiParams.FN_SCORE,
-                    fieldValueFactors.stream()
+                    esScoreFunctions.stream()
                             .map(f -> String.join(";", f.paramList()))
                             .collect(Collectors.joining(","))
             );
@@ -174,21 +176,30 @@ public class QueryParams {
         }
     }
 
-    private List<EsBoost.FieldValueFactor> getEsFieldValueFactors(Map<String, String[]> queryParameters) {
+    private List<EsBoost.ScoreFunction> getEsScoreFunctions(Map<String, String[]> queryParameters) {
+        List<EsBoost.ScoreFunction> scoreFunctions = new ArrayList<>();
         try {
-            return getMultiple(ApiParams.FN_SCORE, queryParameters).stream()
+            getMultiple(ApiParams.FN_SCORE, queryParameters).stream()
                     .map(s -> s.split(";"))
-                    .map(fieldConfig -> {
-                        String field = fieldConfig[0];
-                        int factor = Integer.parseInt(fieldConfig[1]);
-                        String modifier = fieldConfig[2];
-                        int missing = Integer.parseInt(fieldConfig[3]);
-                        int weight = Integer.parseInt(fieldConfig[4]);
-                        return new EsBoost.FieldValueFactor(field, factor, modifier, missing, weight);
-                    })
-                    .toList();
+                    .forEach(fieldConfig -> {
+                        String fnType = fieldConfig[0];
+                        if (fnType.equalsIgnoreCase("fvf")) {
+                            String field = fieldConfig[1];
+                            int factor = Integer.parseInt(fieldConfig[2]);
+                            String modifier = fieldConfig[3];
+                            int missing = Integer.parseInt(fieldConfig[4]);
+                            int weight = Integer.parseInt(fieldConfig[5]);
+                            scoreFunctions.add(new EsBoost.FieldValueFactor(field, factor, modifier, missing, weight));
+                        }
+                        if (fnType.equalsIgnoreCase("mfv")) {
+                            String field = fieldConfig[1];
+                            String value = fieldConfig[2];
+                            int boost = Integer.parseInt(fieldConfig[3]);
+                            scoreFunctions.add(new EsBoost.MatchingFieldValue(field, value, boost));
+                        }
+                    });
         } catch (Exception ignored) {
-            return List.of();
         }
+        return scoreFunctions;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -185,16 +185,16 @@ public class QueryParams {
                         String fnType = fieldConfig[0];
                         if (fnType.equalsIgnoreCase("fvf")) {
                             String field = fieldConfig[1];
-                            int factor = Integer.parseInt(fieldConfig[2]);
+                            float factor = Float.parseFloat(fieldConfig[2]);
                             String modifier = fieldConfig[3];
-                            int missing = Integer.parseInt(fieldConfig[4]);
-                            int weight = Integer.parseInt(fieldConfig[5]);
+                            float missing = Float.parseFloat(fieldConfig[4]);
+                            float weight = Float.parseFloat(fieldConfig[5]);
                             scoreFunctions.add(new EsBoost.FieldValueFactor(field, factor, modifier, missing, weight));
                         }
                         if (fnType.equalsIgnoreCase("mfv")) {
                             String field = fieldConfig[1];
                             String value = fieldConfig[2];
-                            int boost = Integer.parseInt(fieldConfig[3]);
+                            float boost = Float.parseFloat(fieldConfig[3]);
                             scoreFunctions.add(new EsBoost.MatchingFieldValue(field, value, boost));
                         }
                     });

--- a/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
@@ -221,6 +221,11 @@ public class QueryResult {
                                     .findFirst()
                                     .ifPresent(field -> scorePerField.put(field, score));
                         }
+                    } else if (description.startsWith("script score function")) {
+                        Double score = (Double) m.get("value");
+                        if (score > 0) {
+                            scorePerField.put(parseField(description), score);
+                        }
                     }
                 }
                 return new DocumentUtil.Nop();
@@ -253,7 +258,7 @@ public class QueryResult {
                         return m.group();
                     }
                 }
-            } else if (description.startsWith("field value function:")) {
+            } else if (description.startsWith("field value function:") || description.startsWith("script score function")) {
                 Matcher matcher = Pattern.compile("doc\\['[^ ]+']").matcher(description);
                 if (matcher.find()) {
                     String match = matcher.group();


### PR DESCRIPTION
Example usage:
`_fnBoost=mfv;language.@id;https://id.kb.se/language/swe;10` (Add 10 to the total score if language is Swedish).

There might be more effective ways to achieve the same thing (e.g. https://www.elastic.co/guide/en/app-search/current/boosts.html#boosts-value-boosts) should we decide that boosting on specific values is something we want. 

Note that function type now needs to be specified in `_fnBoost`. Use `mfv` for boosting on specific value (see above example) and `fvf` for field value factor, e.g. `fvf;reverseLinks.totalItems;10;ln1p;0;10`.
