### PR TITLE
feat(api): Add parameter _computedLabel=<langcode>

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/CrudGetRequest.groovy
@@ -16,6 +16,7 @@ class CrudGetRequest {
     private View view
     private Lens lens
     private String profile
+    private String computedLabelLocale
 
     static CrudGetRequest parse(HttpServletRequest request) {
         return new CrudGetRequest(request)
@@ -27,6 +28,8 @@ class CrudGetRequest {
         contentType = getBestContentType(getAcceptHeader(request), dataLeaf)
         lens = parseLens(request)
         profile = parseProfile(request)
+
+        computedLabelLocale = parseComputedLabelLocale(request).orElse(null)
     }
 
     HttpServletRequest getHttpServletRequest() {
@@ -67,6 +70,14 @@ class CrudGetRequest {
 
     boolean shouldApplyInverseOf() {
         return getBoolParameter("_applyInverseOf").orElse(false)
+    }
+
+    boolean shouldComputeLabels() {
+        return computedLabelLocale != null
+    }
+
+    String computedLabelLocale() {
+        return computedLabelLocale
     }
 
     View getView() {
@@ -129,6 +140,10 @@ class CrudGetRequest {
             return header
         }
         return null
+    }
+
+    static Optional<String> parseComputedLabelLocale(HttpServletRequest request) {
+        return Optional.ofNullable(request.getParameter("_computedLabel"))
     }
 
     private Optional<Boolean> getBoolParameter(String name) {

--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy
@@ -66,6 +66,7 @@ class SearchUtils {
         String addStats = getReservedQueryParameter('_stats', queryParameters)
         String suggest = getReservedQueryParameter('_suggest', queryParameters)
         String spell = getReservedQueryParameter('_spell', queryParameters)
+        String computedLabel = getReservedQueryParameter('_computedLabel', queryParameters)
 
         if (queryParameters['p'] && !object) {
             throw new InvalidQueryException("Parameter 'p' can only be used together with 'o'")
@@ -89,6 +90,8 @@ class SearchUtils {
                           '_stats' : addStats,
                           '_suggest' : suggest,
                           '_spell': spell,
+                          '_computedLabel': computedLabel,
+
         ]
 
         Map results = queryElasticSearch(
@@ -803,7 +806,7 @@ class SearchUtils {
      * Return a list of reserved query params
      */
     private List getReservedParameters() {
-        return ['q', 'p', 'o', 'value', '_limit', '_offset', '_suggest', '_spell']
+        return ['q', 'p', 'o', 'value', '_limit', '_offset', '_suggest', '_spell', '_computedLabel']
     }
 
     /*

--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -114,6 +114,10 @@ class JsonLd {
         public static final String IS_DEFINED_BY = "isDefinedBy";
     }
 
+    static final class Platform {
+        public static final String COMPUTED_LABEL = "computedLabel";
+    }
+
     public static final String ALTERNATE_PROPERTIES = 'alternateProperties'
 
     private static Logger log = LogManager.getLogger(JsonLd.class)

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -637,7 +637,10 @@ class Whelk {
     void normalize(Document doc) {
         try {
             doc.normalizeUnicode()
-            doc.trimStrings()
+
+            if (!doc.getThingIdentifiers().contains(vocabDisplayUri)) { // don't trim fmt contentBefore / contentAfter
+                doc.trimStrings()
+            }
 
             // TODO: just ensure that normalizers don't trip on these?
             if (doc.data.containsKey(JsonLd.CONTEXT_KEY)) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -2603,8 +2603,8 @@ class PostgreSQLComponent {
     }
 
     private void normalizeDocumentForStorage(Document doc, Connection connection) {
-        // Synthetic property, should never be stored
-        DocumentUtil.findKey(doc.data, JsonLd.REVERSE_KEY) { value, path ->
+        // Synthetic properties, should never be stored
+        DocumentUtil.findKey(doc.data, [JsonLd.REVERSE_KEY, JsonLd.Platform.COMPUTED_LABEL] ) { value, path ->
             new DocumentUtil.Remove()
         }
 

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -32,7 +32,7 @@ class ESQuery {
 
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
-            'q', 'o', '_limit', '_offset', '_sort', '_statsrepr', '_site_base_uri', '_debug', '_boost', '_lens', '_stats', '_suggest', '_site', '_spell'
+            'q', 'o', '_limit', '_offset', '_sort', '_statsrepr', '_site_base_uri', '_debug', '_boost', '_lens', '_stats', '_suggest', '_site', '_spell', '_computedLabel'
     ]
     public static final String AND_PREFIX = 'and-'
     public static final String AND_MATCHES_PREFIX = 'and-matches-'

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -158,6 +158,23 @@ public class FresnelUtil {
         };
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void insertComputedLabels(Object data, LangCode locale) {
+        DocumentUtil.traverse(data, (var value, var path) -> {
+            if (value instanceof Map node && node.containsKey(JsonLd.TYPE_KEY)) {
+                try {
+                    var label = format(applyLens(value, FresnelUtil.LensGroupName.Chip), locale).asString();
+                    node.put(JsonLd.Platform.COMPUTED_LABEL, label);
+                    // TODO Check if structured value and don't compute for sub-nodes?
+                } catch (Exception e) {
+                    logger.warn("Error computing label for {}: {}", data, e, e);
+                }
+            }
+
+            return DocumentUtil.NOP;
+        });
+    }
+
     private Object applyLens(
             Object value,
             LensGroupName lensGroupName,
@@ -546,6 +563,16 @@ public class FresnelUtil {
             }
         }
 
+        public List<String> pick(LangCode langCode) {
+            if (languages.containsKey(langCode)) {
+                return languages.get(langCode);
+            } else {
+                // TODO pick "best"
+                var randomLang = languages.keySet().stream().findFirst();
+                return randomLang.map(languages::get).orElse(Collections.emptyList());
+            }
+        }
+
         public boolean isTransliterated() {
             return languages.keySet().stream().anyMatch(LangCode::isTransliterated);
         }
@@ -800,7 +827,7 @@ public class FresnelUtil {
                 // can never be inside array
                 return lang.isTransliterated()
                         ? List.of(new DecoratedTransliterated(lang))
-                        : formatValues(pickLanguage(lang), className, propertyName);
+                        : formatValues(lang.pick(locale), className, propertyName);
             }
             else if (val instanceof List<?> list) {
                 return mapWithIndex(list,
@@ -854,12 +881,6 @@ public class FresnelUtil {
             };
             formats.valueDetails(className, propertyName).apply(result, isFirst, isLast);
             return result;
-        }
-
-        private List<String> pickLanguage(LanguageContainer value) {
-            // TODO
-            // TODO handle missing
-            return value.languages.get(this.locale);
         }
     }
 
@@ -1211,7 +1232,15 @@ public class FresnelUtil {
             var codes = scripts.keySet().stream().sorted(ORIGINAL_SCRIPT_FIRST).toList();
             before(s);
             if (!codes.isEmpty()) {
-                scripts.get(codes.getFirst()).printTo(s);
+                var originalScript = scripts.get(codes.getFirst()).printTo(new StringBuilder()).toString();
+                var isRtl = Unicode.guessScript(originalScript).map(Unicode::isRtl).orElse(false);
+                if (isRtl) {
+                    s.append(Unicode.RIGHT_TO_LEFT_ISOLATE);
+                }
+                s.append(originalScript);
+                if (isRtl) {
+                    s.append(Unicode.POP_DIRECTIONAL_ISOLATE);
+                }
             }
             if (codes.size() > 1) {
                 s.append(T_START);

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static whelk.util.FresnelUtil.LangCode.ORIGINAL_SCRIPT_FIRST;

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -8,6 +8,9 @@ import java.util.regex.Pattern
 class Unicode {
     public static final int MAX_LEVENSHTEIN_LENGTH = 100
 
+    public static final char RIGHT_TO_LEFT_ISOLATE = '\u2067' as char
+    public static final char POP_DIRECTIONAL_ISOLATE = '\u2069' as char
+
     /**
      * Additional characters we want to normalize that are not covered by NFC.
      *
@@ -55,6 +58,21 @@ class Unicode {
 
     private static final Pattern UNICODE_MARK = Pattern.compile('\\p{M}')
     private static final char PRIVATE_USE_AREA = '\uE000' as char
+
+    private static final EnumSet<Character.UnicodeScript> RTL_SCRIPTS = EnumSet.of(
+            Character.UnicodeScript.ADLAM,
+            Character.UnicodeScript.ARABIC,
+            Character.UnicodeScript.AVESTAN,
+            Character.UnicodeScript.HEBREW,
+            Character.UnicodeScript.MANDAIC,
+            Character.UnicodeScript.MENDE_KIKAKUI,
+            Character.UnicodeScript.NKO,
+            Character.UnicodeScript.OLD_NORTH_ARABIAN,
+            Character.UnicodeScript.OLD_SOUTH_ARABIAN,
+            Character.UnicodeScript.SAMARITAN,
+            Character.UnicodeScript.SYRIAC,
+            Character.UnicodeScript.THAANA,
+    )
     
     static boolean isNormalized(String s) {
         return Normalizer.isNormalized(s, Normalizer.Form.NFC) && !EXTRA_NORMALIZATION_MAP.keySet().any{ s.contains(it) }
@@ -106,6 +124,10 @@ class Unicode {
 
     static String stripSuffix(String s, String suffix) {
         s.endsWith(suffix) ? s.substring(0, s.length() - suffix.length()) : s
+    }
+
+    static boolean isRtl(Character.UnicodeScript script) {
+        return RTL_SCRIPTS.contains(script);
     }
 
     static Optional<Character.UnicodeScript> guessScript(String s) {

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -323,6 +323,22 @@ class FresnelUtilSpec extends Specification {
         result.asString() == "Νεφέλαι : Λυσιστράτη ’Nephelai : Lysistratē’"
     }
 
+    def "Handle RTL original script"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing = [
+                "@type"          : "Title",
+                "mainTitleByLang": [
+                        "ira"                : "تالشی زَوُن",
+                        "ira-Latn-t-ira-Arab": "talysj"],
+        ]
+
+        var result = fresnel.format(fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip), new FresnelUtil.LangCode('sv'))
+
+        expect:
+        result.asString() == "⁧تالشی زَوُن⁩ ’talysj’"
+    }
+
     def "showProperties rdf:type"() {
         given:
         var fresnel = new FresnelUtil(ld)

--- a/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
@@ -126,6 +126,20 @@ class UnicodeSpec extends Specification {
         Optional.of('Kana') | 'デスノート'
         Optional.of('Hira') | 'とんとんとんと'
     }
+
+    def "rtl"() {
+        expect:
+        Unicode.guessScript(string).map(Unicode::isRtl).orElse(false) == rtl
+        where:
+        string                          | rtl
+        ''                              | false
+        '  '                            | false
+        'Это дом'                       | false
+        'dom'                           | false
+        'վիրված'                        | false
+        'می خوانم و غرق در کویر می شوم' | true
+        'קונסט און קינסטלער'            | true
+    }
         
     def "u"() {
         given:


### PR DESCRIPTION
Add support for getting computed labels on things in API responses.
So that simpler clients don't have to handle all formatting details and varying data forms.

example
```
$ curl -s "http://libris.kb.se.localhost:5000/khw03jc347kgv4w/data.jsonld?framed=true&_computedLabel=sv" | gron | grep computedLabel

json.mainEntity.computedLabel = "Heliogabalus, 203-222, romersk kejsare";
json.mainEntity.hasVariant[0].computedLabel = "Elagabalus, 203-222, romersk kejsare";
json.mainEntity.hasVariant[1].computedLabel = "Marcus Aurelius Antoninus, 203-222, romersk kejsare";
json.mainEntity.hasVariant[2].computedLabel = "Bassianus, Varius Avitus, 203-222, romersk kejsare";
json.mainEntity.hasVariant[3].computedLabel = "Héliogabale, 203-222, romersk kejsare";
json.mainEntity.hasVariant[4].computedLabel = "Elagabale, 203-222, romersk kejsare";
json.mainEntity.hasVariant[5].computedLabel = "El Gabal, 203-222, romersk kejsare";
json.mainEntity.hasVariant[6].computedLabel = "Elagabalo, 203-222, romersk kejsare";
json.mainEntity.identifiedBy[0].computedLabel = "VIAF 24583475";
json.mainEntity.identifiedBy[1].computedLabel = "ISNI 0000 0001 0340 7488";
json.mainEntity.nationality[0].computedLabel = "Okänd nationalitet / Okänt verksamhetsland"


$ curl -s "http://libris.kb.se.localhost:5000/7rkvclvk4x1bn9x/data.jsonld?framed=true&_computedLabel=sv" | gron | grep computedLabel | grep subject....computedLabel
json.mainEntity.instanceOf.subject[0].computedLabel = "Miljöskador--Hallandsåsen--Bjärehalvön--Skåne";
json.mainEntity.instanceOf.subject[1].computedLabel = "Miljöskador--Hallandsåsen • sao";
json.mainEntity.instanceOf.subject[2].computedLabel = "Olyckor • albt";
json.mainEntity.instanceOf.subject[3].computedLabel = "Byggnadsarbete • albt";
json.mainEntity.instanceOf.subject[4].computedLabel = "Miljö • albt";
json.mainEntity.instanceOf.subject[5].computedLabel = "Sverige • albt";
json.mainEntity.instanceOf.subject[6].computedLabel = "Tunnlar • albt";
json.mainEntity.instanceOf.subject[7].computedLabel = "Hallandsåsen"
```

Depends on https://github.com/libris/definitions/pull/519

TODO?
- actual formatting rules will be tweaked
- only works for framed responses for now
- In /find responses, only `items` get labels for now