### PR TITLE
Add filter alias for My libraries

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils2.java
@@ -34,7 +34,7 @@ public class SearchUtils2 {
         }
 
         QueryParams queryParams = new QueryParams(queryParameters);
-        AppParams appParams = new AppParams(getAppConfig(queryParameters));
+        AppParams appParams = new AppParams(getAppConfig(queryParameters), queryParams);
 
         Query query = Query.init(queryParams, appParams, vocabMappings, esSettings, whelk);;
 

--- a/whelk-core/src/main/groovy/whelk/search2/AppParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/AppParams.java
@@ -200,7 +200,7 @@ public class AppParams {
 
     private Map<String, Filter.AliasedFilter> getFilterByAlias(Map<String, Object> appConfig, Map<String, String[]> aliasedParams) {
         Stream<Filter.AliasedFilter> queryDefined = aliasedParams.entrySet().stream()
-                .map(e -> new Filter.AliasedFilter(asqPrefix(e.getKey()), e.getValue()[0], new HashMap<>()));
+                .map(e -> new Filter.QueryDefinedFilter(asqPrefix(e.getKey()), e.getValue()[0], new HashMap<>()));
 
         Stream<Filter.AliasedFilter> predefined = getAsListOfMap(appConfig, "_filterAliases").stream()
                 .map(m -> new Filter.AliasedFilter(

--- a/whelk-core/src/main/groovy/whelk/search2/AppParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/AppParams.java
@@ -172,7 +172,7 @@ public class AppParams {
 
     private List<OptionalSiteFilter> getQueryDefinedSiteFilters(QueryParams queryParams, Map<String, Filter.AliasedFilter> filterByAlias) {
         return filterByAlias.entrySet().stream()
-                .filter(e -> e.getKey().startsWith(ALIAS))
+                .filter(e -> e.getKey().startsWith(asqPrefix(ALIAS)))
                 .filter(e -> queryParams.q.contains(asqPrefix(e.getKey())))
                 .map(e ->  new OptionalSiteFilter(e.getValue(), Query.SearchMode.asSet()))
                 .toList();
@@ -200,7 +200,7 @@ public class AppParams {
 
     private Map<String, Filter.AliasedFilter> getFilterByAlias(Map<String, Object> appConfig, Map<String, String[]> aliasedParams) {
         Stream<Filter.AliasedFilter> queryDefined = aliasedParams.entrySet().stream()
-                .map(e -> new Filter.AliasedFilter(e.getKey(), e.getValue()[0], new HashMap<>()));
+                .map(e -> new Filter.AliasedFilter(asqPrefix(e.getKey()), e.getValue()[0], new HashMap<>()));
 
         Stream<Filter.AliasedFilter> predefined = getAsListOfMap(appConfig, "_filterAliases").stream()
                 .map(m -> new Filter.AliasedFilter(

--- a/whelk-core/src/main/groovy/whelk/search2/Filter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Filter.java
@@ -76,4 +76,10 @@ public class Filter {
             return new InactiveFilter(this);
         }
     }
+
+    public static class QueryDefinedFilter extends AliasedFilter {
+        public QueryDefinedFilter(String alias, String raw, Map<String, Object> prefLabelByLang) {
+            super(alias, raw, prefLabelByLang);
+        }
+    }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/Filter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Filter.java
@@ -26,6 +26,10 @@ public class Filter {
         return parsed;
     }
 
+    public String getRaw() {
+        return raw;
+    }
+
     public void parse(Disambiguate disambiguate) throws InvalidQueryException {
         if (parsed == null) {
             this.parsed = QueryTreeBuilder.buildTree(raw, disambiguate);
@@ -53,7 +57,10 @@ public class Filter {
 
         public Map<String, Object> description() {
             return Map.of(TYPE_KEY, RESOURCE,
-                    "prefLabelByLang", prefLabelByLang);
+                    "prefLabelByLang", prefLabelByLang,
+                    "alias", alias,
+                    "raw", this.getRaw()
+            );
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -30,6 +30,7 @@ public class QueryParams {
         public static final String APP_CONFIG = "_appConfig";
         public static final String BOOST = "_boost";
         public static final String STATS = "_stats";
+        public static final String MY_LIBRARIES = "_myLibraries";
         public static final String FN_SCORE = "_fnScore";
     }
 
@@ -49,6 +50,7 @@ public class QueryParams {
     public final Spell spell;
     public final List<String> boostFields;
     public final List<EsBoost.ScoreFunction> esScoreFunctions;
+    public final String myLibraries;
 
     public final String q;
 
@@ -70,6 +72,7 @@ public class QueryParams {
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.skipStats = getOptionalSingle(ApiParams.STATS, apiParameters).map("false"::equalsIgnoreCase).isPresent();
         this.esScoreFunctions = getEsScoreFunctions(apiParameters);
+        this.myLibraries = getOptionalSingle(ApiParams.MY_LIBRARIES, apiParameters).orElse("");
     }
 
     public Map<String, String> getNonQueryParamsNoOffset() {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryParams.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class QueryParams {
     private final static int DEFAULT_LIMIT = 200;
@@ -30,7 +31,7 @@ public class QueryParams {
         public static final String APP_CONFIG = "_appConfig";
         public static final String BOOST = "_boost";
         public static final String STATS = "_stats";
-        public static final String MY_LIBRARIES = "_myLibraries";
+        public static final String ALIAS = "_alias-";
         public static final String FN_SCORE = "_fnScore";
     }
 
@@ -50,7 +51,7 @@ public class QueryParams {
     public final Spell spell;
     public final List<String> boostFields;
     public final List<EsBoost.ScoreFunction> esScoreFunctions;
-    public final String myLibraries;
+    public final Map<String, String[]> aliased;
 
     public final String q;
 
@@ -72,7 +73,7 @@ public class QueryParams {
         this.q = getOptionalSingle(ApiParams.QUERY, apiParameters).orElse("");
         this.skipStats = getOptionalSingle(ApiParams.STATS, apiParameters).map("false"::equalsIgnoreCase).isPresent();
         this.esScoreFunctions = getEsScoreFunctions(apiParameters);
-        this.myLibraries = getOptionalSingle(ApiParams.MY_LIBRARIES, apiParameters).orElse("");
+        this.aliased = getAliased(apiParameters);
     }
 
     public Map<String, String> getNonQueryParamsNoOffset() {
@@ -146,6 +147,12 @@ public class QueryParams {
                 .stream()
                 .flatMap((s -> Arrays.stream(s.split(",")).map(String::trim)))
                 .toList();
+    }
+
+    private static Map<String, String[]> getAliased(Map<String, String[]> queryParameters) {
+        return queryParameters.entrySet().stream()
+                .filter((entry) -> entry.getKey().startsWith(ApiParams.ALIAS))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private int getLimit(Map<String, String[]> queryParameters) throws InvalidQueryException {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
@@ -21,7 +21,8 @@ public record ActiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
     public Map<String, Object> toSearchMapping(QueryTree qt, QueryParams queryParams) {
         var m = new LinkedHashMap<String, Object>();
-        m.put("object", description());
+        var description = description().put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
+        m.put("object", description);
         m.put("value", alias());
         m.put("up", makeUpLink(qt, this, queryParams));
         return m;

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
@@ -21,8 +21,9 @@ public record ActiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
     public Map<String, Object> toSearchMapping(QueryTree qt, QueryParams queryParams) {
         var m = new LinkedHashMap<String, Object>();
-//        var description = description().put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
-        m.put("object", description());
+        LinkedHashMap<String, Object> description = new LinkedHashMap<>(description());
+        description.put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
+        m.put("object", description);
         m.put("value", alias());
         m.put("up", makeUpLink(qt, this, queryParams));
         return m;

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
@@ -21,8 +21,8 @@ public record ActiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
     public Map<String, Object> toSearchMapping(QueryTree qt, QueryParams queryParams) {
         var m = new LinkedHashMap<String, Object>();
-        var description = description().put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
-        m.put("object", description);
+//        var description = description().put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
+        m.put("object", description());
         m.put("value", alias());
         m.put("up", makeUpLink(qt, this, queryParams));
         return m;

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
@@ -5,9 +5,12 @@ import whelk.search2.Filter;
 import whelk.search2.QueryParams;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+
+import static whelk.search2.QueryUtil.makeUpLink;
 
 public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
@@ -17,7 +20,14 @@ public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node
 
     @Override
     public Map<String, Object> toSearchMapping(QueryTree qt, QueryParams queryParams) {
-        throw new UnsupportedOperationException("Query tree must not contain inactive filters");
+        var m = new LinkedHashMap<String, Object>();
+        LinkedHashMap<String, Object> description = new LinkedHashMap<>(description());
+        description.put("parsedFilter", aliasedFilter.getParsed().toSearchMapping(qt, queryParams));
+        m.put("object", description);
+        m.put("value", alias());
+        m.put("up", makeUpLink(qt, this, queryParams));
+        //TODO: mustNotWrap???
+        return m;
     }
 
     @Override
@@ -46,5 +56,9 @@ public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node
 
     private String alias() {
         return aliasedFilter.alias();
+    }
+
+    public Map<String, Object> description() {
+        return aliasedFilter.description();
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
@@ -26,8 +26,7 @@ public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node
         m.put("object", description);
         m.put("value", alias());
         m.put("up", makeUpLink(qt, this, queryParams));
-        //TODO: mustNotWrap???
-        return m;
+        return Map.of("not", m);
     }
 
     @Override

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -63,40 +63,86 @@ class QueryTreeSpec extends Specification {
         def tree = QueryTreeBuilder.buildTree('something (NOT p3:v3 OR p4:"v:4") includeA', disambiguate)
 
         expect:
-        new QueryTree(tree).toSearchMapping(new QueryParams([:])) == [
-                'and': [
-                        [
-                                'property': ['@id': 'textQuery', '@type': 'DatatypeProperty'],
-                                'equals'  : 'something',
-                                'up'      : ['@id': '/find?_limit=200&_q=%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA']
-                        ],
-                        [
-                                'or': [
-                                        [
-                                                'property' : ['@id': 'p3', '@type': 'ObjectProperty'],
-                                                'notEquals': 'v3',
-                                                'up'       : ['@id': '/find?_limit=200&_q=something+p4:%22v:4%22+includeA'],
-                                                '_key'     : 'p3',
-                                                '_value'   : 'v3'
+        new QueryTree(tree).toSearchMapping(new QueryParams([:])) ==
+                [
+                        "and": [[
+                                        "property": [
+                                                "@id"  : "textQuery",
+                                                "@type": "DatatypeProperty"
                                         ],
-                                        [
-                                                'property': ['@id': 'p4', '@type': 'ObjectProperty'],
-                                                'equals'  : 'v:4',
-                                                'up'      : ['@id': '/find?_limit=200&_q=something+NOT+p3:v3+includeA'],
-                                                '_key'    : 'p4',
-                                                '_value'  : 'v:4'
+                                        "equals"  : "something",
+                                        "up"      : [
+                                                "@id": "/find?_limit=200&_q=%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
                                         ]
-                                ],
-                                'up': ['@id': '/find?_limit=200&_q=something+includeA']
-                        ],
-                        [
-                                'object': ['prefLabelByLang': [:], '@type': 'Resource'],
-                                'value' : 'includeA',
-                                'up'    : ['@id': '/find?_limit=200&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29']
+                                ], [
+                                        "or": [[
+                                                       "property" : [
+                                                               "@id"  : "p3",
+                                                               "@type": "ObjectProperty"
+                                                       ],
+                                                       "notEquals": "v3",
+                                                       "up"       : [
+                                                               "@id": "/find?_limit=200&_q=something+p4:%22v:4%22+includeA"
+                                                       ],
+                                                       "_key"     : "p3",
+                                                       "_value"   : "v3"
+                                               ], [
+                                                       "property": [
+                                                               "@id"  : "p4",
+                                                               "@type": "ObjectProperty"
+                                                       ],
+                                                       "equals"  : "v:4",
+                                                       "up"      : [
+                                                               "@id": "/find?_limit=200&_q=something+NOT+p3:v3+includeA"
+                                                       ],
+                                                       "_key"    : "p4",
+                                                       "_value"  : "v:4"
+                                               ]],
+                                        "up": [
+                                                "@id": "/find?_limit=200&_q=something+includeA"
+                                        ]
+                                ], [
+                                        "object": [
+                                                "prefLabelByLang": [:],
+                                                "alias"          : "includeA",
+                                                "raw"            : "NOT excludeA",
+                                                "@type"          : "Resource",
+                                                "parsedFilter"   : [
+                                                        "not": [
+                                                                "object": [
+                                                                        "prefLabelByLang": [:],
+                                                                        "alias"          : "excludeA",
+                                                                        "raw"            : "NOT p1:A",
+                                                                        "@type"          : "Resource",
+                                                                        "parsedFilter"   : [
+                                                                                "property" : [
+                                                                                        "@id"  : "p1",
+                                                                                        "@type": "DatatypeProperty"
+                                                                                ],
+                                                                                "notEquals": "A",
+                                                                                "up"       : [
+                                                                                        "@id": "/find?_limit=200&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
+                                                                                ],
+                                                                                "_key"     : "p1",
+                                                                                "_value"   : "A"
+                                                                        ]
+                                                                ],
+                                                                "value" : "excludeA",
+                                                                "up"    : [
+                                                                        "@id": "/find?_limit=200&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
+                                                                ]
+                                                        ]
+                                                ]
+                                        ],
+                                        "value" : "includeA",
+                                        "up"    : [
+                                                "@id": "/find?_limit=200&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29"
+                                        ]
+                                ]],
+                        "up" : [
+                                "@id": "/find?_limit=200&_q=*"
                         ]
-                ],
-                'up' : ['@id': '/find?_limit=200&_q=*']
-        ]
+                ]
     }
 
     def "normalize free text on instantiation"() {


### PR DESCRIPTION
~* Add `myLibraries` filter alias. Works like other aliases such as `includeEplikt`, but the definition of the alias is parsed from the request query parameters.~

~* Include more data in stats so that frontend can exclude this filter from the "Other" filters below the facets (among other things).~

~Depends on https://github.com/libris/definitions/tree/feature/filter-definitions.~

* Support generic query defined aliased filters. 
* Expects a `alias-`-prefixed part of `q` (e.g.` alias-myLibraries`) and a corresponding query parameter passed from the frontend (`_alias-myLibraries` in this case)
* This is independent of definitions, hence `prefLabelByLang` must by supplied in `i18n` in the frontend.
* `search.mapping` contains a parsed version of the filter:

![Screenshot from 2025-04-15 15-00-03](https://github.com/user-attachments/assets/dc94c73a-8884-4860-9ff6-7a9527d159cb)
