### PR TITLE
Feature/lxl 4134

### DIFF
--- a/housekeeping/src/main/groovy/whelk/housekeeping/WebInterface.groovy
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/WebInterface.groovy
@@ -43,7 +43,7 @@ public class WebInterface extends HttpServlet {
     public void init() {
         Whelk whelk = WhelkFactory.getSingletonWhelk()
 
-        Indexing.start(whelk.getStorage(), whelk.elastic)
+        Indexing.start(whelk)
 
         List<HouseKeeper> houseKeepers = [
                 // Automatic generation is disabled for now, may need design changes approved before activation.

--- a/housekeeping/src/main/groovy/whelk/housekeeping/WebInterface.groovy
+++ b/housekeeping/src/main/groovy/whelk/housekeeping/WebInterface.groovy
@@ -1,5 +1,6 @@
 package whelk.housekeeping
 
+import whelk.Indexing
 import whelk.Whelk
 import whelk.util.WhelkFactory;
 
@@ -40,7 +41,9 @@ public class WebInterface extends HttpServlet {
     Scheduler cronScheduler = new Scheduler()
 
     public void init() {
-        Whelk whelk = WhelkFactory.getSingletonWhelk();
+        Whelk whelk = WhelkFactory.getSingletonWhelk()
+
+        Indexing.start(whelk.getStorage(), whelk.elastic)
 
         List<HouseKeeper> houseKeepers = [
                 // Automatic generation is disabled for now, may need design changes approved before activation.

--- a/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
+++ b/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
@@ -2,6 +2,7 @@ package whelk.reindexer
 
 import groovy.util.logging.Log4j2 as Log
 import whelk.Document
+import whelk.Indexing
 import whelk.Whelk
 import whelk.util.BlockingThreadPool
 
@@ -102,6 +103,8 @@ class ElasticReindexer {
         } finally {
             threadPool.awaitAllAndShutdown()
         }
+        if (suppliedCollection == null) // If a "full" reindex.
+            Indexing.resetStateToNow(whelk.storage)
     }
 
     private void bulkIndexWithRetries(List<Document> docs, Whelk whelk) {

--- a/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
+++ b/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
@@ -121,7 +121,7 @@ class ElasticReindexer {
 
     private Exception tryBulkIndex(List<Document> docs, Whelk whelk) {
         try {
-            whelk.elastic.bulkIndex(docs, whelk)
+            whelk.elastic.bulkIndex(docs, whelk, true)
             return null
         }
         catch (Exception e) {

--- a/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
+++ b/importers/src/main/groovy/whelk/reindexer/ElasticReindexer.groovy
@@ -124,7 +124,7 @@ class ElasticReindexer {
 
     private Exception tryBulkIndex(List<Document> docs, Whelk whelk) {
         try {
-            whelk.elastic.bulkIndex(docs, whelk, true)
+            whelk.elastic.bulkIndex(docs, whelk)
             return null
         }
         catch (Exception e) {

--- a/librisxl-tools/postgresql/migrations/00000024-add-change-log.plsql
+++ b/librisxl-tools/postgresql/migrations/00000024-add-change-log.plsql
@@ -1,0 +1,42 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+   
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 23;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 24;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+
+   CREATE TABLE IF NOT EXISTS lddb__change_log (
+    changenumber BIGSERIAL PRIMARY KEY,
+    id text NOT NULL,
+    loud BOOLEAN NOT NULL,
+    time timestamp with time zone DEFAULT now() NOT NULL,
+    resulting_record_version INTEGER NOT NULL
+   );
+
+   CREATE INDEX IF NOT EXISTS idx_lddb__change_log_time ON lddb__change_log (time);	
+
+END$$;
+
+COMMIT;
+
+
+
+

--- a/librisxl-tools/postgresql/migrations/00000024-add-change-log.plsql
+++ b/librisxl-tools/postgresql/migrations/00000024-add-change-log.plsql
@@ -27,6 +27,7 @@ BEGIN
     changenumber BIGSERIAL PRIMARY KEY,
     id text NOT NULL,
     loud BOOLEAN NOT NULL,
+    skipindexdependers BOOLEAN NOT NULL,
     time timestamp with time zone DEFAULT now() NOT NULL,
     resulting_record_version INTEGER NOT NULL
    );

--- a/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
+++ b/rest/src/main/groovy/whelk/rest/api/RefreshAPI.groovy
@@ -108,6 +108,5 @@ class RefreshAPI extends HttpServlet
 
     void refreshQuietly(Document doc) {
         whelk.storage.refreshDerivativeTables(doc)
-        whelk.elastic.index(doc, whelk)
     }
 }

--- a/whelk-core/src/main/groovy/whelk/Indexing.java
+++ b/whelk-core/src/main/groovy/whelk/Indexing.java
@@ -144,7 +144,7 @@ public class Indexing {
     private static void bulkIndex(Iterable<String> ids, Whelk whelk) {
         for (List a : Iterables.partition(ids, 100)) {
             Collection<Document> docs = whelk.bulkLoad(a).values();
-            whelk.elastic.bulkIndex(docs, whelk, false);
+            whelk.elastic.bulkIndex(docs, whelk);
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/Indexing.java
+++ b/whelk-core/src/main/groovy/whelk/Indexing.java
@@ -1,0 +1,122 @@
+package whelk;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import whelk.component.ElasticSearch;
+import whelk.component.PostgreSQLComponent;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Map;
+
+public class Indexing {
+
+    // There is to be only one of these. Using more than one thread for indexing potentially breaks made assumptions
+    // with regard to indexing-order of records, _which matters_.
+    static Thread worker;
+    private final static String INDEXER_STATE_KEY = "ElasticIndexer";
+    private final static Logger logger = LogManager.getLogger(Indexing.class);
+
+    /**
+     * Index all changes since last invocation of this function
+     */
+    private static void iterate(PostgreSQLComponent psql, ElasticSearch elastic) throws SQLException {
+        Map storedIndexerState = psql.getState(INDEXER_STATE_KEY);
+        if (storedIndexerState == null){
+            resetStateToNow(psql);
+            storedIndexerState = psql.getState(INDEXER_STATE_KEY);
+        }
+        long lastIndexedChangeNumber = (Long) storedIndexerState.get("lastIndexed");
+
+        String sql = "SELECT * FROM lddb__change_log WHERE changenumber > ? ORDER BY changenumber ASC LIMIT 500";
+        try (Connection connection = psql.getOuterConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            connection.setAutoCommit(false);
+            statement.setFetchSize(500);
+
+            statement.setLong(1, lastIndexedChangeNumber);
+            ResultSet resultSet = statement.executeQuery();
+            Long changeNumber = 0L;
+            while (resultSet.next()) {
+                changeNumber = resultSet.getLong("changenumber");
+                String id = resultSet.getString("id");
+                Instant modificationInstant = resultSet.getTimestamp("time").toInstant();
+                int resultingVersion = resultSet.getInt("resulting_record_version");
+
+                System.err.println("Now want to reindex: " + id + " ch-nr: " + changeNumber + " recordv: " + resultingVersion);
+            }
+
+            if (changeNumber > lastIndexedChangeNumber) {
+                psql.putState(INDEXER_STATE_KEY, Map.of("lastIndexed", changeNumber));
+            }
+        }
+
+    }
+
+    /**
+     * This resets the state of the Indexing code to "now", as in:
+     * "forget whatever you thought you had left to, you are just indexing new changes from *now* and forward."
+     *
+     * This should be called whenever a full reindexing has been done.
+     */
+    public synchronized static void resetStateToNow(PostgreSQLComponent psql) throws SQLException {
+        String sql = """
+        INSERT INTO lddb__state (key, value)
+        SELECT 'ElasticIndexer', jsonb_build_object( 'lastIndexed', MAX(changenumber) ) FROM lddb__change_log
+        ON CONFLICT (key)
+        DO UPDATE SET value = EXCLUDED.value;
+        """.stripIndent();
+
+        try (Connection connection = psql.getOuterConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        }
+    }
+
+    /**
+     * Run in background, and index data continually as it changes
+     */
+    public synchronized static void start(PostgreSQLComponent psql, ElasticSearch elastic) {
+        if (worker != null)
+            return;
+
+        worker = Thread.ofPlatform().name("Whelk elastic indexing").unstarted( new IndexingRunnable(psql, elastic) );
+        worker.start();
+    }
+
+    // The necessary machinery for invoking iterate() at a suitable cadence
+    private static class IndexingRunnable implements Runnable {
+        private PostgreSQLComponent psql;
+        ElasticSearch elastic;
+
+        public IndexingRunnable(PostgreSQLComponent psql, ElasticSearch elastic) {
+            this.psql = psql;
+            this.elastic = elastic;
+        }
+
+        public void run() {
+            while (true) {
+
+                try {
+                    iterate(psql, elastic);
+
+                    // Don't run hot, wait a little before the next pass.
+                    try {
+                        Thread.sleep(100); // 0.1 seconds
+                    } catch (InterruptedException ie) { /* ignore */ }
+                } catch (Exception e) {
+                    // Catch all, and wait a little before retrying. This thread should never be allowed to crash completely.
+                    logger.error("Unexpected exception while indexing.", e);
+                    try {
+                        Thread.sleep(120 * 1000); // 2 minutes
+                    } catch (InterruptedException ie) { /* ignore */ }
+                }
+
+            }
+        }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/Indexing.java
+++ b/whelk-core/src/main/groovy/whelk/Indexing.java
@@ -239,6 +239,8 @@ public class Indexing {
         if (storedIndexerState != null && storedIndexerState.get("lastIndexed") == null) {
             psql.putState(INDEXER_STATE_KEY, Map.of("lastIndexed", "0"));
         }
+
+        logger.info("Elastic indexer state was reset (and is now considered \"caught up\").");
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -395,7 +395,6 @@ class Whelk {
             return false
         }
 
-        //reindexUpdated(updated, preUpdateDoc)
         sparqlUpdater?.pollNow()
 
         return true
@@ -410,7 +409,6 @@ class Whelk {
             return
         }
 
-        //reindexUpdated(updated, preUpdateDoc)
         sparqlUpdater?.pollNow()
     }
 


### PR DESCRIPTION
This changes Elastic indexing to occur strictly in order with postgres writes.

Every change is logged (in a table) with a sequence number (assigned within the postgres transaction), and indexing occurs by reading that log in the same order. There is still a tolerance for bad data, in the sense that any 400-response from Elastic will be error-logged but ignored. Other types of errors however (be they timeouts, broken connections, or whatever else) are NOT TOLERATED, and will be retried, in order (forever).

A big change for developers in this, is that the housekeeping module must now be running for any indexing to occur at all. It is however perfectly fine to start it up late (it will catch up on its own).
