### PR TITLE
Feature/property search scoring

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -25,6 +25,9 @@ public class EsBoost {
             "_searchCardStr.exact^1"
     );
 
+    // TODO: Better name
+    public static int WITHIN_FIELD_BOOST = 400;
+
     public static List<ScoreFunction> SCORE_FUNCTIONS = List.of(
             new FieldValueFactor("reverseLinks.totalItemsByRelation.instanceOf", 10, "ln1p", 0, 15),
             new FieldValueFactor("reverseLinks.totalItemsByRelation.itemOf.instanceOf", 10, "ln1p", 0, 10)

--- a/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
@@ -87,7 +87,7 @@ public class ObjectQuery extends Query {
                 curatedPredicates,
                 whelk.getJsonld(),
                 rulingTypes,
-                this::getNestedPath);
+                esSettings.mappings);
     }
 
     private List<String> inferSubjectTypes() {

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -38,8 +38,8 @@ public class Query {
     protected final QueryParams queryParams;
     protected final AppParams appParams;
     protected final QueryTree queryTree;
+    protected final ESSettings esSettings;
 
-    private final ESSettings esSettings;
     private final Disambiguate disambiguate;
     private final Stats stats;
     private final LinkLoader linkLoader;
@@ -107,7 +107,7 @@ public class Query {
     }
 
     protected Map<String, Object> getEsQuery(QueryTree queryTree, Collection<String> rulingTypes) {
-        var esQuery = queryTree.toEs(whelk.getJsonld(), this::getNestedPath, queryParams.boostFields, rulingTypes);
+        var esQuery = queryTree.toEs(whelk.getJsonld(), esSettings.mappings, queryParams.boostFields, rulingTypes);
         return addBoosts(esQuery, queryParams.esScoreFunctions);
     }
 
@@ -115,7 +115,7 @@ public class Query {
         return Aggs.buildAggQuery(appParams.statsRepr.sliceList(),
                 whelk.getJsonld(),
                 rulingTypes,
-                this::getNestedPath);
+                esSettings.mappings);
     }
 
     protected Map<String, Object> getEsQueryDsl(Map<String, Object> query, Map<String, Object> aggs) {
@@ -153,13 +153,6 @@ public class Query {
         }
 
         return queryDsl;
-    }
-
-    protected Optional<String> getNestedPath(String path) {
-        if (esSettings.mappings.isNestedField(path)) {
-            return Optional.of(path);
-        }
-        return esSettings.mappings.getNestedFields().stream().filter(path::startsWith).findFirst();
     }
 
     private Map<String, Object> getPartialCollectionView() {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
@@ -1,20 +1,19 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsMappings;
 import whelk.search2.Filter;
 import whelk.search2.QueryParams;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 
 import static whelk.search2.QueryUtil.makeUpLink;
 
 public record ActiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
-    public Map<String, Object> toEs(Function<String, Optional<String>> getNestedPath, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
         throw new UnsupportedOperationException("Expand filter before converting to ES");
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -2,6 +2,7 @@ package whelk.search2.querytree;
 
 import whelk.JsonLd;
 import whelk.search.ESQuery;
+import whelk.search2.EsMappings;
 import whelk.search2.Operator;
 import whelk.search2.QueryParams;
 import whelk.util.Unicode;
@@ -12,8 +13,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 
 import static whelk.search2.QueryUtil.makeUpLink;
 import static whelk.search2.QueryUtil.mustNotWrap;
@@ -26,7 +25,7 @@ public record FreeText(Property.TextQuery textQuery, Operator operator, String v
     }
 
     @Override
-    public Map<String, Object> toEs(Function<String, Optional<String>> getNestedPath, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
         String s = value;
         s = Unicode.normalizeForSearch(s);
         boolean isSimple = ESQuery.isSimple(s);

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -140,10 +140,11 @@ public sealed abstract class Group implements Node permits And, Or {
                     .forEach((k, v) -> {
                         boolean isGroup = v.size() > 1;
                         boolean isNegatedGroup = k && isGroup;
-                        var es = v.stream().map(pv -> pv.toEs(isNegatedGroup)).toList();
                         if (isNegatedGroup) {
+                            var es = v.stream().map(pv -> pv.replaceOperator(Operator.EQUALS).getCoreEsQuery(esMappings)).toList();
                             bool.put("must_not", nestedWrap(nestedStem, wrap(es)));
                         } else {
+                            var es = v.stream().map(pv -> pv.getCoreEsQuery(esMappings)).toList();
                             bool.put("must", nestedWrap(nestedStem, isGroup ? wrap(es) : es.getFirst()));
                         }
                     });

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
@@ -1,17 +1,16 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsMappings;
 import whelk.search2.Filter;
 import whelk.search2.QueryParams;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 
 public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
-    public Map<String, Object> toEs(Function<String, Optional<String>> getNestedPath, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
         throw new UnsupportedOperationException("Query tree must not contain inactive filters");
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -1,17 +1,16 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsMappings;
 import whelk.search2.QueryParams;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 
 public sealed interface Node permits ActiveFilter, FreeText, Group, InactiveFilter, PathValue {
-    Map<String, Object> toEs(Function<String, Optional<String>> getNestedPath, Collection<String> boostFields);
+    Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields);
 
     Node expand(JsonLd jsonLd, Collection<String> rulingTypes);
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -1,6 +1,7 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsMappings;
 
 import java.util.Collection;
 import java.util.List;
@@ -72,7 +73,7 @@ public class Path {
                 .collect(Collectors.joining("."));
     }
 
-    public String fullSearchPath() {
+    public String fullEsSearchPath() {
         return path.stream()
                 .map(Subpath::toString)
                 .map(Path::substitute)
@@ -111,6 +112,14 @@ public class Path {
     @Override
     public int hashCode() {
         return Objects.hash(path);
+    }
+
+    public Optional<String> getEsNestedStem(EsMappings esMappings) {
+        String esPath = fullEsSearchPath();
+        if (esMappings.isNestedField(esPath)) {
+            return Optional.of(esPath);
+        }
+        return esMappings.getNestedFields().stream().filter(esPath::startsWith).findFirst();
     }
 
     private boolean shouldAddSuffix(Value value) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -4,6 +4,7 @@ import whelk.JsonLd;
 import whelk.exception.InvalidQueryException;
 import whelk.search2.AppParams;
 import whelk.search2.Disambiguate;
+import whelk.search2.EsMappings;
 import whelk.search2.Filter;
 import whelk.search2.EsBoost;
 import whelk.search2.Operator;
@@ -42,12 +43,12 @@ public class QueryTree {
         return new QueryTree(tree, filtered);
     }
 
-    public Map<String, Object> toEs(JsonLd jsonLd, Function<String, Optional<String>> getNestedPath) {
-        return toEs(jsonLd, getNestedPath, List.of(), List.of());
+    public Map<String, Object> toEs(JsonLd jsonLd, EsMappings esMappings) {
+        return toEs(jsonLd, esMappings, List.of(), List.of());
     }
 
-    public Map<String, Object> toEs(JsonLd jsonLd, Function<String, Optional<String>> getNestedPath, Collection<String> boostFields, Collection<String> rulingTypes) {
-        return getFiltered().tree.expand(jsonLd, rulingTypes).toEs(getNestedPath, boostFields.isEmpty() ? EsBoost.BOOST_FIELDS : boostFields);
+    public Map<String, Object> toEs(JsonLd jsonLd, EsMappings esMappings, Collection<String> boostFields, Collection<String> rulingTypes) {
+        return getFiltered().tree.expand(jsonLd, rulingTypes).toEs(esMappings, boostFields.isEmpty() ? EsBoost.BOOST_FIELDS : boostFields);
     }
 
     private QueryTree(Node tree, QueryTree filtered) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -123,12 +123,12 @@ public class QueryTree {
         return tree == null;
     }
 
-    /**
-     * There is no freetext or all freetext nodes are "*"
-     */
     public boolean isWild() {
-        return StreamSupport.stream(allDescendants(tree).spliterator(), false)
-                .noneMatch(n -> n.isFreeTextNode() && !((FreeText) n).isWild());
+        return isWild(tree);
+    }
+
+    private static boolean isWild(Node tree) {
+        return tree.isFreeTextNode() && ((FreeText) tree).isWild();
     }
 
     public List<String> collectRulingTypes(JsonLd jsonLd) {
@@ -226,7 +226,9 @@ public class QueryTree {
     }
 
     private void removeFreeTextWildcard() {
-        _removeTopLevelNodesByCondition(n -> n.isFreeTextNode() && ((FreeText) n).isWild());
+        if (!isWild()) {
+            _removeTopLevelNodesByCondition(QueryTree::isWild);
+        }
     }
 
     private void resetString() {

--- a/whelk-core/src/test/groovy/whelk/search2/AggsSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/AggsSpec.groovy
@@ -8,41 +8,42 @@ import whelk.search2.querytree.TestData
 
 class AggsSpec extends Specification {
     JsonLd jsonLd = TestData.getJsonLd()
+    EsMappings esMappings = TestData.getEsMappings()
 
     def "build agg query"() {
         given:
         List<AppParams.Slice> sliceList = ['p1', 'p2', 'p6']
                 .collect { new AppParams.Slice(it, ['size': 100, 'sortOrder': 'desc', 'sort': 'count']) }
-        Map aggQuery = Aggs.buildAggQuery(sliceList, jsonLd, [], x -> x == 'p3.p4.@id' ? Optional.of('p3') : Optional.empty())
+        Map aggQuery = Aggs.buildAggQuery(sliceList, jsonLd, [], esMappings)
 
         expect:
         aggQuery == [
-                "p1": [
+                "p1"       : [
                         "filter": [
                                 "bool": [
                                         "must": []
                                 ]
                         ],
-                        "aggs": [
+                        "aggs"  : [
                                 "p1": [
                                         "terms": [
-                                                "size": 100,
+                                                "size" : 100,
                                                 "field": "p1",
                                                 "order": ["_count": "desc"]
                                         ]
                                 ]
                         ]
                 ],
-                "p2": [
+                "p2"       : [
                         "filter": [
                                 "bool": [
                                         "must": []
                                 ]
                         ],
-                        "aggs": [
+                        "aggs"  : [
                                 "p2": [
                                         "terms": [
-                                                "size": 100,
+                                                "size" : 100,
                                                 "field": "p2",
                                                 "order": ["_count": "desc"]
                                         ]
@@ -55,12 +56,12 @@ class AggsSpec extends Specification {
                                         "must": []
                                 ]
                         ],
-                        "aggs": [
+                        "aggs"  : [
                                 "p6": [
-                                        "aggs": [
+                                        "aggs"  : [
                                                 "n": [
                                                         "terms": [
-                                                                "size": 100,
+                                                                "size" : 100,
                                                                 "field": "p3.p4.@id",
                                                                 "order": ["_count": "desc"]
                                                         ]
@@ -77,64 +78,64 @@ class AggsSpec extends Specification {
         given:
         List<AppParams.Slice> sliceList = ['p7', 'p8', 'p9']
                 .collect { new AppParams.Slice(it, ['size': 100, 'sortOrder': 'desc', 'sort': 'count']) }
-        Map aggQuery = Aggs.buildAggQuery(sliceList, jsonLd, ['T1'], x -> Optional.empty())
+        Map aggQuery = Aggs.buildAggQuery(sliceList, jsonLd, ['T1'], esMappings)
 
         expect:
         aggQuery == [
-            "p7.@id" : [
-                "filter" : [
-                    "bool" : [
-                        "must" : [ ]
-                    ]
-                ],
-                "aggs" : [
-                    "p7" : [
-                        "terms" : [
-                            "order" : [
-                                "_count" : "desc"
-                            ],
-                            "field" : "p7.@id",
-                            "size" : 100
+                "p7.@id"           : [
+                        "filter": [
+                                "bool": [
+                                        "must": []
+                                ]
+                        ],
+                        "aggs"  : [
+                                "p7": [
+                                        "terms": [
+                                                "order": [
+                                                        "_count": "desc"
+                                                ],
+                                                "field": "p7.@id",
+                                                "size" : 100
+                                        ]
+                                ]
                         ]
-                    ]
-                ]
-            ],
-            "instanceOf.p8.@id" : [
-                "filter" : [
-                    "bool" : [
-                        "must" : [ ]
-                    ]
                 ],
-                "aggs" : [
-                    "p8" : [
-                        "terms" : [
-                            "order" : [
-                                "_count" : "desc"
-                            ],
-                            "field" : "instanceOf.p8.@id",
-                            "size" : 100
+                "instanceOf.p8.@id": [
+                        "filter": [
+                                "bool": [
+                                        "must": []
+                                ]
+                        ],
+                        "aggs"  : [
+                                "p8": [
+                                        "terms": [
+                                                "order": [
+                                                        "_count": "desc"
+                                                ],
+                                                "field": "instanceOf.p8.@id",
+                                                "size" : 100
+                                        ]
+                                ]
                         ]
-                    ]
-                ]
-            ],
-            "p9.@id" : [
-                "filter" : [
-                    "bool" : [
-                        "must" : [ ]
-                    ]
                 ],
-                "aggs" : [
-                    "p9" : [
-                        "terms" : [
-                            "order" : [
-                                "_count" : "desc"
-                            ],
-                            "field" : "p9.@id",
-                            "size" : 100
+                "p9.@id"           : [
+                        "filter": [
+                                "bool": [
+                                        "must": []
+                                ]
+                        ],
+                        "aggs"  : [
+                                "p9": [
+                                        "terms": [
+                                                "order": [
+                                                        "_count": "desc"
+                                                ],
+                                                "field": "p9.@id",
+                                                "size" : 100
+                                        ]
+                                ]
                         ]
-                    ]
                 ]
-            ]
         ]
     }
 
@@ -142,47 +143,43 @@ class AggsSpec extends Specification {
         given:
         Link object = new Link("https://libris.kb.se/fcrtpljz1qp2bdv#it")
         List<Property> predicates = ['p2', 'p6'].collect { new Property(it, jsonLd) }
-        Map aggQuery = Aggs.buildPAggQuery(object, predicates, jsonLd, List.of(), x -> x == 'p3.p4.@id' ? Optional.of('p3') : Optional.empty())
+        Map aggQuery = Aggs.buildPAggQuery(object, predicates, jsonLd, List.of(), esMappings)
 
         expect:
         aggQuery == [
-            "_p" : [
-                "filters" : [
-                    "filters" : [
-                        "p2" : [
-                            "bool" : [
-                                "filter" : [
-                                    "simple_query_string" : [
-                                        "default_operator" : "AND",
-                                        "query" : "https://libris.kb.se/fcrtpljz1qp2bdv#it",
-                                        "fields" : [ "p2" ]
-                                    ]
-                                ]
-                            ]
-                        ],
-                        "p6" : [
-                            "bool" : [
-                                "must" : [
-                                    "nested" : [
-                                        "path" : "p3",
-                                        "query" : [
-                                            "bool" : [
-                                                "filter" : [
-                                                    "simple_query_string" : [
-                                                        "default_operator" : "AND",
-                                                        "query" : "https://libris.kb.se/fcrtpljz1qp2bdv#it",
-                                                        "fields" : [ "p3.p4.@id" ]
-                                                    ]
+                "_p": [
+                        "filters": [
+                                "filters": [
+                                        "p2": [
+                                                "bool": [
+                                                        "filter": [
+                                                                "term": [
+                                                                        "p2": "https://libris.kb.se/fcrtpljz1qp2bdv#it"
+                                                                ]
+                                                        ]
                                                 ]
-                                            ]
+                                        ],
+                                        "p6": [
+                                                "bool": [
+                                                        "must": [
+                                                                "nested": [
+                                                                        "path" : "p3",
+                                                                        "query": [
+                                                                                "bool": [
+                                                                                        "filter": [
+                                                                                                "term": [
+                                                                                                        "p3.p4.@id": "https://libris.kb.se/fcrtpljz1qp2bdv#it"
+                                                                                                ]
+                                                                                        ]
+                                                                                ]
+                                                                        ]
+                                                                ]
+                                                        ]
+                                                ]
                                         ]
-                                    ]
                                 ]
-                            ]
                         ]
-                    ]
                 ]
-            ]
         ]
     }
 }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/FreeTextSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/FreeTextSpec.groovy
@@ -1,12 +1,15 @@
 package whelk.search2.querytree
 
 import spock.lang.Specification
+import whelk.search2.EsMappings
 
 class FreeTextSpec extends Specification {
+    EsMappings esMappings = TestData.getEsMappings()
+
     def "to ES query (basic boosting)"() {
         given:
         List<String> boostFields = ["field1^10", "field2^20"]
-        Map esQuery = new FreeText("something").toEs(x -> Optional.empty(), boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
 
         expect:
         esQuery == [
@@ -25,7 +28,7 @@ class FreeTextSpec extends Specification {
     def "to ES query (function boosting)"() {
         given:
         List<String> boostFields = ["field1^10(someFunc)", "field2^20(someFunc)", "field3^10(another(func))"]
-        Map esQuery = new FreeText("something").toEs(x -> Optional.empty(), boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
 
         expect:
         esQuery == [
@@ -77,7 +80,7 @@ class FreeTextSpec extends Specification {
     def "to ES query (basic boosting + function boosting)"() {
         given:
         List<String> boostFields = ["field1^10", "field2^20", "field3^10(someFunc)"]
-        Map esQuery = new FreeText("something").toEs(x -> Optional.empty(), boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
 
         expect:
         esQuery == [

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -17,7 +17,7 @@ class QueryTreeSpec extends Specification {
         QueryTree tree = new QueryTree('(NOT p1:v1 OR p2:v2) something', disambiguate)
 
         expect:
-        tree.toEs(jsonLd, x -> Optional.empty(), ['_str^10'], []) ==
+        tree.toEs(jsonLd, TestData.getEsMappings(), ['_str^10'], []) ==
                 ['bool': [
                         'must': [
                                 [
@@ -31,24 +31,20 @@ class QueryTreeSpec extends Specification {
                                 ['bool': [
                                         'should': [
                                                 ['bool': [
-                                                        'filter': [
-                                                                'bool': [
-                                                                        'must_not': [
-                                                                                'simple_query_string': [
-                                                                                        'default_operator': 'AND',
-                                                                                        'query'           : 'v1',
-                                                                                        'fields'          : ['p1']
-                                                                                ]
-                                                                        ]
+                                                        'must_not': [
+                                                                'simple_query_string': [
+                                                                        'default_operator': 'AND',
+                                                                        'query'           : 'v1',
+                                                                        'fields'          : ['p1']
                                                                 ]
                                                         ]
                                                 ]],
                                                 ['bool': [
-                                                        'filter': [
+                                                        'must': [
                                                                 'simple_query_string': [
                                                                         'default_operator': 'AND',
                                                                         'query'           : 'v2',
-                                                                        'fields'          : ['p2']
+                                                                        'fields'          : ['p2^400']
                                                                 ]
                                                         ]
                                                 ]]

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -1,7 +1,9 @@
 package whelk.search2.querytree
 
 import whelk.JsonLd
+import whelk.Whelk
 import whelk.search2.Disambiguate
+import whelk.search2.EsMappings
 import whelk.search2.Filter
 import whelk.search2.VocabMappings
 
@@ -161,5 +163,14 @@ class TestData {
                 '@context': ['@vocab': 'https://id.kb.se/vocab/', 'p2': ['@type': '@vocab']]
         ]
         return new JsonLd(ctx, [:], vocab)
+    }
+
+    static def getEsMappings() {
+        def mappings = [
+                'properties': [
+                        'p3': ['type': 'nested']
+                ]
+        ]
+        return new EsMappings(mappings)
     }
 }


### PR DESCRIPTION
Count score from free text search within specific fields, e.g.  `medverkande:strindberg`. 

The boost factor of 400 is set arbitrarily now as a starting point.

Properties that may appear on both instance and work will be "favored" with this solution as each individual field (e.g. `hasTitle.mainTitle`/`@reverse.instanceOf.hasTitle.mainTitle`) will contribute to the score. This is of course problematic, but maybe let that be until we've settled the whole instance vs work issue. (We should soon!)

We should also sort out the use of keyword fields as discussed.