### PR TITLE
Feature/es score quoted freetext

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -25,10 +25,14 @@ public class QueryUtil {
 
     public static String quoteIfPhraseOrContainsSpecialSymbol(String s) {
         // TODO: Don't hardcode. Keep quotes in parsing instead of requoting?
-        return !isQuoted(s) && s.matches(".*(>=|<=|[=!~<>(): ]).*") ? "\"" + s + "\"" : s;
+        return !isQuoted(s) && s.matches(".*(>=|<=|[=!~<>(): ]).*") ? quote(s) : s;
     }
 
-    private static boolean isQuoted(String s) {
+    public static String quote(String s) {
+        return "\"" + s + "\"";
+    }
+
+    public static boolean isQuoted(String s) {
         return s.matches("\".+\"");
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
@@ -1,5 +1,6 @@
 package whelk.search2.querytree;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -96,9 +97,10 @@ public final class And extends Group {
     }
 
     public Node add(Node node) {
-        List<Node> newChildren = Stream.concat(children.stream(), node instanceof And ? node.children().stream() : Stream.of(node))
-                .distinct()
-                .toList();
+        List<Node> newChildren = new ArrayList<>(children);
+        (node instanceof And ? node.children().stream() : Stream.of(node))
+                .filter(Predicate.not(children::contains))
+                .forEach(newChildren::add);
         return new And(newChildren);
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -96,12 +96,15 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     List<Node> flattenChildren(List<Node> children) {
-        return children.stream()
-                .flatMap(c -> c instanceof Group g
-                        ? (g.getClass() == this.getClass() ? g.children().stream() : Stream.of(g))
-                        : Stream.of(c))
-                .distinct()
-                .toList();
+        List<Node> flattened = new ArrayList<>();
+        for (Node child : children) {
+            if (child instanceof Group g && g.getClass() == this.getClass()) {
+                g.children().stream().filter(c -> !flattened.contains(c) && !children.contains(c)).forEach(flattened::add);
+            } else {
+                flattened.add(child);
+            }
+        }
+        return flattened;
     }
 
     Node filterAndReinstantiate(Predicate<Node> p) {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/GroupSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/GroupSpec.groovy
@@ -10,15 +10,12 @@ class GroupSpec extends Specification {
 
     def "flatten children on instantiation"() {
         given:
-        def nestedAnd = buildTree("p1:v1 (p1:v1 p2:v2)", disambiguate)
-        def or = buildTree("p1:v1 OR p2:v2", disambiguate)
-        def pv = buildTree("p2:v2", disambiguate)
-        def nestedOr = buildTree("(p1:v1 OR p2:v2) OR p2:v2", disambiguate)
-        def children = [nestedAnd, or, pv, nestedOr]
+        var andTree = buildTree("x x p1:v1 (p1:v1 p2:v2 (p2:v2 p3:v3)) (p1:v1 p2:v2) (p1:v1 OR p2:v2)", disambiguate)
+        var orTree = buildTree("((x OR p1:v1 OR (p1:v1 OR p2:v2 OR (p2:v2 OR p3:v3))) OR (p1:v1 OR p2:v2)) (p1:v1 p2:v2)", disambiguate)
 
         expect:
-        new And(children).toString() == 'p1:v1 p2:v2 (p1:v1 OR p2:v2)'
-        new Or(children).toString() == '(p1:v1 p2:v2) OR p1:v1 OR p2:v2'
+        andTree.toString() == 'x x p1:v1 p2:v2 p3:v3 (p1:v1 OR p2:v2)'
+        orTree.toString() == '(x OR p1:v1 OR p2:v2 OR p3:v3) p1:v1 p2:v2'
     }
 
     def "equality check"() {


### PR DESCRIPTION
Should improve the relevancy for queries like
https://beta.libris-qa.kb.se/find?_q=Physiology+of+sport+and+exercise&_limit=20&_offset=0&_sort=&_spell=true
https://beta.libris-qa.kb.se/find?_q=jakt+och+fiske&_limit=20&_offset=0&_sort=&_spell=true
https://beta.libris-qa.kb.se/find?_q=h%C3%A4star+h%C3%A4star+h%C3%A4star&_limit=20&_offset=0&_sort=&_spell=true

A small bugfix (f868209613b58a84152f937ef275c361d129c087) was required for the last example to work. Before this fix, the query `hästar hästar hästar` would be transformed into just `hästar` which didn't really matter before however now that we also want to match the entire phrase it does matter.