### PR TITLE
Bugfix/sum scores

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
@@ -104,7 +104,7 @@ public class ObjectQuery extends Query {
                         Property::name,
                         p -> new PathValue(p, Operator.EQUALS, object)
                                 .expand(jsonLd, rulingTypes.isEmpty() ? p.domain() : rulingTypes)
-                                .toEs(esMappings, List.of()))
+                                .toEs(esMappings, EsBoost.Config.empty()))
                 );
 
         if (!filters.isEmpty()) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/ActiveFilter.java
@@ -1,6 +1,7 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsBoost;
 import whelk.search2.EsMappings;
 import whelk.search2.Filter;
 import whelk.search2.QueryParams;
@@ -13,7 +14,7 @@ import static whelk.search2.QueryUtil.makeUpLink;
 
 public record ActiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
-    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, EsBoost.Config boostConfig) {
         throw new UnsupportedOperationException("Expand filter before converting to ES");
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -77,7 +77,7 @@ public record FreeText(Property.TextQuery textQuery, Operator operator, String v
                 basicBoostFields = basicBoostFields.entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() / divisor));
             }
-            queries.addAll(buildQueries(queryMode, quote(queryString), basicBoostFields, functionBoostFields));
+            queries.addAll(buildQueries("query_string", quote(queryString), basicBoostFields, functionBoostFields));
         }
 
         return wrap(queries.size() == 1 ? queries.getFirst() : shouldWrap(queries));
@@ -199,6 +199,9 @@ public record FreeText(Property.TextQuery textQuery, Operator operator, String v
         query.put("default_operator", "AND");
         if (!fields.isEmpty()) {
             query.put("fields", fields);
+        }
+        if (queryMode.equals("query_string")) {
+            query.put("type", "most_fields");
         }
         return Map.of(queryMode, query);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -1,6 +1,7 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsBoost;
 import whelk.search2.EsMappings;
 import whelk.search2.Operator;
 import whelk.search2.QueryParams;
@@ -43,9 +44,9 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     @Override
-    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, EsBoost.Config boostConfig) {
         Map<String, List<PathValue>> nestedGroups = getNestedGroups(esMappings);
-        return nestedGroups.isEmpty() ? wrap(childrenToEs(esMappings, boostFields)) : toEsNested(nestedGroups, esMappings, boostFields);
+        return nestedGroups.isEmpty() ? wrap(childrenToEs(esMappings, boostConfig)) : toEsNested(nestedGroups, esMappings, boostConfig);
     }
 
     @Override
@@ -138,7 +139,7 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     // TODO: Review/refine nested logic and proper tests
-    private Map<String, Object> toEsNested(Map<String, List<PathValue>> nestedGroups, EsMappings esMappings, Collection<String> boostFields) {
+    private Map<String, Object> toEsNested(Map<String, List<PathValue>> nestedGroups, EsMappings esMappings, EsBoost.Config boostConfig) {
         List<Map<String, Object>> esChildren = new ArrayList<>();
         List<Node> nonNested = new ArrayList<>(children());
 
@@ -161,7 +162,7 @@ public sealed abstract class Group implements Node permits And, Or {
         });
 
         for (Node n : nonNested) {
-            esChildren.add(n.toEs(esMappings, boostFields));
+            esChildren.add(n.toEs(esMappings, boostConfig));
         }
 
         return esChildren.size() == 1 ? esChildren.getFirst() : wrap(esChildren);
@@ -192,8 +193,8 @@ public sealed abstract class Group implements Node permits And, Or {
         return nestedGroups;
     }
 
-    private List<Map<String, Object>> childrenToEs(EsMappings esMappings, Collection<String> boostFields) {
-        return mapToMap(n -> n.toEs(esMappings, boostFields));
+    private List<Map<String, Object>> childrenToEs(EsMappings esMappings, EsBoost.Config boostConfig) {
+        return mapToMap(n -> n.toEs(esMappings, boostConfig));
     }
 
     private List<Node> mapToNode(Function<Node, Node> mapper) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/InactiveFilter.java
@@ -1,6 +1,7 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsBoost;
 import whelk.search2.EsMappings;
 import whelk.search2.Filter;
 import whelk.search2.QueryParams;
@@ -13,7 +14,7 @@ import static whelk.search2.QueryUtil.makeUpLink;
 
 public record InactiveFilter(Filter.AliasedFilter aliasedFilter) implements Node {
     @Override
-    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, EsBoost.Config boostConfig) {
         throw new UnsupportedOperationException("Query tree must not contain inactive filters");
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -1,6 +1,7 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
+import whelk.search2.EsBoost;
 import whelk.search2.EsMappings;
 import whelk.search2.QueryParams;
 
@@ -10,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 public sealed interface Node permits ActiveFilter, FreeText, Group, InactiveFilter, PathValue {
-    Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields);
+    Map<String, Object> toEs(EsMappings esMappings, EsBoost.Config boostConfig);
 
     Node expand(JsonLd jsonLd, Collection<String> rulingTypes);
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -40,7 +40,7 @@ public record PathValue(Path path, Operator operator, Value value) implements No
     }
 
     @Override
-    public Map<String, Object> toEs(EsMappings esMappings, Collection<String> boostFields) {
+    public Map<String, Object> toEs(EsMappings esMappings, EsBoost.Config boostConfig) {
         var es = getCoreEsQuery(esMappings);
         return getEsNestedQuery(es, esMappings).orElse(es);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -47,13 +47,13 @@ public class QueryTree {
 
     public Map<String, Object> toEs(JsonLd jsonLd,
                                     EsMappings esMappings,
-                                    Collection<String> boostFields,
+                                    EsBoost.Config boostConfig,
                                     Collection<String> rulingTypes,
                                     List<Node> exclude)
     {
         return getFiltered().omitNodes(exclude)
                 .expand(jsonLd, rulingTypes)
-                .toEs(esMappings, boostFields.isEmpty() ? EsBoost.BOOST_FIELDS : boostFields);
+                .toEs(esMappings, boostConfig);
     }
 
     private QueryTree(Node tree, QueryTree filtered) {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/FreeTextSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/FreeTextSpec.groovy
@@ -1,6 +1,7 @@
 package whelk.search2.querytree
 
 import spock.lang.Specification
+import whelk.search2.EsBoost
 import whelk.search2.EsMappings
 
 class FreeTextSpec extends Specification {
@@ -9,7 +10,7 @@ class FreeTextSpec extends Specification {
     def "to ES query (basic boosting)"() {
         given:
         List<String> boostFields = ["field1^10", "field2^20"]
-        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, EsBoost.Config.newBoostFieldsConfig(boostFields))
 
         expect:
         esQuery == [
@@ -28,7 +29,7 @@ class FreeTextSpec extends Specification {
     def "to ES query (function boosting)"() {
         given:
         List<String> boostFields = ["field1^10(someFunc)", "field2^20(someFunc)", "field3^10(another(func))"]
-        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, EsBoost.Config.newBoostFieldsConfig(boostFields))
 
         expect:
         esQuery == [
@@ -80,7 +81,7 @@ class FreeTextSpec extends Specification {
     def "to ES query (basic boosting + function boosting)"() {
         given:
         List<String> boostFields = ["field1^10", "field2^20", "field3^10(someFunc)"]
-        Map esQuery = new FreeText("something").toEs(esMappings, boostFields)
+        Map esQuery = new FreeText("something").toEs(esMappings, EsBoost.Config.newBoostFieldsConfig(boostFields))
 
         expect:
         esQuery == [

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 import whelk.JsonLd
 import whelk.search2.AppParams
 import whelk.search2.Disambiguate
+import whelk.search2.EsBoost
 import whelk.search2.Filter
 import whelk.search2.Query
 import whelk.search2.QueryParams
@@ -16,9 +17,10 @@ class QueryTreeSpec extends Specification {
     def "convert to ES query"() {
         given:
         QueryTree tree = new QueryTree('(NOT p1:v1 OR p2:v2) something', disambiguate)
+        EsBoost.Config esBoostConfig = EsBoost.Config.newBoostFieldsConfig(["_str^10"])
 
         expect:
-        tree.toEs(jsonLd, TestData.getEsMappings(), ['_str^10'], [], []) ==
+        tree.toEs(jsonLd, TestData.getEsMappings(), esBoostConfig, [], []) ==
                 ['bool': [
                         'must': [
                                 [


### PR DESCRIPTION
All scores from the extra phrase matching weren't summed together as expected. a1b4a91 fixes that. 

Consequently, we'll end up with higher scores from matching phrases, hence setting the `PHRASE_BOOST_DIVISOR` a high number for now. Let's find a more accurate number by experimenting with the `_phraseBoostDivisor` API parameter again. The scores should at least be more predictable now and match what we actually see when using the visual debug mode.