### PR TITLE
feat(search2): Allow escaping of one-char wildcard (?)

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -89,6 +89,12 @@ public class Lex {
                     offset.increase(1);
                     if (query.isEmpty())
                         throw new InvalidQueryException("Lexer error: Escaped EOF at character index: " + symbolOffset);
+                    if (escapedC == '?') {
+                        // ? only needs to be escaped when last char in word
+                        // need to later be able to distinguish between escaped or not
+                        // TODO how should we handle escaping of one-char wildcards?
+                        symbolValue.append("\\");
+                    }
                     symbolValue.append(escapedC);
                 } else {
                     symbolValue.append(c);
@@ -117,6 +123,12 @@ public class Lex {
                     if (query.isEmpty())
                         throw new InvalidQueryException("Lexer error: Escaped EOF at character index: " + symbolOffset);
                     char escapedC = query.charAt(0);
+                    if (escapedC == '?') {
+                        // ? only needs to be escaped when last char in word
+                        // need to later be able to distinguish between escaped or not
+                        // TODO how should we handle escaping of one-char wildcards?
+                        symbolValue.append("\\");
+                    }
                     symbolValue.append(escapedC);
                     query.deleteCharAt(0);
                     offset.increase(1);

--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -120,6 +120,8 @@ public class Lex {
                     symbolValue.append(escapedC);
                     query.deleteCharAt(0);
                     offset.increase(1);
+                    if (query.isEmpty())
+                        break;
                 } else {
                     query.deleteCharAt(0);
                     offset.increase(1);

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -37,7 +37,7 @@ public record FreeText(Property.TextQuery textQuery, Operator operator, String v
         boolean isSimple = QueryUtil.isSimple(s);
         String queryMode = isSimple ? "simple_query_string" : "query_string";
         if (!isSimple) {
-            s = ESQuery.escapeNonSimpleQueryString(s);
+            s = QueryUtil.escapeNonSimpleQueryString(s);
         }
         String queryString = s;
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -294,7 +294,7 @@ public record PathValue(Path path, Operator operator, Value value) implements No
         boolean isSimple = QueryUtil.isSimple(value);
         String queryMode = isSimple ? "simple_query_string" : "query_string";
         var query = new HashMap<>();
-        query.put("query", isSimple ? value : ESQuery.escapeNonSimpleQueryString(value));
+        query.put("query", isSimple ? value : QueryUtil.escapeNonSimpleQueryString(value));
         query.put("fields", List.of(field));
         query.put("default_operator", "AND");
         return Map.of(queryMode, query);

--- a/whelk-core/src/test/groovy/whelk/search2/QueryUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/QueryUtilSpec.groovy
@@ -25,19 +25,36 @@ class QueryUtilSpec extends Specification {
         QueryUtil.isSimple(query) == result
 
         where:
-        query                       | result
-        "Hästar"                    | true
-        "Häst*"                     | true
-        "H*star"                    | false
-        "*star"                     | false
-        "Häst?"                     | true // treat these as no masking when last char. (e.g. pasted titles)
-        "H?star"                    | false
-        "H?star?"                   | false
-        "H*star?"                   | false
-        "?ästar"                    | false
-        'Это дом'                   | true
-        'Это д?м'                   | false
-        'վիրված'                    | true
-        'վիրվ?ած'                   | false
+        query       | result
+        "Hästar"    | true
+        "Häst*"     | true
+        "H*star"    | false
+        "*star"     | false
+        "Häst?"     | true // don't treat ? as wildcard when last char in word. (e.g. pasted titles)
+        "Häst? abc" | true // don't treat ? as wildcard when last char in word. (e.g. pasted titles)
+        "Häst? Ko?" | true // don't treat ? as wildcard when last char in word. (e.g. pasted titles)
+        "Häst\\?"   | false
+        "H?star"    | false
+        "H?star?"   | false
+        "H*star?"   | false
+        "?ästar"    | false
+        'Это дом'   | true
+        'Это д?м'   | false
+        'վիրված'    | true
+        'վիրվ?ած'   | false
+    }
+
+    def "escape"() {
+        expect:
+        QueryUtil.escapeNonSimpleQueryString(query) == result
+
+        where:
+        query          | result
+        "H*star"       | "H*star"
+        "Häst\\?"      | "Häst?"
+        "*star"        | "*star"
+        "Häs^tak"      | "Häs\\^tak"
+        "hyp-hen -not" | "hyp\\-hen -not"
+        "-not"         | "-not"
     }
 }

--- a/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
@@ -88,6 +88,30 @@ class LexSpec extends Specification {
         ]
     }
 
+    def "escaped wildcard"() {
+        given:
+        def input = "quo\\?"
+        def lexedSymbols = Lex.lexQuery(input)
+
+        expect:
+        lexedSymbols as List == [
+                new Lex.Symbol(Lex.TokenName.STRING, "quo\\?", 0),
+        ]
+    }
+
+    def "escaped wildcard in quoted string"() {
+        given:
+        def input = "AAA:\"BB\\?\""
+        def lexedSymbols = Lex.lexQuery(input)
+
+        expect:
+        lexedSymbols as List == [
+                new Lex.Symbol(Lex.TokenName.STRING, "AAA", 0),
+                new Lex.Symbol(Lex.TokenName.OPERATOR, ":", 3),
+                new Lex.Symbol(Lex.TokenName.STRING, "BB\\?", 4),
+        ]
+    }
+
     def "error on escaped eol"() {
         given:
         def input = "AAA\\"

--- a/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
@@ -66,6 +66,28 @@ class LexSpec extends Specification {
         ]
     }
 
+    def "escape last char"() {
+        given:
+        def input = "quo\\="
+        def lexedSymbols = Lex.lexQuery(input)
+
+        expect:
+        lexedSymbols as List == [
+                new Lex.Symbol(Lex.TokenName.STRING, "quo=", 0),
+        ]
+    }
+
+    def "escape last char + whitespace"() {
+        given:
+        def input = "quo\\= "
+        def lexedSymbols = Lex.lexQuery(input)
+
+        expect:
+        lexedSymbols as List == [
+                new Lex.Symbol(Lex.TokenName.STRING, "quo=", 0),
+        ]
+    }
+
     def "error on escaped eol"() {
         given:
         def input = "AAA\\"


### PR DESCRIPTION
When ? only appears as the last character of a word (or words) we don't
treat it as a wildcard. It is unlikely that the user intent is to use a
wildcard. This makes pasted titles work as queries e.g. `who is who?`.

If ? is used in any other position, wildcards are enabled. Including trailing.
examples: `blom??uist`, `wom??`, `?ome?`.

Add the possibility to force a single trailing ? to be interpreted as a
wildcard by escaping it: `who\?`. (or maybe rather "unescaping" it)

Also fix  StringIndexOutOfBoundsException in Lex when last
character in string is escaped https://github.com/libris/librisxl/pull/1598/commits/1c65dcbdcf2e1df5767dea18752be13374938dd5

TODO?
We might want to handle this in a different way in the lexing step.
i.e. by parsing ? as a symbol. Worth it?