### PR TITLE
fix(bulk): Skip and log conflict when moving holdings

### DIFF
--- a/whelktool/src/main/resources/bulk-change-scripts/create.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/create.groovy
@@ -14,8 +14,6 @@ import static whelk.datatool.form.MatchForm.collectFormBNodeIdToPath
 import static whelk.datatool.form.MatchForm.collectFormBNodeIdToResourceIds
 import static whelk.util.DocumentUtil.traverse
 
-PrintWriter conflictingHoldReport = getReportWriter("holding-conflict.txt")
-
 Map targetForm = parameters.get(TARGET_FORM_KEY)
 
 Map<String, Set<String>> nodeIdMappings = collectFormBNodeIdToResourceIds(targetForm, getWhelk())
@@ -59,7 +57,7 @@ def docs = verifiedUris.collect { uri ->
 selectFromIterable(docs) {
     it.scheduleSave(loud: true, onError: { e ->
         if (e instanceof ConflictingHoldException) {
-            conflictingHoldReport.println("Failed to create document: ${e.getMessage()}")
+            it.reportFailed("Failed to create document: ${e.getMessage()}")
         } else {
             throw e
         }

--- a/whelktool/src/main/resources/bulk-change-scripts/update.groovy
+++ b/whelktool/src/main/resources/bulk-change-scripts/update.groovy
@@ -1,5 +1,6 @@
 import whelk.Document
 import whelk.Whelk
+import whelk.component.PostgreSQLComponent
 import whelk.datatool.form.ModifiedThing
 import whelk.datatool.form.Transform
 
@@ -16,7 +17,13 @@ Transform transform = new Transform(matchForm, targetForm, getWhelk())
 selectByForm(transform.matchForm) {
     try {
         if (modify(transform, it.doc, it.whelk)) {
-            it.scheduleSave(loud: isLoudAllowed)
+            it.scheduleSave(loud: isLoudAllowed, onError: { e ->
+                if (e instanceof PostgreSQLComponent.ConflictingHoldException) {
+                    it.reportFailed("Failed to update document: ${e.getMessage()}")
+                } else {
+                    throw e
+                }
+            })
         }
     } catch (ModifiedThing.IllegalModificationException ignored) {
     }


### PR DESCRIPTION
- Skip and log ConflictingHoldException in bulk update (same behavior as bulk create)
- Log to standard FAILED.txt and ERRORS.txt so that failed docs are included in count.
- Make the above logs available to scripts through reportFailed() on DocumentItem