### PR TITLE
Bugfix/empty whelktool reports

### DIFF
--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -130,8 +130,10 @@ class WhelkTool {
         this.reportsDir = reportsDir
         reportsDir.mkdirs()
         mainLog = new PrintWriter(new File(reportsDir, MAIN_LOG_NAME))
-        errorLog = new PrintWriter(new File(reportsDir, ERROR_LOG_NAME))
-        failedLog = new PrintWriter(new File(reportsDir, FAILED_LOG_NAME))
+        def errorLogFile = new File(reportsDir, ERROR_LOG_NAME)
+        errorLog = new PrintWriter(errorLogFile)
+        def failedLogFile = new File(reportsDir, FAILED_LOG_NAME)
+        failedLog = new PrintWriter(failedLogFile)
         def modifiedLogFile = new File(reportsDir, MODIFIED_LOG_NAME)
         modifiedLog = new PrintWriter(modifiedLogFile)
         def createdLogFile = new File(reportsDir, CREATED_LOG_NAME)
@@ -154,7 +156,7 @@ class WhelkTool {
                 }
             }
 
-            [modifiedLogFile, createdLogFile, deletedLogFile].each { if (it.length() == 0) it.delete() }
+            [modifiedLogFile, createdLogFile, deletedLogFile, errorLogFile, failedLogFile].each { if (it.length() == 0) it.delete() }
         }
 
         var lock = new Object()

--- a/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJob.java
+++ b/whelktool/src/main/java/whelk/datatool/bulkchange/BulkJob.java
@@ -113,9 +113,13 @@ public class BulkJob implements Runnable {
     }
 
     private long lineCount(String reportName) {
-        try (Stream<String> stream = Files.lines(new File(reportDir(), reportName).toPath(), StandardCharsets.UTF_8)) {
-            return stream.count();
-        } catch(FileNotFoundException ignored) {
+        try {
+            File reportFile = new File(reportDir(), reportName);
+            if (reportFile.exists()) {
+                try (Stream<String> stream = Files.lines(reportFile.toPath(), StandardCharsets.UTF_8)) {
+                    return stream.count();
+                }
+            }
             return 0;
         } catch (IOException e) {
             log.warn("Could not get line count", e);


### PR DESCRIPTION
Should help to avoid unnecessary log warnings of type

`2025-06-24T11:24:17,150 [Thread-37218] WARN  whelk.datatool.bulkchange.BulkJob - Could not get line count`