### PR TITLE
Feature/simpler view links

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
@@ -17,7 +17,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static whelk.search2.QueryParams.ApiParams.OBJECT;
 import static whelk.search2.QueryParams.ApiParams.PREDICATES;
+import static whelk.search2.QueryParams.ApiParams.SORT;
 import static whelk.search2.QueryUtil.makeFindUrl;
 
 public class ObjectQuery extends Query {
@@ -72,7 +74,7 @@ public class ObjectQuery extends Query {
                     int count = counts.get(p);
 
                     if (count > 0) {
-                        Map<String, String> params = queryParams.getNonQueryParamsNoOffset();
+                        Map<String, String> params = queryParams.getCustomParamsMap(List.of(SORT, OBJECT));
                         params.put(PREDICATES, p);
                         result.add(Map.of(
                                 "totalItems", count,

--- a/whelk-core/src/main/groovy/whelk/search2/Pagination.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Pagination.java
@@ -7,8 +7,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static whelk.search2.QueryUtil.makeFindUrlNoOffset;
-import static whelk.search2.QueryUtil.makeFindUrlWithOffset;
+import static whelk.search2.QueryUtil.makeFindUrl;
 
 public class Pagination {
     public static Map<String, Map<String, String>> makeLinks(int numHits, int maxItems, QueryTree queryTree, QueryParams queryParams) {
@@ -21,19 +20,19 @@ public class Pagination {
 
         Offsets offsets = new Offsets(Math.min(numHits, maxItems), queryParams.limit, queryParams.offset);
 
-        result.put("first", Map.of(JsonLd.ID_KEY, makeFindUrlNoOffset(queryTree, queryParams)));
-        result.put("last", Map.of(JsonLd.ID_KEY, makeFindUrlWithOffset(queryTree, queryParams, offsets.last)));
+        result.put("first", Map.of(JsonLd.ID_KEY, makeFindUrl(queryTree, queryParams, 0)));
+        result.put("last", Map.of(JsonLd.ID_KEY, makeFindUrl(queryTree, queryParams, offsets.last)));
 
         if (offsets.prev != null) {
             if (offsets.prev == 0) {
                 result.put("previous", result.get("first"));
             } else {
-                result.put("previous", Map.of(JsonLd.ID_KEY, makeFindUrlWithOffset(queryTree, queryParams, offsets.prev)));
+                result.put("previous", Map.of(JsonLd.ID_KEY, makeFindUrl(queryTree, queryParams, offsets.prev)));
             }
         }
 
         if (offsets.next != null) {
-            result.put("next", Map.of(JsonLd.ID_KEY, makeFindUrlWithOffset(queryTree, queryParams, offsets.next)));
+            result.put("next", Map.of(JsonLd.ID_KEY, makeFindUrl(queryTree, queryParams, offsets.next)));
         }
 
         return result;

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 import static whelk.component.ElasticSearch.flattenedLangMapKey;
 import static whelk.search2.EsBoost.addBoosts;
 import static whelk.search2.QueryUtil.castToStringObjectMap;
-import static whelk.search2.QueryUtil.makeFindUrlNoOffset;
+import static whelk.search2.QueryUtil.makeViewFindUrl;
 
 public class Query {
     protected final Whelk whelk;
@@ -503,7 +503,7 @@ public class Query {
                     Map<String, Object> observation = new LinkedHashMap<>();
 
                     observation.put("totalItems", count);
-                    observation.put("view", Map.of(JsonLd.ID_KEY, makeFindUrlNoOffset(alteredTree, queryParams)));
+                    observation.put("view", Map.of(JsonLd.ID_KEY, makeViewFindUrl(alteredTree, queryParams)));
                     observation.put("object", v instanceof Resource r ? r.description() : v.toString());
                     if (connective == Connective.OR) {
                         observation.put("_selected", isSelected);
@@ -547,7 +547,7 @@ public class Query {
             String templateQueryString = queryTree.remove(selectedFilters.getSelected(propertyKey))
                     .add(placeholderNode)
                     .toQueryString();
-            String templateUrl = makeFindUrlNoOffset(templateQueryString, queryParams);
+            String templateUrl = QueryUtil.makeViewFindUrl(templateQueryString, queryParams);
 
             Function<Operator, String> getLimit = op -> selectedFilters.getRangeSelected(propertyKey)
                     .stream()
@@ -597,7 +597,7 @@ public class Query {
                 // TODO: fix form
                 res.put("totalItems", 0);
                 res.put("object", f.description());
-                res.put("view", Map.of(JsonLd.ID_KEY, makeFindUrlNoOffset(alteredTree, queryParams)));
+                res.put("view", Map.of(JsonLd.ID_KEY, makeViewFindUrl(alteredTree, queryParams)));
                 res.put("_selected", isSelected);
 
                 results.add(res);

--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -18,8 +18,11 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static whelk.search2.QueryParams.ApiParams.OBJECT;
 import static whelk.search2.QueryParams.ApiParams.OFFSET;
+import static whelk.search2.QueryParams.ApiParams.PREDICATES;
 import static whelk.search2.QueryParams.ApiParams.QUERY;
+import static whelk.search2.QueryParams.ApiParams.SORT;
 
 public class QueryUtil {
     private static final Escaper QUERY_ESCAPER = UrlEscapers.urlFormParameterEscaper();
@@ -52,32 +55,32 @@ public class QueryUtil {
         return m;
     }
 
-    public static String makeFindUrlNoOffset(QueryTree qt, QueryParams queryParams) {
-        return makeFindUrlNoOffset(qt.toQueryString(), queryParams);
+    public static String makeViewFindUrl(QueryTree qt, QueryParams queryParams) {
+        return makeViewFindUrl(qt.toQueryString(), queryParams);
     }
 
-    public static String makeFindUrlNoOffset(String q, QueryParams queryParams) {
-        return makeFindUrl(q, queryParams.getNonQueryParamsNoOffset());
-    }
-
-    public static String makeFindUrlWithOffset(QueryTree qt, QueryParams queryParams, int offset) {
-        return makeFindUrl(qt.toQueryString(), queryParams.getNonQueryParamsNoOffset(), offset);
+    public static String makeViewFindUrl(String q, QueryParams queryParams) {
+        return makeFindUrl(q, queryParams.getCustomParamsMap(List.of(SORT, OBJECT, PREDICATES)), null);
     }
 
     public static String makeFindUrl(QueryTree qt, QueryParams queryParams) {
-        return makeFindUrl(qt.toQueryString(), queryParams.getNonQueryParams());
+        return makeFindUrl(qt.toQueryString(), queryParams.getFullParamsMap(), null);
     }
 
-    private static String makeFindUrl(String q, Map<String, String> nonQueryParams) {
-        return makeFindUrl(q, nonQueryParams, null);
+    public static String makeFindUrl(QueryTree qt, QueryParams queryParams, Integer customOffset) {
+        return makeFindUrl(qt.toQueryString(), queryParams.getFullParamsMap(), customOffset);
     }
 
-    private static String makeFindUrl(String q, Map<String, String> nonQueryParams, Integer customOffset) {
-        nonQueryParams.put(QUERY, q);
+    private static String makeFindUrl(String q, Map<String, String> params, Integer customOffset) {
+        params.put(QUERY, q);
         if (customOffset != null) {
-            nonQueryParams.put(OFFSET, "" + customOffset);
+            if (customOffset > 0) {
+                params.put(OFFSET, "" + customOffset);
+            } else {
+                params.remove(OFFSET);
+            }
         }
-        return makeFindUrl(nonQueryParams);
+        return makeFindUrl(params);
     }
 
     public static String makeFindUrl(Map<String, String> params) {
@@ -88,7 +91,7 @@ public class QueryUtil {
 
     public static Map<String, String> makeUpLink(QueryTree queryTree, Node n, QueryParams queryParams) {
         QueryTree reducedTree = queryTree.remove(n);
-        String upUrl = makeFindUrlNoOffset(reducedTree, queryParams);
+        String upUrl = makeViewFindUrl(reducedTree, queryParams);
         return Map.of(JsonLd.ID_KEY, upUrl);
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/Spell.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Spell.java
@@ -39,7 +39,7 @@ public class Spell {
             Map<String, Object> m = new LinkedHashMap<>();
             m.put("label", s.text());
             m.put("labelHtml", s.highlighted());
-            m.put("view", Map.of(JsonLd.ID_KEY, QueryUtil.makeFindUrlNoOffset(qt.replaceSimpleFreeText(s.text()), queryParams)));
+            m.put("view", Map.of(JsonLd.ID_KEY, QueryUtil.makeViewFindUrl(qt.replaceSimpleFreeText(s.text()), queryParams)));
             suggestions.add(m);
         }
         return suggestions;

--- a/whelk-core/src/main/groovy/whelk/search2/SuggestQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/SuggestQuery.java
@@ -90,7 +90,9 @@ public class SuggestQuery extends Query {
     @Override
     protected Object doGetEsQueryDsl() {
         applySiteFilters(suggestQueryTree, SearchMode.SUGGEST);
-        return getEsQueryDsl(getEsQuery(suggestQueryTree, List.of()));
+        var queryDsl = getEsQueryDsl(getEsQuery(suggestQueryTree, List.of()));
+        queryDsl.remove("sort");
+        return queryDsl;
     }
 
     private List<Path> getApplicablePredicates(Map<?, ?> item, Map<String, Property> propertyByKey) {

--- a/whelk-core/src/main/groovy/whelk/search2/SuggestQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/SuggestQuery.java
@@ -74,7 +74,7 @@ public class SuggestQuery extends Query {
                                     newCursorPos += 1;
                                 }
                                 return Map.of("_predicate", predicateDefinition,
-                                        "_q", QueryUtil.makeFindUrlNoOffset(q, queryParams),
+                                        "_q", QueryUtil.makeViewFindUrl(q, queryParams),
                                         "_cursor", newCursorPos);
                             })
                             .toList();

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/PathValueSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/PathValueSpec.groovy
@@ -21,7 +21,7 @@ class PathValueSpec extends Specification {
         searchMapping == [
                 'property': ['@id': 'p1', '@type': 'DatatypeProperty'],
                 'equals'  : 'v1',
-                'up'      : ['@id': '/find?_limit=20&_q=*'],
+                'up'      : ['@id': '/find?_q=*'],
                 '_key'    : 'p1.@id',
                 '_value'  : 'v1'
         ]
@@ -41,7 +41,7 @@ class PathValueSpec extends Specification {
                         ]
                 ],
                 'notEquals': ['@id': 'E1', '@type': 'Class'],
-                'up'       : ['@id': '/find?_limit=20&_q=*'],
+                'up'       : ['@id': '/find?_q=*'],
                 '_key'     : 'p1.p2',
                 '_value'   : 'E1'
         ]
@@ -61,7 +61,7 @@ class PathValueSpec extends Specification {
                         ]
                 ],
                 'equals'  : 'v1',
-                'up'      : ['@id': '/find?_limit=20&_q=*'],
+                'up'      : ['@id': '/find?_q=*'],
                 '_key'    : '@reverse.p3.@reverse.p4',
                 '_value'  : 'v1'
         ]

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -119,7 +119,7 @@ class QueryTreeSpec extends Specification {
                                         ],
                                         "equals"  : "something",
                                         "up"      : [
-                                                "@id": "/find?_limit=20&_q=%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
+                                                "@id": "/find?_q=%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
                                         ]
                                 ], [
                                         "or": [[
@@ -129,7 +129,7 @@ class QueryTreeSpec extends Specification {
                                                        ],
                                                        "notEquals": "v3",
                                                        "up"       : [
-                                                               "@id": "/find?_limit=20&_q=something+p4:%22v:4%22+includeA"
+                                                               "@id": "/find?_q=something+p4:%22v:4%22+includeA"
                                                        ],
                                                        "_key"     : "p3",
                                                        "_value"   : "v3"
@@ -140,13 +140,13 @@ class QueryTreeSpec extends Specification {
                                                        ],
                                                        "equals"  : "\"v:4\"",
                                                        "up"      : [
-                                                               "@id": "/find?_limit=20&_q=something+NOT+p3:v3+includeA"
+                                                               "@id": "/find?_q=something+NOT+p3:v3+includeA"
                                                        ],
                                                        "_key"    : "p4",
                                                        "_value"  : "\"v:4\""
                                                ]],
                                         "up": [
-                                                "@id": "/find?_limit=20&_q=something+includeA"
+                                                "@id": "/find?_q=something+includeA"
                                         ]
                                 ], [
                                         "object": [
@@ -168,7 +168,7 @@ class QueryTreeSpec extends Specification {
                                                                                 ],
                                                                                 "notEquals": "A",
                                                                                 "up"       : [
-                                                                                        "@id": "/find?_limit=20&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
+                                                                                        "@id": "/find?_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
                                                                                 ],
                                                                                 "_key"     : "p1",
                                                                                 "_value"   : "A"
@@ -176,18 +176,18 @@ class QueryTreeSpec extends Specification {
                                                                 ],
                                                                 "value" : "excludeA",
                                                                 "up"    : [
-                                                                        "@id": "/find?_limit=20&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
+                                                                        "@id": "/find?_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29+includeA"
                                                                 ]
                                                         ]
                                                 ]
                                         ],
                                         "value" : "includeA",
                                         "up"    : [
-                                                "@id": "/find?_limit=20&_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29"
+                                                "@id": "/find?_q=something+%28NOT+p3:v3+OR+p4:%22v:4%22%29"
                                         ]
                                 ]],
                         "up" : [
-                                "@id": "/find?_limit=20&_q=*"
+                                "@id": "/find?_q=*"
                         ]
                 ]
     }


### PR DESCRIPTION
Enables https://github.com/libris/lxlviewer/pull/1338 (see Jesper's TODO comment). The `_limit` parameter won't be included in find links for facets, pills, suggestions etc. This isn't problem since we have a hard coded default limit (20) as fallback when `_limit` is missing. We probably do want to include `_sort` however, since e.g. removing/adding a filter shouldn't change the sort order.