### PR TITLE
Optimize History initialization

### DIFF
--- a/whelk-core/src/main/groovy/whelk/history/History.java
+++ b/whelk-core/src/main/groovy/whelk/history/History.java
@@ -109,14 +109,9 @@ public class History {
                    the whole containing object (the instance in this case).
             */
             {
+                TrieNode trieRoot = buildTrie(claimedPaths);
                 for (List<Object> claimedPath : claimedPaths) {
-                    boolean existsMoreSpecific = false;
-                    for (List deeperPath : claimedPaths) {
-                        if (isSubList(claimedPath, deeperPath) && deeperPath.size() > claimedPath.size()) {
-                            existsMoreSpecific = true;
-                        }
-                    }
-
+                    boolean existsMoreSpecific = hasMoreSpecific(trieRoot, claimedPath);
                     if (!existsMoreSpecific) {
                         List<Object> finalClaim;
                         if (claimedPath.get(claimedPath.size()-1) instanceof String) {
@@ -166,7 +161,37 @@ public class History {
             }
         }
     }
-        
+
+    private static class TrieNode {
+        Map<Object, TrieNode> children = new HashMap<>();
+        boolean isEnd = false;
+    }
+
+    private static TrieNode buildTrie(List<List<Object>> paths) {
+        TrieNode root = new TrieNode();
+        for (List<Object> path : paths) {
+            TrieNode node = root;
+            for (Object part : path) {
+                node = node.children.computeIfAbsent(part, k -> new TrieNode());
+            }
+            node.isEnd = true;
+        }
+        return root;
+    }
+
+    private static boolean hasMoreSpecific(TrieNode root, List<Object> path) {
+        TrieNode node = root;
+        for (Object part : path) {
+            node = node.children.get(part);
+            if (node == null) {
+                // No more specific path found
+                return false;
+            }
+        }
+        // If there are any children at this point, a more specific path exists
+        return !node.children.isEmpty();
+    }
+
     private static boolean isSubList(List a, List b) {
         if (a.size() > b.size())
             return false;


### PR DESCRIPTION
The history view for certain records didn't seem to work. Turns out that while it works OK in most cases, generating the changeset for records with a very large amount of diffs can take too long (minutes), causing timeouts. The most extreme example is https://libris.kb.se/5phvtdlh579r04n.

I imported https://libris.kb.se/5phvtdlh579r04n and its 787 (!) versions locally. Fetching `http://localhost:8180/5phvtdlh579r04n/_changesets` took 40-60 seconds. Profiling showed that it was mainly caused by `whelk.History.isSubList`.

Previously, for each DocumentVersion, we'd check each claimedPath against every other claimedPath to see if there existed a longer, more specific path, doing a list comparison to see if list A was a prefix of list B. For this particular record this would result in 2.2 billion calls to isSubList.

I found that using a [trie](https://en.wikipedia.org/wiki/Trie) (aka prefix tree) structure greatly reduced the complexity. With this change, was happens is that for each DocumentVersion, build a trie (a kind of tree structure) for the claimedPaths. Then, for each path, use hasMoreSpecific to see if a more specific path exists, starting at the root of the tree.

Generating the (identical) changeset now only takes a couple of seconds, with buildTrie/hasMoreSpecific taking less than 100 ms in total.