### PR TITLE
feat(search): Make contribution nested

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -396,6 +396,15 @@
                 }
             },
             {
+                "contribution_template": {
+                    "path_match": ["contribution", "instanceOf.contribution", "@reverse.instanceOf.contribution"],
+                    "mapping": {
+                        "type": "nested",
+                        "include_in_parent": true
+                    }
+                }
+            },
+            {
                 "reverse_itemOf_template": {
                     "path_match": ["@reverse.itemOf", "@reverse.instanceOf.@reverse.itemOf"],
                     "mapping": {


### PR DESCRIPTION
Enables faceting on contribution role.
We should maybe explore if this is better done through "virtual relations" instead.

Let's keep track of indexing speed and no of docs in index.

Existing lxl-web and cataloging facet on Work and instance contribution still works.