### PR TITLE
Feature/lws 401 top level index field

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -443,7 +443,7 @@
             },
             {
                 "str_template": {
-                    "match": ["_topChipStr"],
+                    "match": ["_topStr"],
                     "mapping": {
                         "fields": {
                             "exact": {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -444,8 +444,8 @@ class ElasticSearch {
         }
         String thingId = thingIds.get(0)
 
-        Map framed = JsonLd.frame(thingId, copy.data)
-        Map searchCard = toSearchCard(whelk, framed, links)
+        Map framedFull = JsonLd.frame(thingId, copy.data)
+        Map searchCard = toSearchCard(whelk, framedFull, links)
 
         searchCard['_links'] = links
         searchCard['_outerEmbellishments'] = copy.getEmbellishments() - links
@@ -469,16 +469,16 @@ class ElasticSearch {
         ]
 
         searchCard['_sortKeyByLang'] = whelk.jsonld.applyLensAsMapByLang(
-                framed,
+                framedFull,
                 whelk.jsonld.locales as Set,
                 REMOVABLE_BASE_URIS,
                 document.getThingInScheme() ? ['tokens', 'chips'] : ['chips'])
 
         try {
-            var topLens = whelk.fresnelUtil.applyLens(framed, FresnelUtil.LensGroupName.SearchToken, NO_FALLBACK)
+            var topLens = whelk.fresnelUtil.applyLens(framedFull, FresnelUtil.LensGroupName.SearchToken, NO_FALLBACK)
             if (topLens.isEmpty()) {
                 // If there is no search token, take first property of chip instead
-                topLens = whelk.fresnelUtil.applyLens(framed, FresnelUtil.LensGroupName.Chip, TAKE_FIRST_SHOW_PROPERTY)
+                topLens = whelk.fresnelUtil.applyLens(framedFull, FresnelUtil.LensGroupName.Chip, TAKE_FIRST_SHOW_PROPERTY)
             }
             var topStr = topLens.byLang().subMap(whelk.jsonld.locales).values()
                     ?: topLens.byScript().values()
@@ -486,9 +486,9 @@ class ElasticSearch {
             if (topStr) {
                 searchCard[TOP_STR] = topStr
             }
-            searchCard[CHIP_STR] = whelk.fresnelUtil.applyLens(framed, FresnelUtil.LensGroupName.Chip, TAKE_ALL_ALTERNATE).asString()
-            searchCard[CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
-            searchCard[SEARCH_CARD_STR] = whelk.fresnelUtil.applyLens(framed, Lenses.SEARCH_CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
+            searchCard[CHIP_STR] = whelk.fresnelUtil.applyLens(framedFull, FresnelUtil.LensGroupName.Chip, TAKE_ALL_ALTERNATE).asString()
+            searchCard[CARD_STR] = whelk.fresnelUtil.applyLens(framedFull, Lenses.CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
+            searchCard[SEARCH_CARD_STR] = whelk.fresnelUtil.applyLens(framedFull, Lenses.SEARCH_CARD_ONLY, TAKE_ALL_ALTERNATE).asString()
         } catch (Exception e) {
             log.error(e, e)
         }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -480,7 +480,7 @@ class ElasticSearch {
                 // If there is no search token, take first property of chip instead
                 topLens = whelk.fresnelUtil.applyLens(framedFull, FresnelUtil.LensGroupName.Chip, TAKE_FIRST_SHOW_PROPERTY)
             }
-            var topStr = topLens.byLang().subMap(whelk.jsonld.locales).values()
+            var topStr = topLens.byLang().subMap(whelk.jsonld.locales).values() // The values follow the key order in whelk.jsonld.locales (see subMap method implementation)
                     ?: topLens.byScript().values()
                     ?: topLens.asString()
             if (topStr) {

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -15,8 +15,8 @@ import static whelk.search2.QueryUtil.shouldWrap;
 public class EsBoost {
     // TODO: Don't hardcode boost configuration
     public static List<String> BOOST_FIELDS = List.of(
-            "_topChipStr^400(_score / (doc['_topChipStr.length'].size() == 0 || doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
-            "_topChipStr.exact^400(_score / (doc['_topChipStr.length'].size() == 0 || doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
+            "_topStr^400(_score / (doc['_topStr.length'].size() == 0 || doc['_topStr.length'].value == 0 ? 1 : doc['_topStr.length'].value))",
+            "_topStr.exact^400(_score / (doc['_topStr.length'].size() == 0 || doc['_topStr.length'].value == 0 ? 1 : doc['_topStr.length'].value))",
             "_chipStr^200",
             "_chipStr.exact^200",
             "_cardStr^50",

--- a/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsBoost.java
@@ -15,8 +15,8 @@ import static whelk.search2.QueryUtil.shouldWrap;
 public class EsBoost {
     // TODO: Don't hardcode boost configuration
     public static List<String> BOOST_FIELDS = List.of(
-            "_topChipStr^400(_score / (doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
-            "_topChipStr.exact^400(_score / (doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
+            "_topChipStr^400(_score / (doc['_topChipStr.length'].size() == 0 || doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
+            "_topChipStr.exact^400(_score / (doc['_topChipStr.length'].size() == 0 || doc['_topChipStr.length'].value == 0 ? 1 : doc['_topChipStr.length'].value))",
             "_chipStr^200",
             "_chipStr.exact^200",
             "_cardStr^50",

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -394,7 +394,7 @@ public class FresnelUtil {
 
         @Override
         public boolean isEmpty() {
-            return orderedProps.isEmpty();
+            return orderedSelection.isEmpty();
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -317,6 +317,8 @@ public class FresnelUtil {
             return asLangMap(byScript(new LinkedHashMap<>()));
         }
 
+        public abstract boolean isEmpty();
+
         protected abstract StringBuilder printTo(StringBuilder s);
 
         protected abstract Map<LangCode, StringBuilder> byLang(Map<LangCode, StringBuilder> stringsByLang);
@@ -391,6 +393,11 @@ public class FresnelUtil {
         }
 
         @Override
+        protected boolean isEmpty() {
+            return orderedProps.isEmpty();
+        }
+
+        @Override
         protected StringBuilder printTo(StringBuilder s) {
             orderedSelection.forEach(p -> printTo(s, p.value));
             return s;
@@ -460,6 +467,11 @@ public class FresnelUtil {
         Map<LangCode, Node> transliterations = new HashMap<>();
         void add(LangCode langCode, Node node) {
             transliterations.put(langCode, node);
+        }
+
+        @Override
+        protected boolean isEmpty() {
+            return transliterations.values().stream().allMatch(Node::isEmpty);
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -677,8 +677,7 @@ public class FresnelUtil {
             case Card -> LensGroupName.Chip;
             case Chip, Token -> LensGroupName.Token;
 
-            case SearchCard -> LensGroupName.SearchChip;
-            case SearchChip -> LensGroupName.Token; // TODO ??
+            case SearchCard, SearchChip -> LensGroupName.SearchChip;
             case SearchToken -> LensGroupName.SearchToken;
         };
     }

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -393,7 +393,7 @@ public class FresnelUtil {
         }
 
         @Override
-        protected boolean isEmpty() {
+        public boolean isEmpty() {
             return orderedProps.isEmpty();
         }
 
@@ -470,7 +470,7 @@ public class FresnelUtil {
         }
 
         @Override
-        protected boolean isEmpty() {
+        public boolean isEmpty() {
             return transliterations.values().stream().allMatch(Node::isEmpty);
         }
 

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -384,13 +384,13 @@ public class FresnelUtil {
 
         @Override
         public Map<LangCode, StringBuilder> byLang(Map<LangCode, StringBuilder> stringsByLang) {
-            orderedProps.forEach(prop -> byLang(stringsByLang, prop.value()));
+            orderedSelection.forEach(p -> byLang(stringsByLang, p.value()));
             return stringsByLang;
         }
 
         @Override
         protected Map<LangCode, StringBuilder> byScript(Map<LangCode, StringBuilder> stringsByLang) {
-            orderedProps.forEach(prop -> byScript(stringsByLang, prop.value()));
+            orderedSelection.forEach(p -> byScript(stringsByLang, p.value()));
             return stringsByLang;
         }
 

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -108,7 +108,45 @@ class FresnelUtilSpec extends Specification {
 
             ],
             "lensGroups": [
-                    "tokens":
+                    "search-tokens": [
+                            "@id"   : "search-tokens",
+                            "@type" : "fresnel:Group",
+                            "lenses": [
+                                    "Work"  : [
+                                            "@type"          : "fresnel:Lens",
+                                            "classLensDomain": "Work",
+                                            "showProperties" : [
+                                                    [
+                                                            // TODO
+//                                                            "alternateProperties": [
+//                                                                    [
+//                                                                            "@type" : "fresnel:fslselector",
+//                                                                            "@value": "hasTitle/Title/mainTitle"
+//                                                                    ],
+//                                                                    [
+//                                                                            "@type" : "fresnel:fslselector",
+//                                                                            "@value": "hasTitle/KeyTitle/mainTitle"
+//                                                                    ],
+//                                                                    [
+//                                                                            "@type" : "fresnel:fslselector",
+//                                                                            "@value": "hasTitle/*/mainTitle"
+//                                                                    ]
+//                                                            ]
+                                                    ]
+                                            ]
+                                    ],
+                                    "Person": [
+                                            "@type"          : "fresnel:Lens",
+                                            "classLensDomain": "Person",
+                                            "showProperties" : [
+                                                    "givenName",
+                                                    "familyName",
+                                                    "name"
+                                            ]
+                                    ]
+                            ]
+                    ],
+                    "tokens"       :
                             ["lenses": [
                                     "Contribution": [
                                             "@id"            : "Contribution-tokens",
@@ -117,7 +155,7 @@ class FresnelUtilSpec extends Specification {
                                             "showProperties" : ["agent"]
                                     ],
                             ]],
-                    "chips" :
+                    "chips"        :
                             ["lenses": [
                                     "Contribution": [
                                             "@id"            : "Contribution-chips",
@@ -186,7 +224,7 @@ class FresnelUtilSpec extends Specification {
                                             ]
                                     ],
                             ]],
-                    "cards" :
+                    "cards"        :
                             ["lenses": [
                                     "Work": [
                                             "@id"            : "Work-cards",
@@ -706,9 +744,9 @@ class FresnelUtilSpec extends Specification {
         when:
         thing = [
                 '@type'   : 'Work',
-                'hasTitle': [['@type': 'Title',
+                'hasTitle': [['@type'          : 'Title',
                               'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"],
-                              'subtitleByLang': ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
+                              'subtitleByLang' : ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
                 'language': [
                         ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
                 ]
@@ -721,9 +759,9 @@ class FresnelUtilSpec extends Specification {
         when:
         thing = [
                 '@type'   : 'Work',
-                'hasTitle': [['@type': 'Title',
+                'hasTitle': [['@type'          : 'Title',
                               'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"],
-                              'subtitleByLang': ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
+                              'subtitleByLang' : ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
                 'language': [
                         ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
                 ]
@@ -732,5 +770,57 @@ class FresnelUtilSpec extends Specification {
 
         then:
         chip.byScript() == ['grc': 'Νεφέλαι Λυσιστράτη Svenska Swedish', 'grc-Latn-t-grc-Grek-x0-skr-1980': 'Nephelai Lysistratē Svenska Swedish']
+    }
+
+    def "search-tokens"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing
+        var searchToken
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title', 'mainTitle': 'Titel'], ['@type': 'VariantTitle', 'mainTitle': 'variant title']],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        searchToken = fresnel.applyLens(thing, FresnelUtil.LensGroupName.SearchToken, FresnelUtil.Options.NO_FALLBACK)
+
+        then:
+        searchToken.asString() == "" //TODO
+
+        when:
+        thing = [
+                '@type'     : 'Person',
+                'givenName' : 'Namn',
+                'familyName': 'Namnsson',
+                'lifeSpan'  : '1990-'
+        ]
+        searchToken = fresnel.applyLens(thing, FresnelUtil.LensGroupName.SearchToken, FresnelUtil.Options.NO_FALLBACK)
+
+        then:
+        searchToken.asString() == "Namn Namnsson"
+
+        when:
+        thing = [
+                '@type'    : 'Topic',
+                'prefLabel': 'Hästar'
+        ]
+        searchToken = fresnel.applyLens(thing, FresnelUtil.LensGroupName.SearchToken, FresnelUtil.Options.NO_FALLBACK)
+
+        then:
+        searchToken.asString() == ""
+
+        when:
+        thing = [
+                '@type'    : 'Topic',
+                'prefLabel': 'Hästar'
+        ]
+        searchToken = fresnel.applyLens(thing, FresnelUtil.LensGroupName.SearchToken)
+
+        then:
+        searchToken.asString() == "Hästar"
     }
 }

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -609,4 +609,128 @@ class FresnelUtilSpec extends Specification {
         ["hasTitle/KeyTitle/mainTitle", "hasTitle/VariantTitle/mainTitle"] | "variant title"       | "variant title"
         ["hasTitle/KeyTitle/mainTitle", "hasTitle/*/mainTitle"]            | "Titel variant title" | "Titel variant title"
     }
+
+    def "Take first in showProperties"() {
+        given:
+        var thing = [
+                '@type'   : 'Work',
+                'hasTitle': title,
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        var fresnel = new FresnelUtil(ld)
+        var first = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip, FresnelUtil.Options.TAKE_FIRST_SHOW_PROPERTY)
+
+        expect:
+        first.asString() == res
+
+        where:
+        title                                                                                                                                | res
+        [['@type': 'Title', 'mainTitle': 'Titel'], ['@type': 'VariantTitle', 'mainTitle': 'variant title']]                                  | "Titel"
+        [['@type': 'VariantTitle', 'mainTitle': 'variant title']]                                                                            | 'variant title'
+        [['@type': 'Title', 'mainTitleByLang': ['sv': 'Titel', 'en': 'Title']]]                                                              | "Titel Title"
+        [['@type': 'Title', 'mainTitleByLang': ['sv': 'Titel', 'en': 'Title'], 'subtitle': 'subtitle']]                                      | "Titel Title subtitle"
+        [['@type': 'Title', 'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"], 'subtitle': 'Lysistratē']] | "Nephelai Lysistratē Νεφέλαι Lysistratē"
+    }
+
+    def "Split up strings by language"() {
+        given:
+        var thing = [
+                '@type'   : 'Work',
+                'hasTitle': title,
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        var fresnel = new FresnelUtil(ld)
+        var chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        expect:
+        chip.byLang() == res
+
+        where:
+        title                                                                                                      | res
+        [['@type': 'Title', 'mainTitle': 'Titel'], ['@type': 'VariantTitle', 'mainTitle': 'variant title']]        | ['sv': 'Titel Svenska', 'en': 'Titel Swedish']
+        [['@type': 'VariantTitle', 'mainTitle': 'variant title']]                                                  | ['sv': 'variant title Svenska', 'en': 'variant title Swedish']
+        [['@type': 'Title', 'mainTitleByLang': ['sv': 'Titel', 'en': 'Title']]]                                    | ['sv': 'Titel Svenska', 'en': 'Title Swedish']
+        [['@type': 'Title', 'mainTitleByLang': ['sv': 'Titel', 'en': 'Title'], 'subtitle': 'subtitle']]            | ['sv': 'Titel subtitle Svenska', 'en': 'Title subtitle Swedish']
+        [['@type': 'Title', 'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"]]] | ['sv': 'Nephelai Νεφέλαι Svenska', 'en': 'Nephelai Νεφέλαι Swedish']
+    }
+
+    def "Split up strings by script language"() {
+        given:
+        var fresnel = new FresnelUtil(ld)
+        var thing
+        var chip
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title', 'mainTitle': 'Titel'], ['@type': 'VariantTitle', 'mainTitle': 'variant title']],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        then:
+        chip.byScript() == [:]
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title', 'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"]]],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        then:
+        chip.byScript() == ['grc': 'Νεφέλαι Svenska Swedish', 'grc-Latn-t-grc-Grek-x0-skr-1980': 'Nephelai Svenska Swedish']
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title', 'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"], 'subtitle': 'subtitle']],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        then:
+        chip.byScript() == ['grc': 'Νεφέλαι subtitle Svenska Swedish', 'grc-Latn-t-grc-Grek-x0-skr-1980': 'Nephelai subtitle Svenska Swedish']
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title',
+                              'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"],
+                              'subtitleByLang': ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        then:
+        chip.byScript() == ['grc': 'Νεφέλαι Λυσιστράτη Svenska Swedish', 'grc-Latn-t-grc-Grek-x0-skr-1980': 'Nephelai Lysistratē Svenska Swedish']
+
+        when:
+        thing = [
+                '@type'   : 'Work',
+                'hasTitle': [['@type': 'Title',
+                              'mainTitleByLang': ["grc": "Νεφέλαι", "grc-Latn-t-grc-Grek-x0-skr-1980": "Nephelai"],
+                              'subtitleByLang': ["grc": "Λυσιστράτη", "grc-Latn-t-grc-Grek-x0-skr-1980": "Lysistratē"]]],
+                'language': [
+                        ['@type': 'Language', 'code': 'sv', 'labelByLang': ['en': 'Swedish', 'sv': 'Svenska']],
+                ]
+        ]
+        chip = fresnel.applyLens(thing, FresnelUtil.LensGroupName.Chip)
+
+        then:
+        chip.byScript() == ['grc': 'Νεφέλαι Λυσιστράτη Svenska Swedish', 'grc-Latn-t-grc-Grek-x0-skr-1980': 'Nephelai Lysistratē Svenska Swedish']
+    }
 }

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -117,21 +117,20 @@ class FresnelUtilSpec extends Specification {
                                             "classLensDomain": "Work",
                                             "showProperties" : [
                                                     [
-                                                            // TODO
-//                                                            "alternateProperties": [
-//                                                                    [
-//                                                                            "@type" : "fresnel:fslselector",
-//                                                                            "@value": "hasTitle/Title/mainTitle"
-//                                                                    ],
-//                                                                    [
-//                                                                            "@type" : "fresnel:fslselector",
-//                                                                            "@value": "hasTitle/KeyTitle/mainTitle"
-//                                                                    ],
-//                                                                    [
-//                                                                            "@type" : "fresnel:fslselector",
-//                                                                            "@value": "hasTitle/*/mainTitle"
-//                                                                    ]
-//                                                            ]
+                                                            "alternateProperties": [
+                                                                    [
+                                                                            "@type" : "fresnel:fslselector",
+                                                                            "@value": "hasTitle/Title/mainTitle"
+                                                                    ],
+                                                                    [
+                                                                            "@type" : "fresnel:fslselector",
+                                                                            "@value": "hasTitle/KeyTitle/mainTitle"
+                                                                    ],
+                                                                    [
+                                                                            "@type" : "fresnel:fslselector",
+                                                                            "@value": "hasTitle/*/mainTitle"
+                                                                    ]
+                                                            ]
                                                     ]
                                             ]
                                     ],
@@ -789,7 +788,7 @@ class FresnelUtilSpec extends Specification {
         searchToken = fresnel.applyLens(thing, FresnelUtil.LensGroupName.SearchToken, FresnelUtil.Options.NO_FALLBACK)
 
         then:
-        searchToken.asString() == "" //TODO
+        searchToken.asString() == "Titel"
 
         when:
         thing = [


### PR DESCRIPTION
The field that we've called `_topChipStr` (now renamed to `_topStr` (open to other suggestions)) should contain only the very most essential properties to a thing described in a document. Most often this coincides with the first property of chip, however not always, and we've experimented with temporary hard coded solutions while figuring out exactly what should be included in this field. Now it's time to replace the temporary stuff with a more formal implementation.

- Handle new lens group `search-token` defined in https://github.com/libris/definitions/pull/534. If there is a `search-token` lens definition for a given entity, then `_topStr` should be set to the string representation after applying that lens.
- If there isn't a `search-token`, take the first property of chip instead. (Is this necessary? We could also just define `search-token` lenses for all searchable types.)
- Keep language tagged strings separate, i.e. if we have
`{ "@type": "Language", "prefLabelByLang": { "sv": "Svenska", "en": "English"  } }`
then 
`_topStr = [ "Svenska", "Engelska" ]`
`_topStr.length = [ 1, 1 ]` (see [config](https://github.com/libris/librisxl/blob/debfb3f7f084fa7b1221da684a61ff9dada4e776/librisxl-tools/elasticsearch/libris_config.json#L445))
rather than
`_topStr = "Svenska Engelska"`
`_topStr.length = 2`
With the latter values we'd end up with a misapplied "[length normalization](https://github.com/libris/librisxl/blob/debfb3f7f084fa7b1221da684a61ff9dada4e776/whelk-core/src/main/groovy/whelk/search2/EsBoost.java#L18)" on the `_topStr` field, where for example the score from the query term "Svenska" would be divided in half even though it's an exact match.
By keeping language tagged strings as separate array elements we get a more accurate length normalization, however not always perfect, since the number of tokens may differ between languages (e.g. "Nordirland" vs "Northern Ireland") and there is no mapping between the elements in `_topStr` (=`["Nordirland", "Northern Ireland"]`) and `_topStr.length` (=`[1, 2]`), so the value to use in the score function will be picked arbitrarily. In most cases the number of tokens won't differ between languages though so this shouldn't be a big problem. A possible improvement would be to take the average of the values in `_topStr.length` but I didn't manage to find a built-in function doing that.
- The last two commits, [0e7dd89](https://github.com/libris/librisxl/pull/1612/commits/0e7dd8909cf10c5f4479b77bad25126a687e7e11) and [debfb3f](https://github.com/libris/librisxl/pull/1612/commits/debfb3f7f084fa7b1221da684a61ff9dada4e776) are necessary for https://github.com/libris/definitions/commit/6b8332decff4ab661e146ca689adf170585ce270 to take effect and are independent from the rest in this PR. 
- See individual commits for details.