### PR TITLE
feat(search): Handle ISBNs with hyphens

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -153,6 +153,12 @@ public record FreeText(Property.TextQuery textQuery, boolean negate, List<Token>
     private Map<String, Object> _toEs(List<Token> tokens, EsBoost.Config boostConfig) {
         String s = joinTokens(tokens, " ");
         s = Unicode.normalizeForSearch(s);
+
+        // TODO search for original string OR stripped string?
+        if (Unicode.looksLikeIsbn(s) && s.contains("-")) {
+            s = s.replace("-", "");
+        }
+
         boolean isSimple = isSimple(s);
         String queryMode = isSimple ? "simple_query_string" : "query_string";
         if (!isSimple) {

--- a/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Unicode.groovy
@@ -321,4 +321,11 @@ class Unicode {
                 ? isni.split("").collate(4).collect{ it.join() }.join(" ")
                 : isni
     }
+
+    private static var ISBN10 = Pattern.compile("(?:\\d-?){9}(?:\\d|X)").asMatchPredicate()
+    private static var ISBN13 = Pattern.compile("(?:978|979)(?:-?\\d){10}").asMatchPredicate()
+
+    static boolean looksLikeIsbn(String s) {
+        return ISBN10.test(s) || ISBN13.test(s)
+    }
 }

--- a/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/UnicodeSpec.groovy
@@ -205,4 +205,25 @@ class UnicodeSpec extends Specification {
         '143256' | '123456'  || 2
         'abc'    | '1234567' || 7
     }
+
+    def "looksLikeIsbn"() {
+        expect:
+        Unicode.looksLikeIsbn(s) == result
+
+        where:
+        s                   | result
+        '978-917-8034-239'  | true
+        '917-8034-239'      | true
+        '0-8044-2957-X'     | true
+        '080442957X'        | true
+        '0-8044-2957-4'     | true  // bad checksum still looks like ISBN
+        '979-917-8034-239'  | true  // Newer ISBN or "music land"
+        '9789177483922'     | true
+        '978--917-8034-239' | false
+        '980-917-8034-239'  | false  // Not book or music land
+        '978917748392X'     | false  // X is not used as check digit in ISBN-13
+        '978917748392'      | false
+        '978-917-8034-23-'  | false
+        '978-917-8034-23-'  | false
+    }
 }


### PR DESCRIPTION
Remove hyphens from strings that look like ISBNs in queries. e.g. 978-917-8034-239
For now only works if the whole query is an ISBN.
Should we update it to search for both the original string and the one with hyphens removed?