### PR TITLE
feat(search): Also index ISMN without hyphen

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -572,6 +572,7 @@ class ElasticSearch {
 
             var ids = (Collection<Map>) value
             addIdentifierForms(ids, 'ISBN', this::getOtherIsbns)
+            addIdentifierForms(ids, 'ISMN', c -> c.findAll{ it.contains("-") }.collect { it.replace("-", "") })
             addIdentifierForms(ids, 'ISNI', this::getFormattedIsnis)
             addIdentifierForms(ids, 'ORCID', this::getFormattedIsnis) // ORCID is a subset of ISNI, same format
 


### PR DESCRIPTION
So that the ISBN normalization in search2 also catches ISMNs that are not normalized in lddb.