### PR TITLE
perf: Speed up DocumentUtil.traverse

### DIFF
--- a/whelk-core/src/main/groovy/whelk/util/DFS.java
+++ b/whelk-core/src/main/groovy/whelk/util/DFS.java
@@ -1,0 +1,59 @@
+package whelk.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+// This is a straightforward port of the old groovy version in DocumentUtil. Can probably be improved
+class DFS {
+    private Stack<Object> path;
+    private DocumentUtil.Visitor visitor;
+    private List<DocumentUtil.Operation> operations;
+
+    private record Node(Object value, Object keyOrIndex) {}
+
+    public boolean traverse(final Object obj, DocumentUtil.Visitor visitor) {
+        this.visitor = visitor;
+        path = new Stack<>();
+        operations = new ArrayList<>();
+
+        node(obj);
+
+        Collections.reverse(operations);
+        for  (DocumentUtil.Operation op : operations) {
+            op.perform(obj);
+        };
+        return !operations.isEmpty();
+    }
+
+    private void node(Object obj) {
+        var op = visitor.visitElement(obj, Collections.unmodifiableList(path));
+        if (op != null && !(op instanceof DocumentUtil.Nop)) {
+            op.setPath(path);
+            operations.add(op);
+        }
+
+        if (obj instanceof Map<?, ?> map) {
+            var nodes = map.entrySet().stream()
+                    .map(e -> new Node(e.getValue(), e.getKey()))
+                    .toList();
+            descend(nodes);
+        } else if (obj instanceof List<?> list) {
+            var nodes = new ArrayList<Node>(list.size());
+            for (int i = 0 ; i < list.size() ; i++) {
+                nodes.add(new Node(list.get(i), i));
+            }
+            descend(nodes);
+        }
+    }
+
+    private void descend(List<Node> nodes) {
+        for (var n : nodes) {
+            path.push(n.keyOrIndex);
+            node(n.value);
+            path.pop();
+        }
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/DocumentUtil.groovy
@@ -183,45 +183,6 @@ class DocumentUtil {
         nodes.findAll { !isBlank(it) }.collect { it['@id'] }
     }
 
-    private static class DFS {
-        Stack path
-        Visitor visitor
-        List operations
-
-        boolean traverse(obj, Visitor visitor) {
-            this.visitor = visitor
-            path = new Stack()
-            operations = []
-
-            node(obj)
-            operations = operations.reverse().each { it.perform(obj) }
-            return !operations.isEmpty()
-        }
-
-        private void node(obj) {
-            Operation op = visitor.visitElement(obj, Collections.unmodifiableList(path))
-            if (op && !(op instanceof Nop)) {
-                op.setPath(path)
-                operations.add(op)
-            }
-
-            if (obj instanceof Map) {
-                descend(((Map) obj).entrySet().collect({ new Tuple2(it.value, it.key) }))
-            } else if (obj instanceof List) {
-                descend(((List) obj).withIndex())
-            }
-        }
-
-        private void descend(List<Tuple2> nodes) {
-            for (n in nodes) {
-                path.push(n.v2)
-                node(n.v1)
-                path.pop()
-            }
-        }
-    }
-
-
     static abstract class Operation {
         List path
 


### PR DESCRIPTION
It is used in many places, e.g. when shaping docs for ES indexing.

Just porting it to Java without any other changes cut indexing time with xx% on my computer.
It can probably be improved.

Before
<img width="1002" height="473" alt="Skärmbild från 2025-08-28 13-42-44" src="https://github.com/user-attachments/assets/d940329a-96d3-4b9e-83b7-2787f89b5451" />

After
<img width="978" height="432" alt="Skärmbild från 2025-08-28 13-46-09" src="https://github.com/user-attachments/assets/06de5d1d-f8f5-4b07-8321-c883b0fa5fc7" />

Before
<img width="1025" height="337" alt="Skärmbild från 2025-08-28 13-19-46" src="https://github.com/user-attachments/assets/557d02cb-e4c2-4e50-a1ae-3f54c4d2182a" />

After
<img width="1025" height="309" alt="Skärmbild från 2025-08-28 13-43-18" src="https://github.com/user-attachments/assets/ee13fb61-0419-49be-8297-6037a6013262" />



Seems like it was partly because of lock contention in the groovy interpreter. on org.codehaus.groovy.vmplugin.v8.CacheableCallsite at DFS.node/descend?
<img width="1677" height="1045" alt="Skärmbild från 2025-08-28 10-01-13" src="https://github.com/user-attachments/assets/9b757d59-9be7-4191-859c-75c53806ffe1" />
