### PR TITLE
feat(xsearch): add more holding data to xsearch responses

### DIFF
--- a/whelk-core/src/main/java/se/kb/libris/export/ExportProfile.java
+++ b/whelk-core/src/main/java/se/kb/libris/export/ExportProfile.java
@@ -567,7 +567,7 @@ public class ExportProfile {
 
     // Interleaved holdings - "Inbäddad beståndsinformation"
     // https://katalogverk.kb.se/katalogisering/Formathandboken/Exportformatet/Bestandsinformation/index.html
-    public MarcRecord mergeBibMfhd(MarcRecord bibRecord, String sigel, MarcRecord mfhdRecord) {
+    public static MarcRecord mergeBibMfhd(MarcRecord bibRecord, String sigel, MarcRecord mfhdRecord) {
         // add 841 field
         Datafield df841 = bibRecord.createDatafield("841");
         df841.addSubfield('5', sigel);


### PR DESCRIPTION
We do need more data when `format_level=full` and `holdings=true`:

`curl -s "http://libris.kb.se/xsearch?query=onr:p43923hpmm2vvns9&format=marcxml&format_level=full&holdings=true&n=1" | xmllint --format - | xq-python .| gron | grep -Po '(?<=\["@tag"\] = ")\d+(?=")' | sort | uniq`

```
001
003
005
008
020
035
040
041
042
082
084
100
240
245
264
300
336
337
338
500
520
521
541
600
650
655
700
841
852
866
887
900
949
950
955
976
```