### PR TITLE
Add option to disable exception handling when creating documents

### DIFF
--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -910,7 +910,7 @@ class CrudSpec extends Specification {
         request.getRequestURL() >> {
             return new StringBuffer(BASE_URI.toString())
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             Document doc = it.first()
             doc.setModified(new Date())
             return doc
@@ -936,7 +936,7 @@ class CrudSpec extends Specification {
         request.getContentType() >> {
             "application/ld+json"
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -959,7 +959,7 @@ class CrudSpec extends Specification {
         request.getContentType() >> {
             "application/x-www-form-urlencoded"
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
 
@@ -995,7 +995,7 @@ class CrudSpec extends Specification {
         request.getRequestURL() >> {
             return new StringBuffer(BASE_URI.toString())
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             Document doc = it.first()
             doc.setModified(new Date())
             return doc
@@ -1099,7 +1099,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1151,7 +1151,7 @@ class CrudSpec extends Specification {
         request.getRequestURL() >> {
             return new StringBuffer(BASE_URI.toString())
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         when:
@@ -1208,7 +1208,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         when:
@@ -1265,7 +1265,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         storage.followDependers(_) >> {
@@ -1319,7 +1319,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1370,7 +1370,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1427,7 +1427,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1483,7 +1483,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         accessControl.checkDocumentToPost(_, _) >> {
@@ -1546,7 +1546,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         when:
@@ -1600,7 +1600,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1660,7 +1660,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         when:
@@ -1719,7 +1719,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return true
         }
         when:
@@ -1778,7 +1778,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         when:
@@ -1831,7 +1831,7 @@ class CrudSpec extends Specification {
         storage.getMainId(_) >> {
             return null
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             return null
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -1859,7 +1859,7 @@ class CrudSpec extends Specification {
         request.getContentType() >> {
             "application/ld+json"
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -1882,7 +1882,7 @@ class CrudSpec extends Specification {
         request.getContentType() >> {
             "application/x-www-form-urlencoded"
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
 
@@ -1939,7 +1939,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             Document doc = new Document(newContent)
             doc.setModified(modifiedDate)
             doc.setCreated(createdDate)
@@ -2003,7 +2003,7 @@ class CrudSpec extends Specification {
         storage.getIdType(_) >> {
             return IdType.RecordSameAsId
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             Document doc = new Document(newContent)
             doc.setModified(modifiedDate)
             doc.setCreated(createdDate)
@@ -2197,7 +2197,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2268,7 +2268,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2335,7 +2335,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2402,7 +2402,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2468,7 +2468,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2535,7 +2535,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2600,7 +2600,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2671,7 +2671,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -2743,7 +2743,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -2804,7 +2804,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -2865,7 +2865,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -2938,7 +2938,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -3005,7 +3005,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -3075,7 +3075,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         accessControl.checkDocumentToPut(_, _, _, _) >> {
@@ -3140,7 +3140,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -3212,7 +3212,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -3271,7 +3271,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         LegacyIntegrationTools.determineLegacyCollection(_, _) >> {
@@ -3349,7 +3349,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:
@@ -3417,7 +3417,7 @@ class CrudSpec extends Specification {
             doc.setCreated(Date.parse(dateFormat, createdDate))
             return doc
         }
-        storage.createDocument(_, _, _, _, _) >> {
+        storage.createDocument(_, _, _, _, _, _) >> {
             throw new Exception("This shouldn't happen")
         }
         when:

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -475,7 +475,7 @@ class Whelk {
     /**
      * NEVER use this to _update_ a document. Use storeAtomicUpdate() instead. Using this for new documents is fine.
      */
-    boolean createDocument(Document document, String changedIn, String changedBy, String collection, boolean deleted) {
+    boolean createDocument(Document document, String changedIn, String changedBy, String collection, boolean deleted, boolean handleExceptions = true) {
         normalize(document)
 
         boolean detectCollisionsOnTypedIDs = false
@@ -485,7 +485,7 @@ class Whelk {
             throw new StorageCreateFailedException(document.getShortId(), "Document considered a duplicate of : " + collidingIDs)
         }
 
-        boolean success = storage.createDocument(document, changedIn, changedBy, collection, deleted)
+        boolean success = storage.createDocument(document, changedIn, changedBy, collection, deleted, handleExceptions)
         if (success) {
             indexAsyncOrSync {
                 elastic.index(document, this)

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -725,7 +725,7 @@ class PostgreSQLComponent {
         }
     }
 
-    boolean createDocument(Document doc, String changedIn, String changedBy, String collection, boolean deleted) {
+    boolean createDocument(Document doc, String changedIn, String changedBy, String collection, boolean deleted, boolean handleExceptions) {
         log.debug("Saving ${doc.getShortId()}, ${changedIn}, ${changedBy}, ${collection}")
 
         return withDbConnection {
@@ -807,6 +807,9 @@ class PostgreSQLComponent {
                 log.debug("Saved document ${doc.getShortId()} with timestamps ${doc.created} / ${doc.modified}")
                 return true
             } catch (Exception e) {
+                if (!handleExceptions) {
+                    throw e;
+                }
                 log.debug("Failed to save document: ${e.message}. Rolling back.")
                 connection.rollback()
                 return false

--- a/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
+++ b/whelktool/src/main/groovy/whelk/datatool/WhelkTool.groovy
@@ -643,7 +643,7 @@ class WhelkTool {
 
         if (!dryRun) {
             var collection = LegacyIntegrationTools.determineLegacyCollection(doc, whelk.getJsonld())
-            if (!whelk.createDocument(doc, changedIn, item.changedBy ?: defaultChangedBy, collection, false))
+            if (!whelk.createDocument(doc, changedIn, item.changedBy ?: defaultChangedBy, collection, false, false))
                 throw new WhelkException("Failed to save a new document. See general whelk log for details.")
         }
         createdLog.println(doc.shortId)


### PR DESCRIPTION
In Whelktool, certain exceptions (such as `ConflictingHoldException`) should be surfaced so they can be handled directly in scripts.

While maybe not the most elegant solution it feels safest to not change the behaviour of `Whelk.createDocument(...)` (used in various places) other than in Whelktool.