### PR TITLE
Feature/sort out year fields

### DIFF
--- a/librisxl-tools/elasticsearch/extract_4_digits.painless
+++ b/librisxl-tools/elasticsearch/extract_4_digits.painless
@@ -16,8 +16,11 @@ while (!stack.isEmpty()) {
           def matcher = /\d{4}/.matcher(value);
           if (matcher.find()) {
               def fourDigitStr = matcher.group(0);
-              updates.put(key + "_4_digits_keyword", fourDigitStr);
-              updates.put(key + "_4_digits_short", Short.parseShort(fourDigitStr));
+              // Exclude known non-year placeholders (0000, 9999) from 4-digit fields.
+              if (fourDigitStr != "0000" && fourDigitStr != "9999") {
+                  updates.put(key + "_4_digits_keyword", fourDigitStr);
+                  updates.put(key + "_4_digits_short", Short.parseShort(fourDigitStr));
+              }
           }
       } else if (value instanceof Map) {
           stack.push(value);

--- a/librisxl-tools/elasticsearch/extract_4_digits.painless
+++ b/librisxl-tools/elasticsearch/extract_4_digits.painless
@@ -1,0 +1,36 @@
+def fourDigitFields = ["year", "startYear", "endYear"];
+
+def stack = new ArrayDeque();
+stack.push(ctx);
+
+while (!stack.isEmpty()) {
+  def current = stack.pop();
+
+  def updates = new HashMap();
+
+  for (entry in current.entrySet()) {
+      def key = entry.getKey();
+      def value = entry.getValue();
+
+      if (value instanceof String && fourDigitFields.contains(key)) {
+          def matcher = /\d{4}/.matcher(value);
+          if (matcher.find()) {
+              def fourDigitStr = matcher.group(0);
+              updates.put(key + "_4_digits_keyword", fourDigitStr);
+              updates.put(key + "_4_digits_int", Integer.parseInt(fourDigitStr));
+          }
+      } else if (value instanceof Map) {
+          stack.push(value);
+      } else if (value instanceof List) {
+          for (elem in value) {
+              if (elem instanceof Map) {
+                  stack.push(elem);
+              }
+          }
+      }
+  }
+
+  for (u in updates.entrySet()) {
+      current.put(u.getKey(), u.getValue());
+  }
+}

--- a/librisxl-tools/elasticsearch/extract_4_digits.painless
+++ b/librisxl-tools/elasticsearch/extract_4_digits.painless
@@ -17,7 +17,7 @@ while (!stack.isEmpty()) {
           if (matcher.find()) {
               def fourDigitStr = matcher.group(0);
               updates.put(key + "_4_digits_keyword", fourDigitStr);
-              updates.put(key + "_4_digits_int", Integer.parseInt(fourDigitStr));
+              updates.put(key + "_4_digits_short", Short.parseShort(fourDigitStr));
           }
       } else if (value instanceof Map) {
           stack.push(value);

--- a/librisxl-tools/elasticsearch/extract_4_digits_pipeline.json
+++ b/librisxl-tools/elasticsearch/extract_4_digits_pipeline.json
@@ -1,0 +1,10 @@
+{
+  "description": "Extract first 4 digits from year-like fields and populate keyword + integer sibling fields",
+  "processors": [
+    {
+      "script": {
+        "id": "extract_4_digits"
+      }
+    }
+  ]
+}

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -24,7 +24,8 @@
                     "b": 0,
                     "k1": 0
                 }
-            }
+            },
+            "default_pipeline": "extract_4_digits_pipeline"
         },
         "index.query.default_field": "_all",
         "analysis": {

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -387,10 +387,10 @@
                 }
             },
             {
-                "4_digits_int_template": {
-                    "match": "*_4_digits_int",
+                "4_digits_short_template": {
+                    "match": "*_4_digits_short",
                     "mapping": {
-                        "type": "integer"
+                        "type": "short"
                     }
                 }
             },

--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -378,19 +378,32 @@
                 }
             },
             {
+                "4_digits_keyword_template": {
+                    "match": "*_4_digits_keyword",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            },
+            {
+                "4_digits_int_template": {
+                    "match": "*_4_digits_int",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
                 "year_template": {
                     "match": ["year", "startYear", "endYear"],
                     "mapping": {
                         "fields": {
                             "keyword": {
-                                "index": true,
                                 "type": "keyword"
                             }
                         },
-                        "analyzer": "numeric_extractor",
-                        "index": true,
+                        "analyzer": "standard",
                         "type": "text",
-                        "fielddata": true,
                         "copy_to": "_all"
                     }
                 }

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -25,7 +25,7 @@ class ESQuery {
     private Whelk whelk
     private JsonLd jsonld
     private Set keywordFields
-    private Set fourDigitIntFields
+    private Set fourDigitShortFields
     private Set fourDigitKeywordFields
     private Set dateFields
     private Set<String> nestedFields
@@ -88,7 +88,7 @@ class ESQuery {
         if (whelk.elastic) {
             Map mappings = whelk.elastic.getMappings()
             this.keywordFields = getKeywordFields(mappings)
-            this.fourDigitIntFields = getFourDigitIntFields(mappings)
+            this.fourDigitShortFields = getFourDigitShortFields(mappings)
             this.fourDigitKeywordFields = getFourDigitKeywordFields(mappings)
             this.dateFields = getFieldsOfType('date', mappings)
             this.nestedFields = getFieldsOfType('nested', mappings)
@@ -571,8 +571,8 @@ class ESQuery {
     private String getInferredSortTermPath(String termPath) {
         termPath = expandLangMapKeys(termPath)
 
-        if ("${termPath}_4_digits_int" as String in fourDigitIntFields) {
-            return "${termPath}_4_digits_int"
+        if ("${termPath}_4_digits_short" as String in fourDigitShortFields) {
+            return "${termPath}_4_digits_short"
         } else if (termPath in keywordFields) {
             return "${termPath}.keyword"
         } else {
@@ -1062,8 +1062,8 @@ class ESQuery {
                     if (parameterNoPrefix in dateFields) {
                         return Ranges.date(parameterNoPrefix, whelk.getTimezone(), whelk)
                     }
-                    def fourDigitsFieldName = parameterNoPrefix + '_4_digits_int'
-                    if (fourDigitsFieldName in fourDigitIntFields) {
+                    def fourDigitsFieldName = parameterNoPrefix + '_4_digits_short'
+                    if (fourDigitsFieldName in fourDigitShortFields) {
                         return Ranges.fourDigits(parameterNoPrefix, fourDigitsFieldName, whelk)
                     }
                     return Ranges.nonDate(parameterNoPrefix, whelk)
@@ -1111,8 +1111,8 @@ class ESQuery {
         return getFieldsByCondition(mappings, { _, Map fieldData -> ((Map) fieldData.get('fields'))?.containsKey('keyword') }, '')
     }
 
-    private static Set getFourDigitIntFields(Map mappings) {
-        return getFieldsByCondition(mappings, { String fieldName, _ -> fieldName.endsWith('_4_digits_int') }, '')
+    private static Set getFourDigitShortFields(Map mappings) {
+        return getFieldsByCondition(mappings, { String fieldName, _ -> fieldName.endsWith('_4_digits_short') }, '')
     }
 
     private static Set getFourDigitKeywordFields(Map mappings) {

--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -25,10 +25,10 @@ class ESQuery {
     private Whelk whelk
     private JsonLd jsonld
     private Set keywordFields
+    private Set fourDigitIntFields
     private Set dateFields
     private Set<String> nestedFields
     private Set<String> nestedNotInParentFields
-    private Set<String> numericExtractorFields
 
     private static final int DEFAULT_PAGE_SIZE = 50
     private static final List RESERVED_PARAMS = [
@@ -87,10 +87,10 @@ class ESQuery {
         if (whelk.elastic) {
             Map mappings = whelk.elastic.getMappings()
             this.keywordFields = getKeywordFields(mappings)
+            this.fourDigitIntFields = getFourDigitIntFields(mappings)
             this.dateFields = getFieldsOfType('date', mappings)
             this.nestedFields = getFieldsOfType('nested', mappings)
             this.nestedNotInParentFields = nestedFields - getFieldsWithSetting('include_in_parent', true, mappings)
-            this.numericExtractorFields = getFieldsWithAnalyzer('numeric_extractor', mappings)
 
             if (DocumentUtil.getAtPath(mappings, ['properties', '_sortKeyByLang', 'properties', 'sv', 'fields', 'trigram'], null)) {
                 ENABLE_SPELL_CHECK = true
@@ -568,7 +568,10 @@ class ESQuery {
 
     private String getInferredSortTermPath(String termPath) {
         termPath = expandLangMapKeys(termPath)
-        if (termPath in keywordFields && termPath !in numericExtractorFields) {
+
+        if ("${termPath}_4_digits_int" as String in fourDigitIntFields) {
+            return "${termPath}_4_digits_int"
+        } else if (termPath in keywordFields) {
             return "${termPath}.keyword"
         } else {
             return termPath
@@ -1078,23 +1081,12 @@ class ESQuery {
         }
     }
 
-    static Set getFieldsOfType(String type, Map mappings) {
+    private static Set getFieldsOfType(String type, Map mappings) {
         getFieldsWithSetting('type', type, mappings)
     }
 
-    static Set getFieldsWithAnalyzer(String analyzer, Map mappings) {
-        getFieldsWithSetting('analyzer', analyzer, mappings)
-    }
-
-    static Set getFieldsWithSetting(String setting, value, Map mappings) {
-        Set fields = [] as Set
-        DocumentUtil.findKey(mappings['properties'], setting) { v, path ->
-            if (v == value) {
-                fields.add(path.dropRight(1).findAll { it != 'properties' }.join('.'))
-            }
-            DocumentUtil.NOP
-        }
-        return fields
+    private static Set getFieldsWithSetting(String setting, value, Map mappings) {
+        return getFieldsByCondition(mappings, { _, Map fieldData -> fieldData[setting] == value }, '')
     }
 
     /**
@@ -1108,26 +1100,25 @@ class ESQuery {
      * Public for test only - don't call outside this class!
      *
      */
-    Set getKeywordFields(Map mappings) {
-        Set keywordFields = [] as Set
+    private static Set getKeywordFields(Map mappings) {
+        return getFieldsByCondition(mappings, { _, Map fieldData -> ((Map) fieldData.get('fields'))?.containsKey('keyword') }, '')
+    }
+
+    private static Set getFourDigitIntFields(Map mappings) {
+        return getFieldsByCondition(mappings, { String fieldName, _ -> fieldName.endsWith('_4_digits_int') }, '')
+    }
+
+    private static Set getFieldsByCondition(Map mappings, Closure cond, String parentName) {
+        Set fields = [] as Set
         if (mappings) {
-            keywordFields = getKeywordFieldsFromProperties(mappings['properties'] as Map)
+            (mappings['properties'] as Map)?.each { fieldName, fieldSettings ->
+                fields += getFieldsByCondition(fieldName as String, fieldSettings as Map, cond, parentName)
+            }
         }
-
-        return keywordFields
+        return fields
     }
 
-    private Set getKeywordFieldsFromProperties(Map properties, String parentName = '') {
-        Set result = [] as Set
-        properties.each { fieldName, fieldSettings ->
-            result += getKeywordFieldsFromProperty(fieldName as String,
-                    fieldSettings as Map, parentName)
-        }
-
-        return result
-    }
-
-    private Set getKeywordFieldsFromProperty(String fieldName, Map fieldSettings, String parentName) {
+    private static Set getFieldsByCondition(String fieldName, Map fieldSettings, Closure cond, String parentName) {
         Set result = [] as Set
         String currentField
         if (parentName == '') {
@@ -1135,14 +1126,10 @@ class ESQuery {
         } else {
             currentField = "${parentName}.${fieldName}"
         }
-        Map fields = (Map) fieldSettings.get('fields')
-        if (fields && fields.get('keyword')) {
+        if (cond(currentField, fieldSettings)) {
             result.add(currentField)
         }
-        Map properties = (Map) fieldSettings.get('properties')
-        if (properties) {
-            result += getKeywordFieldsFromProperties(properties, currentField)
-        }
+        result += getFieldsByCondition(fieldSettings, cond, currentField)
         return result
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/ESSettings.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ESSettings.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
@@ -15,7 +15,7 @@ import static whelk.util.DocumentUtil.NOP;
 public class EsMappings {
     private final Set<String> keywordFields;
     private final Set<String> fourDigitsKeywordFields;
-    private final Set<String> fourDigitsIntFields;
+    private final Set<String> fourDigitsShortFields;
     private final Set<String> dateTypeFields;
     private final Set<String> nestedTypeFields;
     private final Set<String> longTypeFields;
@@ -25,12 +25,12 @@ public class EsMappings {
 
     public static String KEYWORD = "keyword";
     public static String FOUR_DIGITS_KEYWORD_SUFFIX = "_4_digits_keyword";
-    public static String FOUR_DIGITS_INT_SUFFIX = "_4_digits_int";
+    public static String FOUR_DIGITS_SHORT_SUFFIX = "_4_digits_short";
 
     public EsMappings(Map<?, ?> mappings) {
         this.keywordFields = getKeywordFields(mappings);
         this.fourDigitsKeywordFields = getFourDigitsKeywordFields(mappings);
-        this.fourDigitsIntFields = getFourDigitsIntFields(mappings);
+        this.fourDigitsShortFields = getFourDigitsShortFields(mappings);
         this.dateTypeFields = getFieldsOfType("date", mappings);
         this.nestedTypeFields = getFieldsOfType("nested", mappings);
         this.longTypeFields = getFieldsOfType("long", mappings);
@@ -50,8 +50,8 @@ public class EsMappings {
         return fourDigitsKeywordFields.contains(fieldPath + FOUR_DIGITS_KEYWORD_SUFFIX);
     }
 
-    public boolean hasFourDigitsIntField(String fieldPath) {
-        return fourDigitsIntFields.contains(fieldPath + FOUR_DIGITS_INT_SUFFIX);
+    public boolean hasFourDigitsShortField(String fieldPath) {
+        return fourDigitsShortFields.contains(fieldPath + FOUR_DIGITS_SHORT_SUFFIX);
     }
 
     public boolean isDateTypeField(String fieldPath) {
@@ -82,8 +82,8 @@ public class EsMappings {
         return getFieldsWithSuffix(mappings, FOUR_DIGITS_KEYWORD_SUFFIX);
     }
 
-    private static Set<String> getFourDigitsIntFields(Map<?, ?> mappings) {
-        return getFieldsWithSuffix(mappings, FOUR_DIGITS_INT_SUFFIX);
+    private static Set<String> getFourDigitsShortFields(Map<?, ?> mappings) {
+        return getFieldsWithSuffix(mappings, FOUR_DIGITS_SHORT_SUFFIX);
     }
 
     private static Set<String> getKeywordFields(Map<?, ?> mappings) {

--- a/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
@@ -2,82 +2,96 @@ package whelk.search2;
 
 import whelk.util.DocumentUtil;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static whelk.util.DocumentUtil.NOP;
 
 public class EsMappings {
     private final Set<String> keywordFields;
-    private final Set<String> dateFields;
-    private final Set<String> nestedFields;
-    private final Set<String> longFields;
+    private final Set<String> fourDigitsKeywordFields;
+    private final Set<String> fourDigitsIntFields;
+    private final Set<String> dateTypeFields;
+    private final Set<String> nestedTypeFields;
+    private final Set<String> longTypeFields;
     private final Set<String> nestedNotInParentFields;
-    private final Set<String> numericExtractorFields;
 
     private final boolean isSpellCheckAvailable;
 
+    public static String KEYWORD = "keyword";
+    public static String FOUR_DIGITS_KEYWORD_SUFFIX = "_4_digits_keyword";
+    public static String FOUR_DIGITS_INT_SUFFIX = "_4_digits_int";
+
     public EsMappings(Map<?, ?> mappings) {
         this.keywordFields = getKeywordFields(mappings);
-        this.dateFields = getFieldsOfType("date", mappings);
-        this.nestedFields = getFieldsOfType("nested", mappings);
-        this.longFields = getFieldsOfType("long", mappings);
-        this.nestedNotInParentFields = new HashSet<>(nestedFields);
+        this.fourDigitsKeywordFields = getFourDigitsKeywordFields(mappings);
+        this.fourDigitsIntFields = getFourDigitsIntFields(mappings);
+        this.dateTypeFields = getFieldsOfType("date", mappings);
+        this.nestedTypeFields = getFieldsOfType("nested", mappings);
+        this.longTypeFields = getFieldsOfType("long", mappings);
+        this.nestedNotInParentFields = new HashSet<>(nestedTypeFields);
         this.nestedNotInParentFields.removeAll(getFieldsWithSetting("include_in_parent", true, mappings));
-        this.numericExtractorFields = getFieldsWithAnalyzer("numeric_extractor", mappings);
 
         // TODO: temporary feature flag, to be removed
         // this feature only works after a full reindex has been done, so we have to detect that
         this.isSpellCheckAvailable = DocumentUtil.getAtPath(mappings, List.of("properties", "_sortKeyByLang", "properties", "sv", "fields", "trigram"), null) != null;
     }
 
-    public boolean isKeywordField(String fieldPath) {
+    public boolean hasKeywordSubfield(String fieldPath) {
         return keywordFields.contains(fieldPath);
     }
 
-    public boolean isDateField(String fieldPath) {
-        return dateFields.contains(fieldPath);
+    public boolean hasFourDigitsKeywordField(String fieldPath) {
+        return fourDigitsKeywordFields.contains(fieldPath + FOUR_DIGITS_KEYWORD_SUFFIX);
     }
 
-    public boolean isNestedField(String fieldPath) {
-        return nestedFields.contains(fieldPath);
+    public boolean hasFourDigitsIntField(String fieldPath) {
+        return fourDigitsIntFields.contains(fieldPath + FOUR_DIGITS_INT_SUFFIX);
     }
 
-    public boolean isLongField(String fieldPath) {
-        return longFields.contains(fieldPath);
+    public boolean isDateTypeField(String fieldPath) {
+        return dateTypeFields.contains(fieldPath);
+    }
+
+    public boolean isNestedTypeField(String fieldPath) {
+        return nestedTypeFields.contains(fieldPath);
+    }
+
+    public boolean isLongTypeField(String fieldPath) {
+        return longTypeFields.contains(fieldPath);
     }
 
     public boolean isNestedNotInParentField(String fieldPath) {
         return nestedNotInParentFields.contains(fieldPath);
     }
 
-    public boolean isFourDigitField(String fieldPath) {
-        return numericExtractorFields.contains(fieldPath);
-    }
-
-    public Set<String> getNestedFields() {
-        return nestedFields;
+    public Set<String> getNestedTypeFields() {
+        return nestedTypeFields;
     }
 
     public boolean isSpellCheckAvailable() {
         return isSpellCheckAvailable;
     }
 
+    private static Set<String> getFourDigitsKeywordFields(Map<?, ?> mappings) {
+        return getFieldsWithSuffix(mappings, FOUR_DIGITS_KEYWORD_SUFFIX);
+    }
+
+    private static Set<String> getFourDigitsIntFields(Map<?, ?> mappings) {
+        return getFieldsWithSuffix(mappings, FOUR_DIGITS_INT_SUFFIX);
+    }
+
     private static Set<String> getKeywordFields(Map<?, ?> mappings) {
-        Predicate<Object> test = v -> v instanceof Map && ((Map<?, ?>) v).containsKey("keyword");
-        return getFieldsWithSetting("fields", test, mappings);
+        return getFieldsWithSetting("fields", v -> v instanceof Map<?, ?> m && m.containsKey(KEYWORD), mappings);
     }
 
     private static Set<String> getFieldsOfType(String type, Map<?, ?> mappings) {
         return getFieldsWithSetting("type", type, mappings);
-    }
-
-    private static Set<String> getFieldsWithAnalyzer(String analyzer, Map<?, ?> mappings) {
-        return getFieldsWithSetting("analyzer", analyzer, mappings);
     }
 
     private static Set<String> getFieldsWithSetting(String setting, Object value, Map<?, ?> mappings) {
@@ -85,25 +99,26 @@ public class EsMappings {
     }
 
     private static Set<String> getFieldsWithSetting(String setting, Predicate<Object> cmp, Map<?, ?> mappings) {
+        return getFieldsByCondition(mappings, (f, v) -> v instanceof Map<?, ?> m && cmp.test(m.get(setting)));
+    }
+
+    private static Set<String> getFieldsWithSuffix(Map<?, ?> mappings, String suffix) {
+        return getFieldsByCondition(mappings, (f, v) -> f.endsWith(suffix));
+    }
+
+    private static Set<String> getFieldsByCondition(Map<?, ?> mappings, BiPredicate<String, Object> p) {
         Set<String> fields = new HashSet<>();
         DocumentUtil.Visitor visitor = (v, path) -> {
-            if (cmp.test(v)) {
-                var p = dropLast(path).stream()
-                        .filter(s -> !"properties".equals(s))
-                        .map(Object::toString)
-                        .toList();
-                var field = String.join(".", p);
+            String field = path.stream()
+                    .filter(s -> !"properties".equals(s))
+                    .map(Object::toString)
+                    .collect(Collectors.joining("."));
+            if (p.test(field, v)) {
                 fields.add(field);
             }
             return NOP;
         };
-        DocumentUtil.findKey(mappings.get("properties"), setting, visitor);
+        DocumentUtil.traverse(mappings.get("properties"), visitor);
         return fields;
-    }
-
-    static <V> List<V> dropLast(List<V> list) {
-        var l = new ArrayList<>(list);
-        l.removeLast();
-        return l;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/Operator.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Operator.java
@@ -51,6 +51,10 @@ public enum Operator {
         );
     }
 
+    public boolean isRange() {
+        return rangeOperators().contains(this);
+    }
+
     public static Set<Operator> rangeOperators() {
         return Set.of(Operator.GREATER_THAN_OR_EQUALS, Operator.GREATER_THAN, Operator.LESS_THAN, Operator.LESS_THAN_OR_EQUALS);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static whelk.component.ElasticSearch.flattenedLangMapKey;
-import static whelk.search2.EsMappings.FOUR_DIGITS_INT_SUFFIX;
+import static whelk.search2.EsMappings.FOUR_DIGITS_SHORT_SUFFIX;
 import static whelk.search2.EsMappings.FOUR_DIGITS_KEYWORD_SUFFIX;
 import static whelk.search2.EsMappings.KEYWORD;
 import static whelk.search2.QueryUtil.castToStringObjectMap;
@@ -260,8 +260,8 @@ public class Query {
 
     private String getSortField(String termPath) {
         var path = expandLangMapKeys(termPath);
-        if (esSettings.mappings().hasFourDigitsIntField(path)) {
-            return String.format("%s%s", path, FOUR_DIGITS_INT_SUFFIX);
+        if (esSettings.mappings().hasFourDigitsShortField(path)) {
+            return String.format("%s%s", path, FOUR_DIGITS_SHORT_SUFFIX);
         }
         else if (esSettings.mappings().hasKeywordSubfield(path)) {
             return String.format("%s.%s", path, KEYWORD);

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static whelk.component.ElasticSearch.flattenedLangMapKey;
+import static whelk.search2.EsMappings.FOUR_DIGITS_INT_SUFFIX;
+import static whelk.search2.EsMappings.FOUR_DIGITS_KEYWORD_SUFFIX;
+import static whelk.search2.EsMappings.KEYWORD;
 import static whelk.search2.QueryUtil.castToStringObjectMap;
 import static whelk.search2.QueryUtil.makeViewFindUrl;
 import static whelk.search2.QueryUtil.mustWrap;
@@ -257,8 +260,11 @@ public class Query {
 
     private String getSortField(String termPath) {
         var path = expandLangMapKeys(termPath);
-        if (esSettings.mappings().isKeywordField(path) && !esSettings.mappings().isFourDigitField(path)) {
-            return String.format("%s.keyword", path);
+        if (esSettings.mappings().hasFourDigitsIntField(path)) {
+            return String.format("%s%s", path, FOUR_DIGITS_INT_SUFFIX);
+        }
+        else if (esSettings.mappings().hasKeywordSubfield(path)) {
+            return String.format("%s.%s", path, KEYWORD);
         } else {
             return termPath;
         }
@@ -310,6 +316,8 @@ public class Query {
                             Map.of("field", JsonLd.TYPE_KEY)));
         }
 
+        EsMappings esMappings = esSettings.mappings();
+
         Map<String, List<Node>> multiSelected = selectedFilters.getAllMultiSelected();
 
         Map<String, Object> query = new LinkedHashMap<>();
@@ -331,30 +339,34 @@ public class Query {
             new Path(property).expand(jsonLd)
                     .getAltPaths(jsonLd, rulingTypes)
                     .forEach(path -> {
+                        String jsonPath = path.jsonForm();
+                        String field = esMappings.hasFourDigitsKeywordField(jsonPath)
+                                ? String.format("%s%s", jsonPath, FOUR_DIGITS_KEYWORD_SUFFIX)
+                                : (esMappings.hasKeywordSubfield(jsonPath) ? String.format("%s.%s", jsonPath, KEYWORD) : jsonPath);
                         Map<String, Object> aggs = path.getEsNestedStem(esSettings.mappings())
-                                .map(nestedStem -> buildNestedAggQuery(path, slice, nestedStem))
-                                .orElse(buildCoreAqqQuery(path, slice));
+                                .map(nestedStem -> buildNestedAggQuery(field, slice, nestedStem))
+                                .orElse(buildCoreAqqQuery(field, slice));
                         Map<String, List<Node>> mSelected = selectedFilters.isMultiSelectable(pKey)
                                 ? new HashMap<>(multiSelected) {{ remove(pKey); }}
                                 : multiSelected;
                         Map<String, Object> filter = getEsMultiSelectedFilters(mSelected, rulingTypes, jsonLd, esSettings);
-                        query.put(path.jsonForm(), filterWrap(aggs, property.name(), filter));
+                        query.put(field, filterWrap(aggs, property.name(), filter));
                     });
         }
 
         return query;
     }
 
-    private static Map<String, Object> buildCoreAqqQuery(Path path, AppParams.Slice slice) {
+    private static Map<String, Object> buildCoreAqqQuery(String field, AppParams.Slice slice) {
         return Map.of("terms",
-                Map.of("field", path.jsonForm(),
+                Map.of("field", field,
                         "size", slice.size(),
                         "order", Map.of(slice.bucketSortKey(), slice.sortOrder())));
     }
 
-    private static Map<String, Object> buildNestedAggQuery(Path path, AppParams.Slice slice, String nestedStem) {
+    private static Map<String, Object> buildNestedAggQuery(String field, AppParams.Slice slice, String nestedStem) {
         return Map.of("nested", Map.of("path", nestedStem),
-                "aggs", Map.of(NESTED_AGG_NAME, buildCoreAqqQuery(path, slice)));
+                "aggs", Map.of(NESTED_AGG_NAME, buildCoreAqqQuery(field, slice)));
     }
 
     private static Map<String, Object> filterWrap(Map<String, Object> aggs, String property, Map<String, Object> filter) {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryResult.java
@@ -112,7 +112,7 @@ public class QueryResult {
 
             var buckets = ((List<?>) agg.get("buckets")).stream()
                     .map(Map.class::cast)
-                    .map(b -> new Bucket((String) b.get("key"), (Integer) b.get("doc_count")))
+                    .map(b -> new Bucket(String.valueOf(b.get("key")), (Integer) b.get("doc_count")))
                     .toList();
 
             aggregations.add(new Aggregation(property, path, buckets));

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Numeric.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Numeric.java
@@ -15,10 +15,6 @@ public record Numeric(int value, Token token) implements Value {
         return "" + value;
     }
 
-    public boolean isFourDigits() {
-        return value >= 1000 && value <= 9999;
-    }
-
     public Numeric increment() {
         return new Numeric(value + 1);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Numeric.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Numeric.java
@@ -15,6 +15,10 @@ public record Numeric(int value, Token token) implements Value {
         return "" + value;
     }
 
+    public boolean isFourDigits() {
+        return value >= 1000 && value <= 9999;
+    }
+
     public Numeric increment() {
         return new Numeric(value + 1);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -128,10 +128,10 @@ public class Path {
 
     public Optional<String> getEsNestedStem(EsMappings esMappings) {
         String esPath = jsonForm();
-        if (esMappings.isNestedField(esPath)) {
+        if (esMappings.isNestedTypeField(esPath)) {
             return Optional.of(esPath);
         }
-        return esMappings.getNestedFields().stream().filter(esPath::startsWith).findFirst();
+        return esMappings.getNestedTypeFields().stream().filter(esPath::startsWith).findFirst();
     }
 
     private Optional<Key> getSuffix(Value value) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -14,12 +14,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static whelk.JsonLd.Owl.INVERSE_OF;
 import static whelk.JsonLd.Owl.PROPERTY_CHAIN_AXIOM;
 import static whelk.JsonLd.TYPE_KEY;
+import static whelk.search2.EsMappings.FOUR_DIGITS_INT_SUFFIX;
+import static whelk.search2.EsMappings.FOUR_DIGITS_KEYWORD_SUFFIX;
 import static whelk.search2.Operator.EQUALS;
 import static whelk.search2.Operator.GREATER_THAN;
 import static whelk.search2.Operator.NOT_EQUALS;
@@ -143,56 +146,79 @@ public record PathValue(Path path, Operator operator, Value value) implements No
     }
 
     private Map<String, Object> _getCoreEsQuery(ESSettings esSettings) {
-        String p = path.jsonForm();
-        Value v = value;
+        String field = path.jsonForm();
+        return switch (value) {
+            case DateTime dateTime -> esDateFilter(field, dateTime, esSettings);
+            case FreeText ft -> esFreeTextFilter(field, ft, esSettings);
+            case InvalidValue ignored -> nonsenseFilter(); // TODO: Treat whole expression as free text?
+            case Numeric numeric -> esNumFilter(field, numeric, esSettings);
+            case Resource resource -> esResourceFilter(field, resource);
+        };
+    }
 
+    private Map<String, Object> esDateFilter(String field, DateTime d, ESSettings esSettings) {
+        // TODO: What about e.g. :firstIssueDate/:lastIssueDate? These have range xsd:date however are not indexed as date type in ES.
+        if (esSettings.mappings().isDateTypeField(field)) {
+            return esNumOrDateFilter(field, d.dateTime().toElasticDateString());
+        }
+        // Treat as free text
+        return esFreeTextFilter(field, new FreeText(d.toString()), esSettings);
+    }
+
+    private Map<String, Object> esNumFilter(String field, Numeric n, ESSettings esSettings) {
         EsMappings esMappings = esSettings.mappings();
 
-        if ((v instanceof Numeric n && !esMappings.isFourDigitField(p) && !esMappings.isLongField(p))) {
-            // Treat as free text
-            v = new FreeText(n.toString());
-        } else if (v instanceof DateTime d && !esMappings.isDateField(p)) {
-            // TODO: What about e.g. :firstIssueDate/:lastIssueDate? These have range xsd:date however are not indexed as date type in ES.
-            v = new FreeText(d.toString());
+        if (operator.isRange() && esMappings.hasFourDigitsIntField(field) && n.isFourDigits()) {
+            return esNumOrDateFilter(field + FOUR_DIGITS_INT_SUFFIX, n.value());
+        }
+        if (!operator.isRange() && esMappings.hasFourDigitsKeywordField(field) && n.isFourDigits()) {
+            return esNumOrDateFilter(field + FOUR_DIGITS_KEYWORD_SUFFIX, n.toString());
+        }
+        if (esMappings.isLongTypeField(field)) {
+            return esNumOrDateFilter(field, n.value());
         }
 
-        Function<Object, Map<String, Object>> numOrDateFilter = numOrDate -> switch (operator) {
-            case EQUALS -> filterWrap(buildTermQuery(p, numOrDate));
-            case NOT_EQUALS -> mustNotWrap(buildTermQuery(p, numOrDate));
-            case GREATER_THAN_OR_EQUALS -> esRangeFilter(p, numOrDate, "gte");
-            case GREATER_THAN -> esRangeFilter(p, numOrDate, "gt");
-            case LESS_THAN_OR_EQUALS -> esRangeFilter(p, numOrDate, "lte");
-            case LESS_THAN -> esRangeFilter(p, numOrDate, "lt");
+        // Treat as free text
+        return esFreeTextFilter(field, new FreeText(n.toString()), esSettings);
+    }
+
+    private Map<String, Object> esNumOrDateFilter(String f, Object v) {
+        return switch (operator) {
+            case EQUALS -> filterWrap(buildTermQuery(f, v));
+            case NOT_EQUALS -> mustNotWrap(buildTermQuery(f, v));
+            case GREATER_THAN_OR_EQUALS -> esRangeFilter(f, v, "gte");
+            case GREATER_THAN -> esRangeFilter(f, v, "gt");
+            case LESS_THAN_OR_EQUALS -> esRangeFilter(f, v, "lte");
+            case LESS_THAN -> esRangeFilter(f, v, "lt");
         };
+    }
 
-        return switch (v) {
-            case DateTime dateTime -> numOrDateFilter.apply(dateTime.dateTime().toElasticDateString());
-            case FreeText ft -> {
-                if (ft.isWild()) {
-                    yield switch (operator) {
-                        case EQUALS -> existsFilter(p);
-                        case NOT_EQUALS -> notExistsFilter(p);
-                        // FIXME: Range makes no sense here
-                        default -> nonsenseFilter();
-                    };
-                }
-                var boostSettings = esSettings.boost().fieldBoost();
-
-                yield switch (operator) {
-                    case EQUALS -> ft.toEs(boostSettings.withField(p));
-                    case NOT_EQUALS -> mustNotWrap(ft.toEs(boostSettings.withField(p, 0)));
-                    // FIXME: Range makes no sense here
-                    default -> nonsenseFilter();
-                };
-            }
-            case InvalidValue ignored -> nonsenseFilter(); // TODO: Treat whole expression as free text?
-            case Numeric numeric -> numOrDateFilter.apply(numeric.value()); // TODO: Sort out keyword fields, e.g. what is indexed into publication.year.keyword
-            case Resource resource -> switch (operator) {
-                case EQUALS -> filterWrap(buildTermQuery(p, resource.jsonForm()));
-                case NOT_EQUALS -> mustNotWrap(buildTermQuery(p, resource.jsonForm()));
+    private Map<String, Object> esFreeTextFilter(String f, FreeText ft, ESSettings esSettings) {
+        if (ft.isWild()) {
+            return switch (operator) {
+                case EQUALS -> existsFilter(f);
+                case NOT_EQUALS -> notExistsFilter(f);
                 // FIXME: Range makes no sense here
                 default -> nonsenseFilter();
             };
+        }
+
+        var boostSettings = esSettings.boost().fieldBoost();
+
+        return switch (operator) {
+            case EQUALS -> ft.toEs(boostSettings.withField(f));
+            case NOT_EQUALS -> mustNotWrap(ft.toEs(boostSettings.withField(f, 0)));
+            // FIXME: Range makes no sense here
+            default -> nonsenseFilter();
+        };
+    }
+
+    private Map<String, Object> esResourceFilter(String f, Resource r) {
+        return switch (operator) {
+            case EQUALS -> filterWrap(buildTermQuery(f, r.jsonForm()));
+            case NOT_EQUALS -> mustNotWrap(buildTermQuery(f, r.jsonForm()));
+            // FIXME: Range makes no sense here
+            default -> nonsenseFilter();
         };
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/PathValue.java
@@ -14,14 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static whelk.JsonLd.Owl.INVERSE_OF;
 import static whelk.JsonLd.Owl.PROPERTY_CHAIN_AXIOM;
 import static whelk.JsonLd.TYPE_KEY;
-import static whelk.search2.EsMappings.FOUR_DIGITS_INT_SUFFIX;
+import static whelk.search2.EsMappings.FOUR_DIGITS_SHORT_SUFFIX;
 import static whelk.search2.EsMappings.FOUR_DIGITS_KEYWORD_SUFFIX;
 import static whelk.search2.Operator.EQUALS;
 import static whelk.search2.Operator.GREATER_THAN;
@@ -168,8 +166,8 @@ public record PathValue(Path path, Operator operator, Value value) implements No
     private Map<String, Object> esNumFilter(String field, Numeric n, ESSettings esSettings) {
         EsMappings esMappings = esSettings.mappings();
 
-        if (operator.isRange() && esMappings.hasFourDigitsIntField(field) && n.isFourDigits()) {
-            return esNumOrDateFilter(field + FOUR_DIGITS_INT_SUFFIX, n.value());
+        if (operator.isRange() && esMappings.hasFourDigitsShortField(field) && n.isFourDigits()) {
+            return esNumOrDateFilter(field + FOUR_DIGITS_SHORT_SUFFIX, n.value());
         }
         if (!operator.isRange() && esMappings.hasFourDigitsKeywordField(field) && n.isFourDigits()) {
             return esNumOrDateFilter(field + FOUR_DIGITS_KEYWORD_SUFFIX, n.toString());


### PR DESCRIPTION
The main objective of this change is to fix bugs in year queries, particularly:
- Truncated/masked queries (e.g. `publication.year=19*`)
- Queries with malformed years (e.g. `publication.year=nnnn`)

Both previously failed due to the `numeric_extractor` analyzer, which only matched clean 4-digit strings.

Year fields (year, startYear, endYear) are used for various operations:  
- **Querying**: term queries, range queries, and masked/truncated queries.  
- **Aggregating**: grouping by publication year.  
- **Sorting**: ordering search results by publication year.  

Previously, year values were stored only as analyzed text and plain keywords. This PR changes the text analyzer from `numeric_extractor` to `standard` in order to support masking/truncation and matching malformed years. Valid years (yyyy) are also stored in two new sibling fields, `*_4_digits_int` and `*_4_digits_keyword` which are used for efficient queries, aggregations and sorting.

#### Example
Previous mapping:
- `publication.year` → `text` (analyzer: `numeric_extractor`)  
- `publication.year.keyword` → `keyword`  

New mapping:
- `publication.year` → `text` (analyzer: `standard`)  
- `publication.year.keyword` → `keyword` (unchanged, preserves raw value)
- `publication.year_4_digits_keyword` → `keyword` (new, normalized 4-digit values for aggregations and exact term queries)  
- `publication.year_4_digits_int` → `integer` (new, normalized 4-digit values for range queries and sorting)  

See [documentation](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/number) for motivation (section "Elasticsearch mapping numeric identifiers").

Queries:
- `yearPublished:1990` 
  - Before: `publication.year:"1990"` → matched analyzed text field (inefficient).  
  - Now: `publication.year_4_digits_keyword:"1990"` → keyword lookup.  

- `yearPublished>=1990`   
  - Before: `publication.year>="1990"` → range query on analyzed text field (inefficient).  
  - Now: `publication.year_4_digits_int>=1990` → proper numeric range query.  

- `yearPublished:nnnn`
  - Before: `publication.year:"nnnn"` → matched text field analyzed with `numeric_extractor` (failed).  
  - Now: `publication.year:"nnnn"`  → matches same field but now works with the `standard` analyzer.

- `yearPublished:19*`
  - Before: `publication.year:"19*"` → matched text field analyzed with `numeric_extractor` (failed).  
  - Now: `publication.year:"19*"`  → matches same field but now works with the `standard` analyzer.

Aggregation:
- Libris Search: `publication.year_4_digits_keyword` (clean 4-digit years only).
- Cataloging: `publication.year.keyword`: (“as-is” values, including malformed years).

Sorting:
- Sorting is performed on `publication.year_4_digits_int`.  
- Valid years are sorted numerically.  
- Malformed years are sorted last.
- Question: Do we also want to filter out known non-years like "9999" or "0000" from the 4-digit fields? 

---

#### Ingest Pipeline
- Added a script-based ingest pipeline to dynamically extract valid 4-digit years and populate `*_4_digits_keyword` and `*_4_digits_int` fields.  
- Pipeline is referenced in config and can be deployed via Fab task (see https://github.com/libris/devops/pull/282).  
- The pipeline script can easily be modified should we want to manipulate or normalize other fields dynamically in the future. 
- Indexing time increased by ~0.035 ms/document (~1h for full reindex). I think this is acceptable given the improved query-time efficiency.