### PR TITLE
Add method to determine if a field can be used in aggregations

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
+++ b/whelk-core/src/main/groovy/whelk/search2/EsMappings.java
@@ -3,7 +3,6 @@ package whelk.search2;
 import whelk.util.DocumentUtil;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
@@ -13,12 +12,16 @@ import java.util.stream.Collectors;
 import static whelk.util.DocumentUtil.NOP;
 
 public class EsMappings {
-    private final Set<String> keywordFields;
+    private final Set<String> keywordSubfieldFields;
+
     private final Set<String> fourDigitsKeywordFields;
     private final Set<String> fourDigitsShortFields;
+
+    private final Set<String> keywordTypeFields;
     private final Set<String> dateTypeFields;
     private final Set<String> nestedTypeFields;
     private final Set<String> longTypeFields;
+
     private final Set<String> nestedNotInParentFields;
 
     public static String KEYWORD = "keyword";
@@ -26,9 +29,10 @@ public class EsMappings {
     public static String FOUR_DIGITS_SHORT_SUFFIX = "_4_digits_short";
 
     public EsMappings(Map<?, ?> mappings) {
-        this.keywordFields = getKeywordFields(mappings);
+        this.keywordSubfieldFields = getKeywordSubfieldFields(mappings);
         this.fourDigitsKeywordFields = getFourDigitsKeywordFields(mappings);
         this.fourDigitsShortFields = getFourDigitsShortFields(mappings);
+        this.keywordTypeFields = getFieldsOfType("keyword", mappings);
         this.dateTypeFields = getFieldsOfType("date", mappings);
         this.nestedTypeFields = getFieldsOfType("nested", mappings);
         this.longTypeFields = getFieldsOfType("long", mappings);
@@ -37,7 +41,7 @@ public class EsMappings {
     }
 
     public boolean hasKeywordSubfield(String fieldPath) {
-        return keywordFields.contains(fieldPath);
+        return keywordSubfieldFields.contains(fieldPath);
     }
 
     public boolean hasFourDigitsKeywordField(String fieldPath) {
@@ -64,6 +68,17 @@ public class EsMappings {
         return nestedNotInParentFields.contains(fieldPath);
     }
 
+    public boolean isAggregatable(String fieldPath) {
+        // Simple check based on current mappings.
+        // Doesn't consider
+        // - text fields with `"fielddata": true` (aggregatable)
+        // - fields with "doc_values": false` (not aggregatable)
+        // This is fine since the current index settings do not use these options.
+        return keywordTypeFields.contains(fieldPath)
+                || dateTypeFields.contains(fieldPath)
+                || longTypeFields.contains(fieldPath);
+    }
+
     public Set<String> getNestedTypeFields() {
         return nestedTypeFields;
     }
@@ -76,7 +91,7 @@ public class EsMappings {
         return getFieldsWithSuffix(mappings, FOUR_DIGITS_SHORT_SUFFIX);
     }
 
-    private static Set<String> getKeywordFields(Map<?, ?> mappings) {
+    private static Set<String> getKeywordSubfieldFields(Map<?, ?> mappings) {
         return getFieldsWithSetting("fields", v -> v instanceof Map<?, ?> m && m.containsKey(KEYWORD), mappings);
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -444,6 +444,9 @@ public class Query {
                     } else if (property.isObjectProperty() && !property.isVocabTerm() && !property.isType()) {
                         field = String.format("%s.%s", field, JsonLd.ID_KEY);
                     }
+                    if (!ctx.esSettings.mappings().isAggregatable(field)) {
+                        return;
+                    }
                     Optional<String> nestedStem = selector.getEsNestedStem(ctx.esSettings.mappings());
                     Map<String, Object> aggs = nestedStem.isPresent()
                             ? buildNestedAggQuery(field, slice, nestedStem.get(), ctx)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -272,8 +272,15 @@ class TestData {
     static def getEsMappings() {
         def mappings = [
                 'properties': [
-                        'p3'                    : ['type': 'nested'],
-                        '@reverse.instanceOf.p3': ['type': 'nested']
+                        'p3'                                : ['type': 'nested'],
+                        '@reverse.instanceOf.p3'            : ['type': 'nested'],
+                        '@type'                             : ['type': 'keyword'],
+                        'p2'                                : ['type': 'keyword'],
+                        'p3.p4.@id'                         : ['type': 'keyword'],
+                        '_categoryByCollection.find.@id'    : ['type': 'keyword'],
+                        '_categoryByCollection.identify.@id': ['type': 'keyword'],
+                        '_categoryByCollection.@none.@id'   : ['type': 'keyword'],
+                        '@reverse.instanceOf.category.@id'  : ['type': 'keyword']
                 ]
         ]
         return new EsMappings(mappings)


### PR DESCRIPTION
Prevents ES error caused by trying to aggregate on a text field.

Bonus effect: Fields that aren't indexed at all won't be included in the agg query either. So for example  `@reverse.instanceOf.language.@id` will now be dropped.

<img width="627" height="121" alt="image" src="https://github.com/user-attachments/assets/da35b8c9-64e8-4207-9b66-cf38b1fc9a38" />
