### PR TITLE
Type/category-revert nested instances and works

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -1,13 +1,17 @@
 package whelk.converter.marc
 
 //import groovy.transform.CompileStatic
+import groovy.util.logging.Log4j2 as Log
 
 import whelk.TypeCategoryNormalizer
 import whelk.converter.BibTypeNormalizer
+import static whelk.converter.BibTypeNormalizer.getType
+import whelk.util.DocumentUtil
 
 import static whelk.JsonLd.asList
 
 //@CompileStatic
+@Log
 class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     boolean requiresResources = true
@@ -50,14 +54,18 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     boolean checkRequired() {
         if (resourceCache == null) {
-            // FIXME: log.warn
-            System.err.println("BibTypeNormalizationStep MISSING resourceCache!")
+            log.warn("BibTypeNormalizationStep MISSING resourceCache!")
             return false
         }
+
         return true
     }
 
     void modify(Map record, Map thing) {
+        if (!checkRequired()) {
+            return
+        }
+
         bibTypeNormaliser.normalize(thing, thing.instanceOf)
     }
 
@@ -66,11 +74,16 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
             return
         }
 
-        def work = instance.instanceOf
-        if (!work) {
-          // Does not look like an instance (cannot usefully unmodify); just skip.
-          return
+        if (instance.instanceOf == null) {
+            log.debug("Does not look like an instance (cannot usefully unmodify); skipping")
+            return
         }
+
+        denormalize(instance)
+    }
+
+    void denormalize(Map instance) {
+        def work = instance.get('instanceOf', [:]) // NOTE: *sets* default value
 
         // Pick out the categories:
         var workCategories = getDescriptions(work.category)
@@ -88,12 +101,30 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
         // Mutate into legacy form:
         def issuanceType = getIssuanceType(work[TYPE], instance[TYPE], workCategories, instanceCategories)
-        reshapeToLegacyWork(work, instance, workCategories, instanceCategories)
-        reshapeToLegacyInstance(work, instance, workCategories, instanceCategories)
+        reshapeToLegacyWork(work, workCategories)
+        reshapeToLegacyInstance(instance, workCategories, instanceCategories)
         instance.issuanceType = issuanceType ?: 'Monograph'
+
+        DocumentUtil.traverse(instance) { value, path ->
+            if (!path.isEmpty() && !path.contains('instanceOf')) {
+                if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Instance')) {
+                    denormalize(value)
+                }
+            }
+        }
+
+        DocumentUtil.traverse(work) { value, path ->
+            if (!path.isEmpty()) {
+                if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
+                    reshapeToLegacyWork(value, getDescriptions(value.category))
+                }
+            }
+        }
+
     }
 
-    void reshapeToLegacyWork(Map work, Map someInstance, List workCategories, List instanceCategories) {
+
+    void reshapeToLegacyWork(Map work, List workCategories) {
         work.contentType = getCategoryOfType(workCategories, 'ContentType', true)
         work.genreForm = getCategoryOfType(workCategories, 'GenreForm')
         work[TYPE] = getWorkType(workCategories) ?: defaultWorkLegacyType
@@ -108,7 +139,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         for (type in result) return type
     }
 
-    void reshapeToLegacyInstance(Map work, Map instance, List workCategories, List instanceCategories) {
+    void reshapeToLegacyInstance(Map instance, List workCategories, List instanceCategories) {
         instance.mediaType = getCategoryOfType(instanceCategories, 'MediaType', true)
         instance.carrierType = getCategoryOfType(instanceCategories, 'CarrierType', true)
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-typenormalization.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-typenormalization.json
@@ -61,5 +61,148 @@
   },
   "_spec:TODO:from": "whelktool/scripts/typenormalization/tailored_examples.jsonl",
   "_spec": [
+    {
+      "name": "bibtype-map embedded instance and work",
+      "source": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "Print",
+          "mediaType": [
+            {"@id": "https://id.kb.se/term/rda/Unmediated"}
+          ],
+          "carrierType": [
+            {"@id": "https://id.kb.se/term/rda/Volume"}
+          ],
+          "issuanceType": "Monograph",
+          "marc:versionOfResource": [
+            {
+              "uri": [
+                "http://urn.kb.se/resolve?urn=urn:nbn:se:liu:diva-219906"
+              ],
+              "@type": "Electronic",
+              "marc:publicNote": [
+                "Sammanfattning och fulltext från Linköping University Electronic Press"
+              ],
+              "instanceOf": {"@type": "Text"},
+              "carrierType": {"@id": "https://id.kb.se/marc/Electronic"},
+              "issuanceType": "Monograph"
+            }
+          ],
+          "instanceOf": {
+            "@type": "Text",
+            "contentType": [
+              {"@id": "https://id.kb.se/marc/Thesis"},
+              {"@id": "https://id.kb.se/term/rda/Text"}
+            ],
+            "genreForm": [
+              {"@id": "https://id.kb.se/term/saogf/Avhandlingar"},
+              {
+                "@type": "GenreForm",
+                "inScheme": {"@id": "https://id.kb.se/term/lcgft"},
+                "prefLabel": "Academic theses"
+              },
+              {"@id": "https://id.kb.se/marc/Thesis"},
+              {"@id": "https://id.kb.se/term/saogf/Facklitteratur"}
+            ],
+            "hasPart": [
+              {
+                "@type": "Text",
+                "intendedAudience": [
+                  {"@id": "https://id.kb.se/marc/Juvenile"}
+                ],
+                "contentType": {"@id": "https://id.kb.se/term/rda/Text"},
+                "genreForm": [
+                  {"@id": "https://id.kb.se/term/saogf/Sk%C3%B6nlitteratur"},
+                  {
+                    "@type": "GenreForm",
+                    "inScheme": {"@id": "https://id.kb.se/term/lcsh"},
+                    "prefLabel": "Literature"
+                  },
+                  {"@id": "https://id.kb.se/marc/FictionNotFurtherSpecified"},
+                  {"@id": "https://id.kb.se/term/ktg/Literature"}
+                ]
+              },
+              {
+                "@type": "Audio",
+                "category": [
+                  {"@id": "https://id.kb.se/marc/Fiction"},
+                  {"@id": "https://id.kb.se/term/ktg/Audio"}
+                ],
+                "intendedAudience": [
+                  {"@id": "https://id.kb.se/marc/Juvenile"}
+                ],
+                "genreForm": [
+                  {"@id": "https://id.kb.se/marc/Fiction"}
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "PhysicalResource",
+          "category": [
+            {"@id": "https://id.kb.se/term/rda/Volume"},
+            {"@id": "https://id.kb.se/term/saobf/Print"}
+          ],
+          "marc:versionOfResource": [
+            {
+              "uri": [
+                "http://urn.kb.se/resolve?urn=urn:nbn:se:liu:diva-219906"
+              ],
+              "@type": "Instance",
+              "instanceOf": {"@type": "Text"},
+              "category": [
+                {"@id": "https://id.kb.se/term/saobf/AbstractElectronic"}
+              ],
+              "marc:publicNote": [
+                "Sammanfattning och fulltext från Linköping University Electronic Press"
+              ]
+            }
+          ],
+          "instanceOf": {
+            "@type": "Monograph",
+            "category": [
+              {"@id": "https://id.kb.se/term/saogf/Avhandlingar"},
+              {"@id": "https://id.kb.se/term/rda/Text"},
+              {
+                "@type": "GenreForm",
+                "inScheme": {"@id": "https://id.kb.se/term/lcgft"},
+                "prefLabel": "Academic theses"
+              }
+            ],
+            "hasPart": [
+              {
+                "@type": "Work",
+                "category": [
+                  {"@id": "https://id.kb.se/term/saogf/Sk%C3%B6nlitteratur"},
+                  {"@id": "https://id.kb.se/term/rda/Text"},
+                  {
+                    "@type": "GenreForm",
+                    "inScheme": {"@id": "https://id.kb.se/term/lcsh"},
+                    "prefLabel": "Literature"
+                  }
+                ],
+                "intendedAudience": [
+                  {"@id": "https://id.kb.se/marc/Juvenile"}
+                ]
+              },
+              {
+                "@type": "Work",
+                "category": [
+                  {"@id": "https://id.kb.se/marc/Fiction"},
+                  {"@id": "https://id.kb.se/term/ktg/Audio"}
+                ],
+                "intendedAudience": [
+                  {"@id": "https://id.kb.se/marc/Juvenile"}
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
   ]
 }


### PR DESCRIPTION
This will enable MARC revert of type-normalized embedded (or linked) works and instances (for link fields, repeated bib 007 and 006).

Change also includes:
- Remove unused parameters on internal methods
- Add test data
- Check required on modify as well (to avoid error on missing resources)
- Improved logging