### PR TITLE
Add temporary workaround to enable free-text search for all holding libraries

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -27,6 +27,7 @@ import static whelk.JsonLd.ID_KEY
 import static whelk.JsonLd.Platform.CATEGORY_BY_COLLECTION
 import static whelk.JsonLd.RECORD_KEY
 import static whelk.JsonLd.REVERSE_KEY
+import static whelk.JsonLd.SEARCH_KEY
 import static whelk.JsonLd.THING_KEY
 import static whelk.JsonLd.TYPE_KEY
 import static whelk.JsonLd.asList
@@ -574,19 +575,30 @@ class ElasticSearch {
                 }
             }
 
-            if (whelk.features.isEnabled(EXPERIMENTAL_INDEX_HOLDING_ORGS)) {
-                if ('Item' != searchCard[TYPE_KEY]
-                        && path
-                        && "heldBy" == path.last()
-                        && !path.contains('hasComponent')
-                        && value instanceof Map
-                        && value[JsonLd.ID_KEY]
-                        && !value['isPartOf']) {
-                    var org = whelk.relations.getBy((String) value[JsonLd.ID_KEY], ['isPartOf'])
-                    if (!org.isEmpty()) {
-                        value['isPartOf'] = [(JsonLd.ID_KEY): org.first()]
+            // FIXME
+            if ('Item' != searchCard[TYPE_KEY]
+                    && path
+                    && "heldBy" == path.last()
+                    && !path.contains('hasComponent')
+                    && value instanceof Map
+                    && value[JsonLd.ID_KEY]) {
+                var item = value.size() == 1
+                        ? (whelk.storage.getDocumentByIri((String) value[JsonLd.ID_KEY])?.getThing() ?: value)
+                        : value
+                addSearchStr(item, whelk, FresnelUtil.Lenses.SEARCH_TOKEN, JsonLd.SEARCH_KEY)
+
+                if (whelk.features.isEnabled(EXPERIMENTAL_INDEX_HOLDING_ORGS)) {
+                    var orgIds = asList(item['isPartOf']).collect { it[ID_KEY] }.toSet()
+                            ?: whelk.relations.getBy((String) value[JsonLd.ID_KEY], ['isPartOf'])
+                    if (!orgIds.isEmpty()) {
+                        var org = whelk.storage.getDocumentByIri(orgIds.first())?.getThing() ?: [(JsonLd.ID_KEY): orgIds.first()]
+                        addSearchStr(org, whelk, FresnelUtil.Lenses.SEARCH_TOKEN, JsonLd.SEARCH_KEY)
+                        item['isPartOf'] = org.subMap([ID_KEY, SEARCH_KEY])
                     }
+                    return new DocumentUtil.Replace(item.subMap([ID_KEY, 'isPartOf', SEARCH_KEY]))
                 }
+
+                return new DocumentUtil.Replace(item.subMap([ID_KEY, SEARCH_KEY]))
             }
 
             return DocumentUtil.NOP


### PR DESCRIPTION
Suboptimal solution. Not sure if it's worth it. Resulting shape:

```
  "@reverse" : {
    "itemOf" : [ {
      "heldBy" : {
        "@id" : "https://libris.kb.se/library/S",
        "isPartOf" : {
          "@id" : "https://libris.kb.se/library/org/KB",
          "_str" : [ "Kungliga biblioteket KB", "Kungliga biblioteket National Library of Sweden KB" ]
        },
        "_str" : "Kungliga biblioteket S"
      }
    } ]
  }
```