### PR TITLE
Avoid querying deprecated types 

### DIFF
--- a/whelk-core/src/main/groovy/whelk/JsonLd.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLd.groovy
@@ -104,6 +104,7 @@ class JsonLd {
         public static final String EQUIVALENT_CLASS = "equivalentClass"
         public static final String EQUIVALENT_PROPERTY = "equivalentProperty"
         public static final String SAME_AS = "sameAs"
+        public static final String DEPRECATED = "deprecated"
     }
 
     static final class Rdfs {
@@ -783,6 +784,10 @@ class JsonLd {
 
     boolean isCategoryPending(String property) {
         getCategoryMembers(Category.PENDING).contains(property)
+    }
+
+    boolean isDeprecated(String term) {
+        return vocabIndex[term]?[Owl.DEPRECATED];
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -197,6 +197,7 @@ public sealed class Condition implements Node permits Type {
         }
 
         List<Condition> altFields = Stream.concat(Stream.of(baseType), subtypes.stream())
+                .filter(Predicate.not(jsonLd::isDeprecated))
                 .sorted()
                 .map(t -> withValue(new VocabTerm(t, jsonLd.vocabIndex.get(t))))
                 .toList();


### PR DESCRIPTION
A bit overkill to include 30 work types in each query :smile: 
<img width="320" height="700" alt="bild" src="https://github.com/user-attachments/assets/ef3ef9bd-2174-4361-8e77-0f5a9156fdf6" />
