### PR TITLE
(EMM) The distinction between an UPDATE event and a CREATED event mus…

### DIFF
--- a/emm/src/main/java/whelk/EmmActivity.java
+++ b/emm/src/main/java/whelk/EmmActivity.java
@@ -15,14 +15,14 @@ public class EmmActivity {
     public final Type activityType;
     public final Timestamp modificationTime;
 
-    public EmmActivity(String uri, String type, Timestamp creationTime, Timestamp modificationTime, boolean deleted, String library) {
+    public EmmActivity(String uri, String type, Timestamp modificationTime, boolean deleted, boolean created, String library) {
         this.uri = uri;
         this.entityType = type;
         this.modificationTime = modificationTime;
         this.library = library;
         if (deleted)
             this.activityType = Type.DELETE;
-        else if (creationTime.equals(modificationTime))
+        else if (created)
             this.activityType = Type.CREATE;
         else
             this.activityType = Type.UPDATE;

--- a/emm/src/main/java/whelk/EmmChangeSet.java
+++ b/emm/src/main/java/whelk/EmmChangeSet.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -91,6 +92,10 @@ public class EmmChangeSet {
 
         try (Connection connection = whelk.getStorage().getOuterConnection()) {
 
+            // If an item appears several time on the same page, only the first of them should be a 'create'-event
+            // (assuming the record was created within the interval).
+            Set<String> idsAlreadyMarkedCreatedInInterval = new HashSet<>();
+
             // Get a page of items
             {
                 String sql = "SELECT" +
@@ -116,10 +121,25 @@ public class EmmChangeSet {
                         Timestamp creationTime = resultSet.getTimestamp(4);
                         String type = resultSet.getString(5);
                         String library = resultSet.getString(6);
-                        if (type != null && uri != null && modificationTime != null)
-                            result.add(new EmmActivity(uri, type, creationTime, modificationTime, deleted, library));
                         if (modificationTime.before(earliestSeenTimeStamp))
                             earliestSeenTimeStamp = modificationTime;
+
+                        if (type != null && uri != null) {
+                            Instant creation = creationTime.toInstant();
+                            Instant latestOnPage = untilTimeStamp.toInstant();
+                            Instant earliestOnPage = earliestSeenTimeStamp.toInstant();
+
+                            // Is the creation time of this record within the page interval, and it hasn't already been reported as created on this very page?
+                            boolean created = !
+                                    (
+                                            creation.isAfter(latestOnPage) ||
+                                            creation.isBefore(earliestOnPage)
+                                    ) && !idsAlreadyMarkedCreatedInInterval.contains(uri);
+                            if (created)
+                                idsAlreadyMarkedCreatedInInterval.add(uri);
+
+                            result.add(new EmmActivity(uri, type, modificationTime, deleted, created, library));
+                        }
                     }
                 }
             }
@@ -144,7 +164,23 @@ public class EmmChangeSet {
                         Timestamp creationTime = resultSet.getTimestamp(4);
                         String type = resultSet.getString(5);
                         String library = resultSet.getString(6);
-                        result.add(new EmmActivity(uri, type, creationTime, modificationTime, deleted, library));
+
+                        if (type != null && uri != null) {
+                            Instant creation = creationTime.toInstant();
+                            Instant latestOnPage = untilTimeStamp.toInstant();
+                            Instant earliestOnPage = earliestSeenTimeStamp.toInstant();
+
+                            // Is the creation time of this record within the page interval, and it hasn't already been reported as created on this very page?
+                            boolean created = !
+                                    (
+                                            creation.isAfter(latestOnPage) ||
+                                            creation.isBefore(earliestOnPage)
+                                    ) && !idsAlreadyMarkedCreatedInInterval.contains(uri);
+                            if (created)
+                                idsAlreadyMarkedCreatedInInterval.add(uri);
+
+                            result.add(new EmmActivity(uri, type, modificationTime, deleted, created, library));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…t be watertight.

The issue here is that prior to this change, the distinction was based on checking if 'modified' == 'created' on the record. But modified is not always updated!

This ment that a 'silent' change to a new record, would result in the item appearing in the EMM stream again, and being marked 'created' again, as these two timestamps were still identical!

Now we instead check if the creation time is within the EMM page interval, and if it is, we define it as a creation. If the item appears multiple times on the same page, only the first one is considered to be a creation.