### PR TITLE
feat(search2): Initial support for like operator ~

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/Operator.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Operator.java
@@ -6,6 +6,7 @@ import java.util.Map;
 //  e.g. https://id.kb.se/vocab/equals)
 public enum Operator {
     EQUALS("equals", "%s:%s"),
+    LIKE("like", "%s~%s"),
     GREATER_THAN_OR_EQUALS("greaterThanOrEquals", "%s>=%s"),
     GREATER_THAN("greaterThan", "%s>%s"),
     LESS_THAN_OR_EQUALS("lessThanOrEquals", "%s<=%s"),
@@ -39,6 +40,9 @@ public enum Operator {
     public static Map<String, Operator> symbolMappings() {
         return Map.of(
                 "=", EQUALS,
+                ":", EQUALS,
+                "~", LIKE,
+
                 ">", GREATER_THAN,
                 ">=", GREATER_THAN_OR_EQUALS,
                 "<", LESS_THAN,
@@ -47,6 +51,6 @@ public enum Operator {
     }
 
     public boolean isRange() {
-        return this != EQUALS;
+        return this != EQUALS && this != LIKE;
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -22,6 +22,7 @@ import whelk.search2.querytree.Value;
 import whelk.search2.querytree.YearRange;
 
 import whelk.util.DocumentUtil;
+import whelk.util.FresnelUtil;
 import whelk.util.Restrictions;
 
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -163,6 +165,8 @@ public class Query {
     }
 
     protected Map<String, Object> getPartialCollectionView() {
+
+
         var view = new LinkedHashMap<String, Object>();
 
         view.put(JsonLd.TYPE_KEY, "PartialCollectionView");
@@ -174,6 +178,22 @@ public class Query {
         if (queryParams.mappingOnly) {
             linkLoader.loadChips();
             return view;
+        }
+
+        var anyLike = qTree.allDescendants().anyMatch(n -> n instanceof Condition c
+                && c.operator() == Operator.LIKE
+                && c.value() instanceof Link);
+        if (anyLike) {
+            // FIXME this depends on chips being queued in getSearchMapping()
+            linkLoader.loadChips();
+            qTree.allDescendants().forEach(n -> {
+                if (n instanceof Condition c
+                        && c.operator() == Operator.LIKE
+                        && c.value() instanceof Link link) {
+                    var needle = whelk.getFresnelUtil().asString(link.description(), FresnelUtil.Lenses.SEARCH_NEEDLE);
+                    link.setSearchNeedle(needle);
+                }
+            });
         }
 
         view.put("itemOffset", queryParams.offset);
@@ -544,6 +564,8 @@ public class Query {
                     links.forEach(link -> link.setChip(dummyChip(id)));
                 }
             });
+
+            links.clear();
         }
 
         private Map<String, Object> dummyChip(String id) {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -104,7 +104,8 @@ public class QueryUtil {
                 // https://tools.ietf.org/html/rfc3986#section-3.4
                 .replace("%3A", ":")
                 .replace("%2F", "/")
-                .replace("%40", "@");
+                .replace("%40", "@")
+                .replace("%7E", "~");
     }
 
     public static Map<String, Object> mustWrap(Object l) {

--- a/whelk-core/src/main/groovy/whelk/search2/parse/Ast.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Ast.java
@@ -115,7 +115,7 @@ public class Ast {
             }
         }
 
-        // Code equals (:/=) term
+        // Code equals (:/=/~) term
         else if (term.string1() == null &&
                 term.uop() == null &&
                 term.term() != null &&
@@ -123,7 +123,7 @@ public class Ast {
                 term.bop() == null &&
                 term.bopeq() != null &&
                 term.string2() != null) {
-            return new Code(term.string2(), Operator.EQUALS, reduce(term.term()));
+            return new Code(term.string2(), Operator.symbolMappings().get(term.bopeq().op().value()), reduce(term.term()));
         }
 
         // Code less/greater than

--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -48,7 +48,7 @@ public class Lex {
         }
     }
 
-    private static final List<Character> reservedCharsInString = Arrays.asList('<', '>', '=', '(', ')', ':');
+    private static final List<Character> reservedCharsInString = Arrays.asList('<', '>', '=', '(', ')', ':', '~');
 
     private static Symbol getNextSymbol(StringBuilder query, MutableInteger offset) throws InvalidQueryException {
         consumeWhiteSpace(query, offset);

--- a/whelk-core/src/main/groovy/whelk/search2/parse/Parse.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Parse.java
@@ -16,7 +16,7 @@ public class Parse {
      * TERM: STRING | GROUP | UOPERATOR TERM | STRING BOPERATOR STRING | STRING BOPERATOREQ TERM
      * UOPERATOR: "NOT"
      * BOPERATOR: "<" | ">" | "<=" | ">="
-     * BOPERATOREQ: ":" | "="
+     * BOPERATOREQ: ":" | "=" | "~"
      * STRING: ...
      */
 
@@ -39,7 +39,7 @@ public class Parse {
     public record Boperator(Lex.Symbol op) {
     }
 
-    public record BoperatorEq() {
+    public record BoperatorEq(Lex.Symbol op) {
     }
 
     public static OrComb parseQuery(LinkedList<Lex.Symbol> symbols) throws InvalidQueryException {
@@ -95,14 +95,14 @@ public class Parse {
             }
         }
 
-        // BOPERATOREQ: ":" | "="
+        // BOPERATOREQ: ":" | "=" | "~"
         {
             if (!stack.isEmpty()) {
                 if (stack.getFirst() instanceof Lex.Symbol s &&
                         s.name() == Lex.TokenName.OPERATOR &&
-                        (s.value().equals("=") || s.value().equals(":"))) {
+                        (s.value().equals("=") || s.value().equals(":") || s.value().equals("~"))) {
                     stack.pop();
-                    stack.push(new BoperatorEq());
+                    stack.push(new BoperatorEq(s));
                     return true;
                 }
             }
@@ -178,6 +178,8 @@ public class Parse {
                         if (lookahead.name() == Lex.TokenName.OPERATOR && lookahead.value().equals("="))
                             okToReduce = false;
                         if (lookahead.name() == Lex.TokenName.OPERATOR && lookahead.value().equals(":"))
+                            okToReduce = false;
+                        if (lookahead.name() == Lex.TokenName.OPERATOR && lookahead.value().equals("~"))
                             okToReduce = false;
                     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Any.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Any.java
@@ -6,6 +6,7 @@ import whelk.search2.ESSettings;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static whelk.search2.QueryUtil.matchAny;
@@ -22,7 +23,7 @@ public sealed abstract class Any implements Node, Value permits Any.EmptyGroup, 
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
         // TODO
         return Map.of();
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -8,6 +8,7 @@ import whelk.search2.QueryUtil;
 import whelk.util.Restrictions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.hash;
@@ -320,10 +322,14 @@ public sealed class Condition implements Node permits Type {
             return esResourceFilter(f, l);
         }
 
+        var needle = Arrays.stream(l.getNeedle().split("\\s"))
+                .map(QueryUtil::quote)
+                .collect(Collectors.joining(" "));
         var freeTextFilter = Map.of("simple_query_string", Map.of(
-                        "query", l.getNeedle(),
+                        "query", needle,
                         "fields", List.of(selector.esField() + "." + SEARCH_KEY),
-                        "default_operator", "AND"));
+                        "default_operator", "AND",
+                        "quote_field_suffix", ESSettings.Boost.EXACT_SUFFIX));
         var notLinked = selector.getEsNestedStem(esSettings.mappings()).isPresent()
             ? mustNotWrap(existsFilter(f))
             : mustNotWrap(esResourceFilter(f, l));

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -25,9 +25,13 @@ import static whelk.search2.EsMappings.FOUR_DIGITS_KEYWORD_SUFFIX;
 import static whelk.search2.EsMappings.FOUR_DIGITS_SHORT_SUFFIX;
 import static whelk.search2.EsMappings.KEYWORD;
 import static whelk.search2.Operator.EQUALS;
+import static whelk.search2.Operator.LIKE;
 import static whelk.search2.QueryUtil.boolWrap;
+import static whelk.search2.QueryUtil.mustNotWrap;
+import static whelk.search2.QueryUtil.mustWrap;
 import static whelk.search2.QueryUtil.nestedWrap;
 import static whelk.search2.QueryUtil.parenthesize;
+import static whelk.search2.QueryUtil.shouldWrap;
 
 public sealed class Condition implements Node permits Type {
     private final Selector selector;
@@ -229,7 +233,9 @@ public sealed class Condition implements Node permits Type {
                     : esFreeTextFilter(selector.isObjectProperty() ? f + "." + SEARCH_KEY : f, ft, esSettings);
             case InvalidValue ignored -> nonsenseFilter(); // TODO: Treat whole expression as free text?
             case Numeric numeric -> esNumFilter(f, numeric, esSettings);
-            case Link link -> esResourceFilter(selector.isObjectProperty() ? f + "." + ID_KEY : f, link);
+            case Link link -> operator == LIKE
+                ? esLikeResourceFilter(selector.isObjectProperty() ? f + "." + ID_KEY : f, link, esSettings)
+                : esResourceFilter(selector.isObjectProperty() ? f + "." + ID_KEY : f, link);
             case VocabTerm vocabTerm -> esResourceFilter(f, vocabTerm);
             case Term term -> esTermFilter(f, term);
             case YearRange yearRange -> esYearRangeFilter(f, yearRange, esSettings);
@@ -292,7 +298,7 @@ public sealed class Condition implements Node permits Type {
 
     private Map<String, Object> esNumOrDateFilter(String f, Object v) {
         return switch (operator) {
-            case EQUALS -> esTermQueryFilter(f, v);
+            case EQUALS, LIKE -> esTermQueryFilter(f, v);
             case GREATER_THAN_OR_EQUALS -> esRangeFilter(f, "gte", v);
             case GREATER_THAN -> esRangeFilter(f, "gt", v);
             case LESS_THAN_OR_EQUALS -> esRangeFilter(f, "lte", v);
@@ -307,6 +313,27 @@ public sealed class Condition implements Node permits Type {
 
     private Map<String, Object> esResourceFilter(String f, Resource r) {
         return esTermQueryFilter(f, r.jsonForm());
+    }
+
+    private Map<String, Object> esLikeResourceFilter(String f, Link l, ESSettings esSettings) {
+        if ("".equals(l.getNeedle())) {
+            return esResourceFilter(f, l);
+        }
+
+        var freeTextFilter = Map.of("simple_query_string", Map.of(
+                        "query", l.getNeedle(),
+                        "fields", List.of(selector.esField() + "." + SEARCH_KEY),
+                        "default_operator", "AND"));
+        var notLinked = mustNotWrap(existsFilter(f));
+        var blankFilter = mustWrap(List.of(freeTextFilter, notLinked));
+
+        var linkedBeforeBlank = 50_000f;
+        return shouldWrap(
+                List.of(
+                        esTermQueryFilter(f, l.jsonForm(), linkedBeforeBlank),
+                        blankFilter
+                )
+        );
     }
 
     private Map<String, Object> esTermFilter(String f, Term t) {
@@ -329,12 +356,20 @@ public sealed class Condition implements Node permits Type {
         return boolWrap(Map.of("filter", m));
     }
 
+    private static Map<String, Object> filterWrap(Map<?, ?> m, float boost) {
+        return Map.of("constant_score", Map.of("filter", m, "boost", boost));
+    }
+
     private static Map<String, Object> rangeWrap(Map<?, ?> m) {
         return Map.of("range", m);
     }
 
     private static Map<String, Object> esTermQueryFilter(String field, Object value) {
         return filterWrap(Map.of("term", Map.of(field, value)));
+    }
+
+    private static Map<String, Object> esTermQueryFilter(String field, Object value, float boost) {
+        return filterWrap(Map.of("term", Map.of(field, Map.of("value", value))), boost);
     }
 
     // FIXME: Handle queries that are syntactically correct but make no sense and are guaranteed to return no hits

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -82,8 +83,8 @@ public sealed class Condition implements Node permits Type {
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
-        return _toSearchMapping(makeUpLink);
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
+        return _toSearchMapping(makeUpLink, makeReplaceLink);
     }
 
     @Override
@@ -210,12 +211,19 @@ public sealed class Condition implements Node permits Type {
         return new Or(altFields);
     }
 
-    private Map<String, Object> _toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
+    private Map<String, Object> _toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
         Map<String, Object> m = new LinkedHashMap<>();
 
         m.put("property", selector.definition());
         m.put(operator.termKey, value instanceof Resource r ? r.description() : value.queryForm());
         m.put("up", makeUpLink.apply(this));
+
+        if (operator == LIKE) {
+            m.put("toEquals", makeReplaceLink.apply(this, new Condition(selector, EQUALS, value)));
+        }
+        if (operator == EQUALS && selector instanceof Property p && p.isPreferLike()) {
+            m.put("toLike", makeReplaceLink.apply(this, new Condition(selector, LIKE, value)));
+        }
 
         m.put("_key", selector.queryKey());
         m.put("_value", value.queryForm());

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -324,7 +324,9 @@ public sealed class Condition implements Node permits Type {
                         "query", l.getNeedle(),
                         "fields", List.of(selector.esField() + "." + SEARCH_KEY),
                         "default_operator", "AND"));
-        var notLinked = mustNotWrap(existsFilter(f));
+        var notLinked = selector.getEsNestedStem(esSettings.mappings()).isPresent()
+            ? mustNotWrap(existsFilter(f))
+            : mustNotWrap(esResourceFilter(f, l));
         var blankFilter = mustWrap(List.of(freeTextFilter, notLinked));
 
         var linkedBeforeBlank = 50_000f;

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FilterAlias.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FilterAlias.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static whelk.JsonLd.Rdfs.RESOURCE;
@@ -42,10 +43,10 @@ public sealed class FilterAlias implements Node {
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
         var m = new LinkedHashMap<String, Object>();
         LinkedHashMap<String, Object> description = new LinkedHashMap<>(description());
-        description.put("parsedFilter", getParsed().toSearchMapping(makeUpLink));
+        description.put("parsedFilter", getParsed().toSearchMapping(makeUpLink, makeReplaceLink));
         m.put("object", description);
         m.put("value", alias());
         m.put("up", makeUpLink.apply(this));

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/FreeText.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,7 +58,7 @@ public record FreeText(Property.TextQuery textQuery, List<Token> tokens, Query.C
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("property", textQuery != null ? textQuery.definition() : Map.of());
         m.put(EQUALS.termKey, queryForm());

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -49,9 +49,9 @@ public sealed abstract class Group implements Node permits And, Or {
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
         var m = new LinkedHashMap<String, Object>();
-        m.put(key(), children().stream().map(c -> c.toSearchMapping(makeUpLink)).toList());
+        m.put(key(), children().stream().map(c -> c.toSearchMapping(makeUpLink, makeReplaceLink)).toList());
         m.put("up", makeUpLink.apply(this));
         return m;
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Link.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Link.java
@@ -16,6 +16,7 @@ public final class Link extends Resource {
     private final Map<String, Object> chip = new LinkedHashMap<>();
 
     private Token token;
+    private String needle;
 
     public Link(String iri) {
         this.iri = iri;
@@ -39,6 +40,14 @@ public final class Link extends Resource {
     public void setThing(Map<String, Object> thing) {
         this.chip.clear();
         this.thing.putAll(thing);
+    }
+
+    public void setSearchNeedle(String needle) {
+        this.needle = needle;
+    }
+
+    public String getNeedle() {
+        return needle;
     }
 
     public String iri() {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Node.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -16,7 +17,7 @@ public sealed interface Node permits Any, Condition, FilterAlias, FreeText, Grou
 
     ExpandedNode expand(JsonLd jsonLd, Collection<String> rdfSubjectTypes);
 
-    Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink);
+    Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink);
 
     String toQueryString(boolean topLevel);
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Not.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Not.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static whelk.search2.QueryUtil.parenthesize;
@@ -31,8 +32,8 @@ public record Not(Node node) implements Node {
     }
 
     @Override
-    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink) {
-        return Map.of("not", node.toSearchMapping(makeUpLink),
+    public Map<String, Object> toSearchMapping(Function<Node, Map<String, String>> makeUpLink, BiFunction<Node, Node, Map<String, String>> makeReplaceLink) {
+        return Map.of("not", node.toSearchMapping(makeUpLink, makeReplaceLink),
                 "up", makeUpLink.apply(this));
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -367,6 +367,11 @@ public non-sealed class Property extends PathElement {
         return langAlias != null;
     }
 
+    public boolean isPreferLike() {
+        // FIXME: don't hardcode
+        return isCategory("https://id.kb.se/ns/librissearch/preferLike", definition);
+    }
+
     private static boolean isComposite(Map<String, Object> definition) {
         // FIXME: don't hardcode
         return isCategory("https://id.kb.se/ns/librissearch/composite", definition);

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -57,7 +57,10 @@ public class QueryTree {
     }
 
     public Map<String, Object> toSearchMapping(QueryParams queryParams, String apiParam) {
-        return tree.toSearchMapping(n -> Map.of(JsonLd.ID_KEY, makeViewFindUrl(remove(n).toQueryString(), queryParams, apiParam)));
+        return tree.toSearchMapping(
+                n -> Map.of(JsonLd.ID_KEY, makeViewFindUrl(remove(n).toQueryString(), queryParams, apiParam)),
+                (n, n2) -> Map.of(JsonLd.ID_KEY, makeViewFindUrl(remove(n).add(n2).toQueryString(), queryParams, apiParam))
+        );
     }
 
     public QueryTree remove(Node node) {

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -55,6 +55,7 @@ public class FresnelUtil {
     public static final String SEARCH_TOKENS = "search-tokens";
     public static final String TOP_SEARCH_TOKENS = "top-search-tokens";
     public static final String TOKENS = "tokens";
+    public static final String SEARCH_NEEDLES = "search-needles";
 
     public record LensGroupChain(List<String> chain) {
         public LensGroupChain(String group) {
@@ -76,6 +77,8 @@ public class FresnelUtil {
         public static final Lens SEARCH_TOKEN = new Lens(SEARCH_TOKEN_CHAIN);
         public static final Lens TOP_SEARCH_TOKEN = new Lens(TOP_SEARCH_TOKEN_CHAIN);
         public static final Lens TOKEN = new Lens(TOKEN_CHAIN);
+        //public static final Lens SEARCH_NEEDLE = new Lens(new LensGroupChain(List.of(SEARCH_NEEDLES, TOP_SEARCH_TOKENS, SEARCH_TOKENS, SEARCH_CHIPS, CHIPS)));
+        public static final Lens SEARCH_NEEDLE = new Lens(new LensGroupChain(List.of(TOP_SEARCH_TOKENS, SEARCH_TOKENS, SEARCH_CHIPS, CHIPS)));
     }
 
     public static final class NestedLenses {

--- a/whelk-core/src/test/groovy/whelk/search2/parse/AstSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/parse/AstSpec.groovy
@@ -107,6 +107,19 @@ class AstSpec extends Specification {
         )
     }
 
+    def "like"() {
+        given:
+        def input = "contributor ~ \"ns:abc\""
+        def lexedSymbols = Lex.lexQuery(input)
+        Parse.OrComb parseTree = Parse.parseQuery(lexedSymbols)
+        Ast.Node ast = Ast.buildFrom(parseTree)
+
+        expect:
+        ast == new Ast.Code(new Lex.Symbol(STRING, "contributor", 0),
+                Operator.LIKE,
+                new Ast.Leaf(new Lex.Symbol(QUOTED_STRING, "ns:abc", 14)))
+    }
+
     def "comparison"() {
         given:
         def input = "published >= 2000"

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -14,7 +14,7 @@ class ConditionSpec extends Specification {
     def "convert to search mapping 1"() {
         given:
         def searchMapping = QueryTreeBuilder.buildTree('p1:v1', disambiguate)
-                .toSearchMapping {n -> ['@id': '/find?_q=*'] }
+                .toSearchMapping ({n -> ['@id': '/find?_q=*']}, {n, n2 -> ['@id': '/find?_q=']})
 
         expect:
         searchMapping == [
@@ -29,7 +29,7 @@ class ConditionSpec extends Specification {
     def "convert to search mapping 2"() {
         given:
         def searchMapping = QueryTreeBuilder.buildTree('NOT p1.p2:E1', disambiguate)
-                .toSearchMapping {n -> ['@id': '/find?_q=*'] }
+                .toSearchMapping ({n -> ['@id': '/find?_q=*']}, {n, n2 -> ['@id': '/find?_q=']})
 
         expect:
         searchMapping == [
@@ -54,7 +54,7 @@ class ConditionSpec extends Specification {
     def "convert to search mapping 3"() {
         given:
         def searchMapping = QueryTreeBuilder.buildTree('@reverse.p3.@reverse.p4:v1', disambiguate)
-                .toSearchMapping {n -> ['@id': '/find?_q=*'] }
+                .toSearchMapping ({n -> ['@id': '/find?_q=*']}, {n, n2 -> ['@id': '/find?_q=']})
 
         expect:
         searchMapping == [


### PR DESCRIPTION
Add support for `selector ~ <id>`

In addition to direct match on id this matches blank nodes whose `_str` contains all `toString(<id>, <needle lens>)`.