### PR TITLE
Define and use prioritizedWorkLegacyTypes

### DIFF
--- a/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
+++ b/whelk-core/src/integTest/groovy/MarcFrameConverterSpec.groovy
@@ -2,8 +2,11 @@ package whelk.converter.marc
 
 import spock.lang.*
 import whelk.filter.LinkFinder
+import whelk.util.DocumentUtil
+import whelk.util.WhelkFactory
 
 import whelk.Whelk
+import static whelk.JsonLd.ID_KEY as ID
 
 @Unroll
 class MarcFrameConverterSpec extends Specification {
@@ -13,6 +16,12 @@ class MarcFrameConverterSpec extends Specification {
     static Map marcframe
 
     static {
+        try {
+            whelk = WhelkFactory.getSingletonWhelk()
+        } catch (Exception e) {
+            System.err.println("Unable to instantiate whelk: $e")
+        }
+
         converter = MarcFrameCli.newMarcFrameConverter()
         marcframe = converter.readConfig(converter.marcframeFile)
         converter.conversion.doPostProcessing = false
@@ -272,7 +281,7 @@ class MarcFrameConverterSpec extends Specification {
         result.fields[1]["008"] == "900101|        |  |||||||||||000 1dswe| "
     }
 
-    def "should handle postprocessing on convert"() {
+    def "should handle postprocessing on convert - #item.spec.name"() {
         given:
         def data = deepcopy(item.spec.source)
         def record = data
@@ -288,7 +297,7 @@ class MarcFrameConverterSpec extends Specification {
         item << postProcStepSpecs.findAll { it.spec.source }
     }
 
-    def "should handle postprocessing on revert"() {
+    def "should handle postprocessing on revert - #item.spec.name"() {
         given:
         def data = getSpecPiece(item.spec, 'result')
         def record = data
@@ -299,6 +308,9 @@ class MarcFrameConverterSpec extends Specification {
         then:
         if (item.spec.back) {
             def expected = getSpecPiece(item.spec, 'back')
+            if (item.spec.back == 'source') {
+                reduceToLinkedForComparison(data)
+            }
             assertJsonEquals(data, expected)
         }
 
@@ -420,6 +432,23 @@ class MarcFrameConverterSpec extends Specification {
         def resultJson = json(result)
         def expectedJson = json(expected)
         assert resultJson == expectedJson
+    }
+
+    boolean reduceToLinkedForComparison(Map entity) {
+        DocumentUtil.traverse(entity) { value, path ->
+            if (!path.isEmpty() && path[-1] != 'mainEntity' && path[-1] != 'instanceOf') {
+                if (value instanceof List && value.isEmpty()) {
+                    return new DocumentUtil.Remove()
+                }
+                if (value instanceof Map && '_revertedBy' in value) {
+                    value.remove('_revertedBy')
+                }
+                if (value instanceof Map && ID in value) {
+                    return new DocumentUtil.Replace([(ID): value[ID]])
+                }
+                return
+            }
+        }
     }
 
     void assertJsonEqualsOnRevert(result, expected) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -23,6 +23,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     List<String> newWorkTypes = Collections.emptyList()
     String defaultWorkLegacyType
     String componentPartCategory
+    List<String> prioritizedWorkLegacyTypes = Collections.emptyList()
     List<String> keepMatchingWithCategories = Collections.emptyList()
 
     Map<String, Set<String>> marcTypeMappings  // TODO: turn JSON set value to Set! (for speed)
@@ -116,7 +117,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         DocumentUtil.traverse(work) { value, path ->
             if (!path.isEmpty()) {
                 if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
-                    reshapeToLegacyWork(value, getDescriptions(value.category))
+                    reshapeToLegacyWork(value, getDescriptions(value.remove('category')))
                 }
             }
         }
@@ -132,10 +133,14 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     String getWorkType(List<Map<String, Object>> workCategories) {
         // TODO:
-        // - better match ranking? i:Audio [if SpokenWords?/Ljudböcker] > a:Text > k:StillImage ?
-        // FIXME: also construct ManuscriptText | ManuscriptNotatedMusic | Cartography
+        // - More involved match ranking? i:Audio [if SpokenWords?/Ljudböcker] > a:Text > k:StillImage ?
+        // - also construct ManuscriptText | ManuscriptNotatedMusic | Cartography (if asked for)
         var result = collectImpliedTypesFromCategory(workCategories)
-        if (defaultWorkLegacyType in result) return defaultWorkLegacyType
+        for (prioType in prioritizedWorkLegacyTypes) {
+            if (prioType in result) {
+                return prioType
+            }
+        }
         for (type in result) return type
     }
 
@@ -165,11 +170,11 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         for (type in result) return type
     }
 
-    List<Map<String, Object>> getDescriptions(Object refs) {
+    List<Map<String, Object>> getDescriptions(Object refs, boolean onlyLinked=false) {
         return (List<Map<String, Object>>) asList(refs).findResults {
             ID in it && it[ID] in typeCategoryNormalizer.categories
                 ? new HashMap(typeCategoryNormalizer.categories[it[ID]])
-                : it
+                : onlyLinked ? null : it
         }
     }
 
@@ -234,7 +239,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
                 result[key] = ctg
             }
             for (rel in matchRelations) {
-                var implied = getDescriptions(ctg[rel])
+                var implied = getDescriptions(ctg[rel], true)
                 if (!keepImplied) {
                     implied.each {
                         var keep = ID in it

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameCli.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameCli.groovy
@@ -11,6 +11,7 @@ import whelk.ResourceCache
 import whelk.TypeCategoryNormalizer
 import whelk.Whelk
 import whelk.filter.LinkFinder
+import whelk.util.WhelkFactory
 
 import static whelk.util.Jackson.mapper
 
@@ -30,7 +31,7 @@ if (fpaths.size() > 1) {
 }
 
 if (cmd == "cachebytype") {
-  var whelk = Whelk.createLoadedSearchWhelk()
+  var whelk = WhelkFactory.getSingletonWhelk()
   var start = new Date().time
   for (type in ['Category', 'marc:EnumeratedTerm']) {
     System.err.println "getByType: ${type}"
@@ -166,7 +167,7 @@ if (perf) {
 
 static MarcFrameConverter newMarcFrameConverter() {
     if (System.properties.getProperty('xl.secret.properties')) {
-        def whelk = Whelk.createLoadedCoreWhelk()
+        var whelk = WhelkFactory.getSingletonWhelk()
         return whelk.getMarcFrameConverter()
     }
 

--- a/whelk-core/src/main/resources/ext/marcframe-bib-postproc-typenormalization.json
+++ b/whelk-core/src/main/resources/ext/marcframe-bib-postproc-typenormalization.json
@@ -3,6 +3,7 @@
   "matchRelations": ["exactMatch", "closeMatch", "broader", "broadMatch"],
   "newWorkTypes": ["Monograph", "Serial", "Collection", "Integrating"],
   "defaultWorkLegacyType": "Text",
+  "prioritizedWorkLegacyTypes": ["Multimedia", "Text"],
   "componentPartCategory": "https://id.kb.se/term/saobf/ComponentPart",
   "keepMatchingWithCategories": [],
   "marcTypeMappings": {
@@ -62,6 +63,45 @@
   "_spec:TODO:from": "whelktool/scripts/typenormalization/tailored_examples.jsonl",
   "_spec": [
     {
+      "name": "bibtype-map simple instance and work",
+      "source": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "Print",
+          "mediaType": [
+            {"@id": "https://id.kb.se/term/rda/Unmediated"}
+          ],
+          "carrierType": [
+            {"@id": "https://id.kb.se/term/rda/Volume"}
+          ],
+          "issuanceType": "Monograph",
+          "instanceOf": {
+            "@type": "Text",
+            "contentType": [
+              {"@id": "https://id.kb.se/term/rda/Text"}
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "PhysicalResource",
+          "category": [
+            {"@id": "https://id.kb.se/term/rda/Volume"},
+            {"@id": "https://id.kb.se/term/saobf/Print"}
+          ],
+          "instanceOf": {
+            "@type": "Monograph",
+            "category": [
+              {"@id": "https://id.kb.se/term/rda/Text"}
+            ]
+          }
+        }
+      },
+      "back": "source"
+    },
+    {
       "name": "bibtype-map embedded instance and work",
       "source": {
         "mainEntity": {
@@ -84,7 +124,9 @@
                 "Sammanfattning och fulltext från Linköping University Electronic Press"
               ],
               "instanceOf": {"@type": "Text"},
-              "carrierType": {"@id": "https://id.kb.se/marc/Electronic"},
+              "carrierType": [
+                {"@id": "https://id.kb.se/marc/Electronic"}
+              ],
               "issuanceType": "Monograph"
             }
           ],
@@ -96,13 +138,16 @@
             ],
             "genreForm": [
               {"@id": "https://id.kb.se/term/saogf/Avhandlingar"},
+              {"@id": "https://id.kb.se/marc/Thesis"},
+              {"@id": "https://id.kb.se/term/saogf/Facklitteratur"},
+              {"@id" : "https://id.kb.se/term/ktg/NonFictionLiterature"},
+              {"@id" : "https://id.kb.se/marc/NotFictionNotFurtherSpecified"},
+              {"@id" : "https://id.kb.se/term/ktg/Literature"},
               {
                 "@type": "GenreForm",
                 "inScheme": {"@id": "https://id.kb.se/term/lcgft"},
                 "prefLabel": "Academic theses"
-              },
-              {"@id": "https://id.kb.se/marc/Thesis"},
-              {"@id": "https://id.kb.se/term/saogf/Facklitteratur"}
+              }
             ],
             "hasPart": [
               {
@@ -110,24 +155,22 @@
                 "intendedAudience": [
                   {"@id": "https://id.kb.se/marc/Juvenile"}
                 ],
-                "contentType": {"@id": "https://id.kb.se/term/rda/Text"},
+                "contentType": [
+                  {"@id": "https://id.kb.se/term/rda/Text"}
+                ],
                 "genreForm": [
                   {"@id": "https://id.kb.se/term/saogf/Sk%C3%B6nlitteratur"},
+                  {"@id": "https://id.kb.se/marc/FictionNotFurtherSpecified"},
+                  {"@id": "https://id.kb.se/term/ktg/Literature"},
                   {
                     "@type": "GenreForm",
                     "inScheme": {"@id": "https://id.kb.se/term/lcsh"},
                     "prefLabel": "Literature"
-                  },
-                  {"@id": "https://id.kb.se/marc/FictionNotFurtherSpecified"},
-                  {"@id": "https://id.kb.se/term/ktg/Literature"}
+                  }
                 ]
               },
               {
                 "@type": "Audio",
-                "category": [
-                  {"@id": "https://id.kb.se/marc/Fiction"},
-                  {"@id": "https://id.kb.se/term/ktg/Audio"}
-                ],
                 "intendedAudience": [
                   {"@id": "https://id.kb.se/marc/Juvenile"}
                 ],
@@ -202,7 +245,54 @@
             ]
           }
         }
-      }
+      },
+      "back": "source"
+    },
+    {
+      "name": "bibtype-map prioritized work legacy type",
+      "source": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "Print",
+          "mediaType": [
+            {"@id": "https://id.kb.se/term/rda/Unmediated"}
+          ],
+          "carrierType": [
+            {"@id": "https://id.kb.se/term/rda/Volume"}
+          ],
+          "issuanceType": "Monograph",
+          "instanceOf": {
+            "@type": "Multimedia",
+            "contentType": [
+              {"@id": "https://id.kb.se/term/rda/ComputerProgram"},
+              {"@id": "https://id.kb.se/marc/ComputerProgram"},
+              {"@id": "https://id.kb.se/term/rda/Text"}
+            ],
+            "genreForm": [
+              {"@id": "https://id.kb.se/marc/ComputerProgram"},
+              {"@id": "https://id.kb.se/term/ktg/Software"}
+            ]
+          }
+        }
+      },
+      "result": {
+        "mainEntity": {
+          "@id": "https://libris.kb.se/000000000000000#it",
+          "@type": "PhysicalResource",
+          "category": [
+            {"@id": "https://id.kb.se/term/rda/Volume"},
+            {"@id": "https://id.kb.se/term/saobf/Print"}
+          ],
+          "instanceOf": {
+            "@type": "Monograph",
+            "category": [
+              {"@id": "https://id.kb.se/term/rda/ComputerProgram"},
+              {"@id": "https://id.kb.se/term/rda/Text"}
+            ]
+          }
+        }
+      },
+      "back": "source"
     }
   ]
 }


### PR DESCRIPTION
Ensures that entailed Multimedia type is used in preference over other types.

Includes:
- New test case data
- Fix running of revert test and adjust otherwise failing existing example
- Reduce result to contain non-embellished links when comparing to source data
- Only include linked terms in implied terms (would otherwise include local closeMatch entities matching e.g. lcgft terms)
- Use singleton whelk in test data (and MarcFrameCli utility class)