### PR TITLE
Feature/es nested grouping

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
@@ -144,9 +144,8 @@ public class ObjectQuery extends Query {
         var filters = new HashMap<>();
 
         predicateToSubjectTypes.forEach((p, subjects) -> {
-            var filter = new Condition(p, Operator.EQUALS, object)
+            var filter = new QueryTree(new Condition(p, Operator.EQUALS, object))
                     .expand(jsonLd, subjects)
-                    .expandedRoot()
                     .toEs(esSettings);
             filters.put(p.name(), filter);
         });

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/And.java
@@ -1,7 +1,6 @@
 package whelk.search2.querytree;
 
 import whelk.JsonLd;
-import whelk.search2.ESSettings;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -11,7 +10,6 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static whelk.search2.QueryUtil.mustWrap;
-import static whelk.search2.QueryUtil.nestedWrap;
 
 public non-sealed class And extends Group {
     private final List<Node> children;
@@ -22,11 +20,6 @@ public non-sealed class And extends Group {
 
     public And(List<Node> children, boolean flattenChildren) {
         this.children = flattenChildren ? flattenChildren(children) : children;
-    }
-
-    @Override
-    public Map<String, Object> toEs(ESSettings esSettings) {
-        return mustWrap(childrenToEs(esSettings));
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -32,11 +31,10 @@ import static whelk.search2.Operator.LIKE;
 import static whelk.search2.QueryUtil.boolWrap;
 import static whelk.search2.QueryUtil.mustNotWrap;
 import static whelk.search2.QueryUtil.mustWrap;
-import static whelk.search2.QueryUtil.nestedWrap;
 import static whelk.search2.QueryUtil.parenthesize;
 import static whelk.search2.QueryUtil.shouldWrap;
 
-public sealed class Condition implements Node permits Type {
+public non-sealed class Condition implements Node {
     private final Selector selector;
     private final Operator operator;
     private final Value value;
@@ -68,11 +66,7 @@ public sealed class Condition implements Node permits Type {
         if (selector instanceof Property.TextQuery && value instanceof FreeText ft) {
             return ft.toEs(esSettings);
         }
-        return getEsNestedQuery(esSettings).orElse(getCoreEsQuery(esSettings));
-    }
-
-    public Map<String, Object> getCoreEsQuery(ESSettings esSettings) {
-        return _getCoreEsQuery(selector.esField(), value, esSettings);
+        return buildEsQuery(selector.esField(), value, esSettings);
     }
 
     @Override
@@ -229,7 +223,7 @@ public sealed class Condition implements Node permits Type {
         return m;
     }
 
-    private Map<String, Object> _getCoreEsQuery(String f, Value v, ESSettings esSettings) {
+    private Map<String, Object> buildEsQuery(String f, Value v, ESSettings esSettings) {
         if (operator.isRange() && !v.isRangeOpCompatible()) {
             // FIXME
             return nonsenseFilter();
@@ -251,19 +245,13 @@ public sealed class Condition implements Node permits Type {
         };
     }
 
-    private Optional<Map<String, Object>> getEsNestedQuery(ESSettings esSettings) {
-        return selector.getEsNestedStem(esSettings.mappings())
-                .filter(esSettings.mappings()::isNestedNotInParentField)
-                .map(nestedStem -> nestedWrap(nestedStem, getCoreEsQuery(esSettings)));
-    }
-
     private Map<String, Object> esDateFilter(String field, DateTime d, ESSettings esSettings) {
         // TODO: What about e.g. :firstIssueDate/:lastIssueDate? These have range xsd:date however are not indexed as date type in ES.
         if (esSettings.mappings().isDateTypeField(field)) {
             return esNumOrDateFilter(field, d.dateTime().toElasticDateString());
         }
         // Treat as free text
-        return _getCoreEsQuery(field, new FreeText(d.toString()), esSettings);
+        return buildEsQuery(field, new FreeText(d.toString()), esSettings);
     }
 
     private Map<String, Object> esNumFilter(String field, Numeric n, ESSettings esSettings) {
@@ -288,7 +276,7 @@ public sealed class Condition implements Node permits Type {
         }
 
         // Treat as free text
-        return _getCoreEsQuery(field, new FreeText(n.toString()), esSettings);
+        return buildEsQuery(field, new FreeText(n.toString()), esSettings);
     }
 
     private Map<String, Object> esYearRangeFilter(String field, YearRange yearRange, ESSettings esSettings) {
@@ -302,7 +290,7 @@ public sealed class Condition implements Node permits Type {
             return esRangeFilter(field, yearRange.toEsDateRange());
         }
 
-        return _getCoreEsQuery(field, new FreeText(yearRange.toString()), esSettings);
+        return buildEsQuery(field, new FreeText(yearRange.toString()), esSettings);
     }
 
     private Map<String, Object> esNumOrDateFilter(String f, Object v) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -253,6 +253,7 @@ public sealed class Condition implements Node permits Type {
 
     private Optional<Map<String, Object>> getEsNestedQuery(ESSettings esSettings) {
         return selector.getEsNestedStem(esSettings.mappings())
+                .filter(esSettings.mappings()::isNestedNotInParentField)
                 .map(nestedStem -> nestedWrap(nestedStem, getCoreEsQuery(esSettings)));
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -60,24 +60,29 @@ public class EsQueryTree {
 
         private static Node _getNestedTree(Node tree, EsMappings esMappings) {
             if (tree instanceof And and) {
-                List<Nested> nestedGroups = collectNestedGroups(and, esMappings);
-                List<Node> nested = nestedGroups.stream().map(And::children).flatMap(List::stream).toList();
+                List<NestedAnd> nestedAndGroups = collectNestedGroups(and, esMappings);
+                List<Node> nested = nestedAndGroups.stream().map(And::children).flatMap(List::stream).toList();
                 List<Node> nonNested = and.children().stream()
                         .filter(Predicate.not(nested::contains))
                         .map(n -> getNestedTree(n, esMappings)).toList();
-                if (nestedGroups.size() == 1 && nonNested.isEmpty()) {
-                    return nestedGroups.getFirst();
+                if (nestedAndGroups.size() == 1 && nonNested.isEmpty()) {
+                    return nestedAndGroups.getFirst();
                 }
-                return new And(Stream.concat(nestedGroups.stream(), nonNested.stream()).toList(), false);
+                return new And(Stream.concat(nestedAndGroups.stream(), nonNested.stream()).toList(), false);
             }
             if (tree instanceof Or or) {
-                return or.mapAndReinstantiate(n -> getNestedTree(n, esMappings));
+                var nestedOr = getNestedStem(or, esMappings)
+                        .filter(esMappings::isNestedNotInParentField)
+                        .map(stem -> new NestedOr(or.children(), stem));
+                return nestedOr.isPresent()
+                        ? nestedOr.get()
+                        : or.mapAndReinstantiate(n -> getNestedTree(n, esMappings));
             }
             return tree;
         }
 
-        private static List<Nested> collectNestedGroups(And and, EsMappings esMappings) {
-            List<Nested> nestedGroups = new ArrayList<>();
+        private static List<NestedAnd> collectNestedGroups(And and, EsMappings esMappings) {
+            List<NestedAnd> nestedAndGroups = new ArrayList<>();
 
             Map<String, Map<String, List<Node>>> groups = new LinkedHashMap<>();
 
@@ -85,7 +90,7 @@ public class EsQueryTree {
                 groups.forEach((stem, nodesByField) -> {
                     var group = nodesByField.values().stream().flatMap(List::stream).toList();
                     if (group.size() > 1) {
-                        nestedGroups.add(new Nested(group, stem));
+                        nestedAndGroups.add(new NestedAnd(group, stem));
                     }
                 });
                 groups.clear();
@@ -116,7 +121,7 @@ public class EsQueryTree {
 
             harvestNested.run();
 
-            return nestedGroups;
+            return nestedAndGroups;
         }
 
         private static Group regroupAltSelectorsByNestedStem(And and, EsMappings esMappings) {
@@ -198,7 +203,7 @@ public class EsQueryTree {
                 return new PostFilterTree(null);
             }
 
-            List<Nested> nestedGroups = new QueryTree(nestedTree.tree()).getTopNodesOfType(Nested.class);
+            List<NestedAnd> nestedAndGroups = new QueryTree(nestedTree.tree()).getTopNodesOfType(NestedAnd.class);
 
             List<Node> postFilterNodes = new ArrayList<>();
             for (List<Node> multiSelected : multiSelectGroups) {
@@ -206,8 +211,8 @@ public class EsQueryTree {
                         .map(PostFilterTree::flattenedConditions)
                         .flatMap(Set::stream)
                         .collect(Collectors.toSet());
-                nestedGroups.stream()
-                        .filter(nested -> intersect(flattenedConditions(nested), selectedConditions))
+                nestedAndGroups.stream()
+                        .filter(nestedAnd -> intersect(flattenedConditions(nestedAnd), selectedConditions))
                         .findFirst()
                         .ifPresentOrElse(postFilterNodes::add,
                                 () -> postFilterNodes.add(multiSelected.size() > 1 ? new Or(multiSelected) : multiSelected.getFirst()));
@@ -234,10 +239,10 @@ public class EsQueryTree {
         }
     }
 
-    private static final class Nested extends And {
+    private static final class NestedAnd extends And {
         private final String stem;
 
-        private Nested(List<? extends Node> children, String stem) {
+        private NestedAnd(List<? extends Node> children, String stem) {
             super(children);
             this.stem = stem;
         }
@@ -248,8 +253,27 @@ public class EsQueryTree {
         }
 
         @Override
-        public Nested newInstance(List<Node> children) {
-            return new Nested(children, stem);
+        public NestedAnd newInstance(List<Node> children) {
+            return new NestedAnd(children, stem);
+        }
+    }
+
+    private static final class NestedOr extends Or {
+        private final String stem;
+
+        private NestedOr(List<? extends Node> children, String stem) {
+            super(children);
+            this.stem = stem;
+        }
+
+        @Override
+        public Map<String, Object> toEs(ESSettings esSettings) {
+            return nestedWrap(stem, super.getCoreEsQuery(esSettings));
+        }
+
+        @Override
+        public NestedOr newInstance(List<Node> children) {
+            return new NestedOr(children, stem);
         }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -224,7 +224,7 @@ public class EsQueryTree {
                         .collect(Collectors.toSet());
                 nestedNodes.stream()
                         .map(Node.class::cast)
-                        .filter(nestedNode -> intersect(flattenedConditions(nestedNode), selectedConditions))
+                        .filter(nestedNode -> intersects(flattenedConditions(nestedNode), selectedConditions))
                         .findFirst()
                         .ifPresentOrElse(postFilterNodes::add,
                                 () -> postFilterNodes.add(multiSelected.size() > 1 ? new Or(multiSelected) : multiSelected.getFirst()));
@@ -238,7 +238,7 @@ public class EsQueryTree {
             return tree == null;
         }
 
-        private static boolean intersect(Set<?> a, Set<?> b) {
+        private static boolean intersects(Set<?> a, Set<?> b) {
             return a.stream().anyMatch(b::contains);
         }
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -6,6 +6,7 @@ import whelk.search2.SelectedFacets;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,7 +60,7 @@ public class EsQueryTree {
 
         private static Node _getNestedTree(Node tree, EsMappings esMappings) {
             if (tree instanceof And and) {
-                List<Nested> nestedGroups = getNestedGroups(and, esMappings);
+                List<Nested> nestedGroups = collectNestedGroups(and, esMappings);
                 List<Node> nested = nestedGroups.stream().map(And::children).flatMap(List::stream).toList();
                 List<Node> nonNested = and.children().stream()
                         .filter(Predicate.not(nested::contains))
@@ -75,16 +76,45 @@ public class EsQueryTree {
             return tree;
         }
 
-        private static List<Nested> getNestedGroups(And and, EsMappings esMappings) {
+        private static List<Nested> collectNestedGroups(And and, EsMappings esMappings) {
             List<Nested> nestedGroups = new ArrayList<>();
 
-            and.children().stream().collect(Collectors.groupingBy(node -> getNestedStem(node, esMappings)))
-                    .forEach((nestedStem, group) -> {
-                        // At least two different paths sharing the same nested stem
-                        if (nestedStem.isPresent() && group.size() > 1) {
-                            nestedGroups.add(new Nested(group, nestedStem.get()));
+            Map<String, Map<String, List<Node>>> groups = new LinkedHashMap<>();
+
+            Runnable harvestNested = () -> {
+                groups.forEach((stem, nodesByField) -> {
+                    var group = nodesByField.values().stream().flatMap(List::stream).toList();
+                    if (group.size() > 1) {
+                        nestedGroups.add(new Nested(group, stem));
+                    }
+                });
+                groups.clear();
+            };
+
+            and.children().forEach(n -> {
+                var stem = getNestedStem(n, esMappings);
+                if (stem.isEmpty()) {
+                    harvestNested.run();
+                } else {
+                    var selectors = (n instanceof Condition c ? List.of(c) : n.children())
+                            .stream()
+                            .map(Condition.class::cast)
+                            .map(Condition::selector)
+                            .toList();
+                    for (Selector s : selectors) {
+                        var field = s.esField();
+                        var nodesForField = groups.getOrDefault(stem.get(), Map.of()).getOrDefault(field, List.of());
+                        if (!nodesForField.isEmpty() && !s.isLdSetContainer()) {
+                            harvestNested.run();
                         }
-                    });
+                        groups.computeIfAbsent(stem.get(), k -> new LinkedHashMap<>())
+                                .computeIfAbsent(field, k -> new ArrayList<>())
+                                .add(n);
+                    }
+                }
+            });
+
+            harvestNested.run();
 
             return nestedGroups;
         }
@@ -119,8 +149,9 @@ public class EsQueryTree {
             if (node instanceof Condition c) {
                 return c.selector().getEsNestedStem(esMappings);
             }
-            if (node instanceof Group g) {
-                var groupedByNestedStem = g.children().stream().collect(Collectors.groupingBy(n -> getNestedStem(n, esMappings)));
+            if (node instanceof Or or) {
+                var groupedByNestedStem = or.children().stream()
+                        .collect(Collectors.groupingBy(n -> getNestedStem(n, esMappings)));
                 if (groupedByNestedStem.size() == 1) {
                     return groupedByNestedStem.keySet().iterator().next();
                 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -67,26 +67,35 @@ public class EsQueryTree {
         }
 
         private static Node _getNestedTree(Node tree, EsMappings esMappings) {
-            if (tree instanceof And and) {
-                List<NestedAnd> nestedAndGroups = collectNestedGroups(and, esMappings);
-                List<Node> nested = nestedAndGroups.stream().map(And::children).flatMap(List::stream).toList();
-                List<Node> nonNested = and.children().stream()
-                        .filter(Predicate.not(nested::contains))
-                        .map(n -> getNestedTree(n, esMappings)).toList();
-                if (nestedAndGroups.size() == 1 && nonNested.isEmpty()) {
-                    return nestedAndGroups.getFirst();
+            return switch (tree) {
+                case And and -> {
+                    List<NestedAnd> nestedAndGroups = collectNestedGroups(and, esMappings);
+                    List<Node> nested = nestedAndGroups.stream().map(And::children).flatMap(List::stream).toList();
+                    List<Node> nonNested = and.children().stream()
+                            .filter(Predicate.not(nested::contains))
+                            .map(n -> getNestedTree(n, esMappings)).toList();
+                    if (nestedAndGroups.size() == 1 && nonNested.isEmpty()) {
+                        yield nestedAndGroups.getFirst();
+                    }
+                    yield new And(Stream.concat(nestedAndGroups.stream(), nonNested.stream()).toList(), false);
                 }
-                return new And(Stream.concat(nestedAndGroups.stream(), nonNested.stream()).toList(), false);
-            }
-            if (tree instanceof Or or) {
-                var nestedOr = getNestedStem(or, esMappings)
+                case Or or -> {
+                    var nestedOr = findUnambiguousNestedStem(or, esMappings)
+                            .filter(esMappings::isNestedNotInParentField)
+                            .map(stem -> new NestedOr(or.children(), stem));
+                    yield nestedOr.isPresent()
+                            ? nestedOr.get()
+                            : or.mapAndReinstantiate(n -> getNestedTree(n, esMappings));
+                }
+                case Not(Node node) -> node instanceof Group g
+                        ? getNestedTree(g.getInverse(), esMappings)
+                        : new Not(getNestedTree(node, esMappings));
+                case Condition c -> c.selector().getEsNestedStem(esMappings)
                         .filter(esMappings::isNestedNotInParentField)
-                        .map(stem -> new NestedOr(or.children(), stem));
-                return nestedOr.isPresent()
-                        ? nestedOr.get()
-                        : or.mapAndReinstantiate(n -> getNestedTree(n, esMappings));
-            }
-            return tree;
+                        .map(stem -> (Condition) new NestedCondition(c, stem))
+                        .orElse(c);
+                default -> tree;
+            };
         }
 
         private static List<NestedAnd> collectNestedGroups(And and, EsMappings esMappings) {
@@ -96,8 +105,8 @@ public class EsQueryTree {
 
             Runnable harvestNested = () -> {
                 groups.forEach((stem, nodesByField) -> {
-                    var group = nodesByField.values().stream().flatMap(List::stream).toList();
-                    if (group.size() > 1) {
+                    var group = nodesByField.values().stream().flatMap(List::stream).distinct().toList();
+                    if (group.size() > 1 && !group.stream().allMatch(Not.class::isInstance)) {
                         nestedAndGroups.add(new NestedAnd(group, stem));
                     }
                 });
@@ -105,7 +114,7 @@ public class EsQueryTree {
             };
 
             and.children().forEach(n -> {
-                var stem = getNestedStem(n, esMappings);
+                var stem = findUnambiguousNestedStem(n, esMappings);
                 if (stem.isEmpty()) {
                     harvestNested.run();
                 } else {
@@ -117,7 +126,7 @@ public class EsQueryTree {
                     for (Selector s : selectors) {
                         var field = s.esField();
                         var nodesForField = groups.getOrDefault(stem.get(), Map.of()).getOrDefault(field, List.of());
-                        if (!nodesForField.isEmpty() && !s.isLdSetContainer()) {
+                        if (!nodesForField.isEmpty() && !s.isLdSetContainer() && !(n instanceof Not)) {
                             harvestNested.run();
                         }
                         groups.computeIfAbsent(stem.get(), k -> new LinkedHashMap<>())
@@ -148,7 +157,7 @@ public class EsQueryTree {
                 Map<Optional<String>, List<Node>> groupedByNestedStem = altSelectors.stream()
                         .map(Node::children)
                         .flatMap(List::stream)
-                        .collect(Collectors.groupingBy(n -> getNestedStem(n, esMappings)));
+                        .collect(Collectors.groupingBy(n -> findUnambiguousNestedStem(n, esMappings)));
                 if (!groupedByNestedStem.containsKey(Optional.empty())) {
                     newChildren.removeAll(altSelectors);
                     newChildren.add(new Or(groupedByNestedStem.values().stream().map(And::new).toList()));
@@ -158,18 +167,20 @@ public class EsQueryTree {
             return newChildren.size() == 1 ? (Or) newChildren.getFirst() : new And(newChildren);
         }
 
-        private static Optional<String> getNestedStem(Node node, EsMappings esMappings) {
-            if (node instanceof Condition c) {
-                return c.selector().getEsNestedStem(esMappings);
-            }
-            if (node instanceof Or or) {
-                var groupedByNestedStem = or.children().stream()
-                        .collect(Collectors.groupingBy(n -> getNestedStem(n, esMappings)));
-                if (groupedByNestedStem.size() == 1) {
-                    return groupedByNestedStem.keySet().iterator().next();
+        private static Optional<String> findUnambiguousNestedStem(Node node, EsMappings esMappings) {
+            return switch (node) {
+                case Condition c -> c.selector().getEsNestedStem(esMappings);
+                case Not not -> findUnambiguousNestedStem(not.node(), esMappings);
+                case Or or -> {
+                    var stems = or.children().stream()
+                            .map(n -> findUnambiguousNestedStem(n, esMappings))
+                            .collect(Collectors.toSet());
+                    yield stems.size() == 1
+                            ? stems.iterator().next()
+                            : Optional.empty();
                 }
-            }
-            return Optional.empty();
+                default -> Optional.empty();
+            };
         }
 
         private static Node remove(Node tree, Collection<Condition> remove) {
@@ -203,7 +214,7 @@ public class EsQueryTree {
                 return new PostFilterTree(null);
             }
 
-            List<NestedAnd> nestedAndGroups = new QueryTree(nestedTree.tree()).getTopNodesOfType(NestedAnd.class);
+            List<NestedNode> nestedNodes = new QueryTree(nestedTree.tree()).getTopNodesOfType(NestedNode.class);
 
             List<Node> postFilterNodes = new ArrayList<>();
             for (List<Node> multiSelected : multiSelectGroups) {
@@ -211,8 +222,9 @@ public class EsQueryTree {
                         .map(EsQueryTree::flattenedConditions)
                         .flatMap(Set::stream)
                         .collect(Collectors.toSet());
-                nestedAndGroups.stream()
-                        .filter(nestedAnd -> intersect(flattenedConditions(nestedAnd), selectedConditions))
+                nestedNodes.stream()
+                        .map(Node.class::cast)
+                        .filter(nestedNode -> intersect(flattenedConditions(nestedNode), selectedConditions))
                         .findFirst()
                         .ifPresentOrElse(postFilterNodes::add,
                                 () -> postFilterNodes.add(multiSelected.size() > 1 ? new Or(multiSelected) : multiSelected.getFirst()));
@@ -235,7 +247,24 @@ public class EsQueryTree {
         return node.allDescendants().filter(Condition.class::isInstance).map(Condition.class::cast).collect(Collectors.toSet());
     }
 
-    private static final class NestedAnd extends And {
+    private sealed interface NestedNode permits NestedCondition, NestedAnd, NestedOr {
+    }
+
+    private static final class NestedCondition extends Condition implements NestedNode {
+        private final String stem;
+
+        NestedCondition(Condition c, String stem) {
+            super(c.selector(), c.operator(), c.value());
+            this.stem = stem;
+        }
+
+        @Override
+        public Map<String, Object> toEs(ESSettings esSettings) {
+            return nestedWrap(stem, super.toEs(esSettings));
+        }
+    }
+
+    private static final class NestedAnd extends And implements NestedNode {
         private final String stem;
 
         NestedAnd(List<? extends Node> children, String stem) {
@@ -245,7 +274,7 @@ public class EsQueryTree {
 
         @Override
         public Map<String, Object> toEs(ESSettings esSettings) {
-            return nestedWrap(stem, super.getCoreEsQuery(esSettings));
+            return nestedWrap(stem, super.toEs(esSettings));
         }
 
         @Override
@@ -254,7 +283,7 @@ public class EsQueryTree {
         }
     }
 
-    private static final class NestedOr extends Or {
+    private static final class NestedOr extends Or implements NestedNode {
         private final String stem;
 
         NestedOr(List<? extends Node> children, String stem) {
@@ -264,7 +293,7 @@ public class EsQueryTree {
 
         @Override
         public Map<String, Object> toEs(ESSettings esSettings) {
-            return nestedWrap(stem, super.getCoreEsQuery(esSettings));
+            return nestedWrap(stem, super.toEs(esSettings));
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -47,8 +47,16 @@ public class EsQueryTree {
     }
 
     private record NestedTree(Node tree) {
-        private static NestedTree from(ExpandedQueryTree queryTree, EsMappings esMappings) {
+        static NestedTree from(ExpandedQueryTree queryTree, EsMappings esMappings) {
             return new NestedTree(getNestedTree(queryTree.tree(), esMappings));
+        }
+
+        NestedTree remove(PostFilterTree postFilterTree) {
+            if (postFilterTree.isEmpty()) {
+                return this;
+            }
+            var modified = remove(tree, flattenedConditions(postFilterTree.tree()));
+            return new NestedTree(modified == null ? new Any.EmptyString() : modified);
         }
 
         private static Node getNestedTree(Node tree, EsMappings esMappings) {
@@ -101,10 +109,10 @@ public class EsQueryTree {
                 if (stem.isEmpty()) {
                     harvestNested.run();
                 } else {
-                    var selectors = (n instanceof Condition c ? List.of(c) : n.children())
+                    var selectors = flattenedConditions(n)
                             .stream()
-                            .map(Condition.class::cast)
                             .map(Condition::selector)
+                            .distinct()
                             .toList();
                     for (Selector s : selectors) {
                         var field = s.esField();
@@ -164,14 +172,6 @@ public class EsQueryTree {
             return Optional.empty();
         }
 
-        private NestedTree remove(PostFilterTree postFilterTree) {
-            if (postFilterTree.isEmpty()) {
-                return this;
-            }
-            var modified = remove(tree, postFilterTree.flattenedConditions());
-            return new NestedTree(modified == null ? new Any.EmptyString() : modified);
-        }
-
         private static Node remove(Node tree, Collection<Condition> remove) {
             if (remove.stream().anyMatch(n -> n == tree)) {
                 return null;
@@ -188,7 +188,7 @@ public class EsQueryTree {
     }
 
     private record PostFilterTree(Node tree) {
-        private static PostFilterTree from(ExpandedQueryTree eqt, NestedTree nestedTree, SelectedFacets selectedFacets) {
+        static PostFilterTree from(ExpandedQueryTree eqt, NestedTree nestedTree, SelectedFacets selectedFacets) {
             if (selectedFacets == null) {
                 return new PostFilterTree(null);
             }
@@ -208,7 +208,7 @@ public class EsQueryTree {
             List<Node> postFilterNodes = new ArrayList<>();
             for (List<Node> multiSelected : multiSelectGroups) {
                 var selectedConditions = multiSelected.stream()
-                        .map(PostFilterTree::flattenedConditions)
+                        .map(EsQueryTree::flattenedConditions)
                         .flatMap(Set::stream)
                         .collect(Collectors.toSet());
                 nestedAndGroups.stream()
@@ -222,16 +222,8 @@ public class EsQueryTree {
             return new PostFilterTree(postFilterNodes.size() > 1 ? new And(postFilterNodes, false) : postFilterNodes.getFirst());
         }
 
-        private boolean isEmpty() {
+        boolean isEmpty() {
             return tree == null;
-        }
-
-        private Set<Condition> flattenedConditions() {
-            return flattenedConditions(tree);
-        }
-
-        private static Set<Condition> flattenedConditions(Node node) {
-            return node.allDescendants().filter(Condition.class::isInstance).map(Condition.class::cast).collect(Collectors.toSet());
         }
 
         private static boolean intersect(Set<?> a, Set<?> b) {
@@ -239,10 +231,14 @@ public class EsQueryTree {
         }
     }
 
+    static Set<Condition> flattenedConditions(Node node) {
+        return node.allDescendants().filter(Condition.class::isInstance).map(Condition.class::cast).collect(Collectors.toSet());
+    }
+
     private static final class NestedAnd extends And {
         private final String stem;
 
-        private NestedAnd(List<? extends Node> children, String stem) {
+        NestedAnd(List<? extends Node> children, String stem) {
             super(children);
             this.stem = stem;
         }
@@ -261,7 +257,7 @@ public class EsQueryTree {
     private static final class NestedOr extends Or {
         private final String stem;
 
-        private NestedOr(List<? extends Node> children, String stem) {
+        NestedOr(List<? extends Node> children, String stem) {
             super(children);
             this.stem = stem;
         }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Group.java
@@ -21,11 +21,8 @@ public sealed abstract class Group implements Node permits And, Or {
     abstract Map<String, Object> wrap(List<Map<String, Object>> esChildren);
 
     @Override
-    public abstract boolean equals(Object o);
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.getClass(), new HashSet<>(children()));
+    public Map<String, Object> toEs(ESSettings esSettings) {
+        return wrap(children().stream().map(n -> n.toEs(esSettings)).toList());
     }
 
     @Override
@@ -68,8 +65,9 @@ public sealed abstract class Group implements Node permits And, Or {
         return toQueryString(true);
     }
 
-    public Node filterAndReinstantiate(Predicate<Node> p) {
-        return mapFilterAndReinstantiate(Function.identity(), p);
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getClass(), new HashSet<>(children()));
     }
 
     public Group mapAndReinstantiate(Function<Node, Node> mapper) {
@@ -111,21 +109,5 @@ public sealed abstract class Group implements Node permits And, Or {
                     reduced.add(child);
                 });
         return reduced.size() == 1 ? reduced.getFirst() : newInstance(reduced);
-    }
-
-    List<Map<String, Object>> childrenToEs(ESSettings esSettings) {
-        return children().stream().map(n -> n.toEs(esSettings)).toList();
-    }
-
-    Map<String, Object> getCoreEsQuery(ESSettings esSettings) {
-        return wrap(children().stream().map(n -> toCoreEsQuery(n, esSettings)).toList());
-    }
-
-    private static Map<String, Object> toCoreEsQuery(Node node, ESSettings esSettings) {
-        return switch (node) {
-            case Condition c -> c.getCoreEsQuery(esSettings);
-            case Group g -> g.getCoreEsQuery(esSettings);
-            default -> node.toEs(esSettings);
-        };
     }
 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Key.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Key.java
@@ -51,6 +51,11 @@ public sealed abstract class Key extends PathElement permits Key.AmbiguousKey, K
     }
 
     @Override
+    public boolean isLdSetContainer() {
+        return false;
+    }
+
+    @Override
     public boolean mayAppearOnType(String type, JsonLd jsonLd) {
         return false;
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 
 import static whelk.search2.QueryUtil.shouldWrap;
 
-public sealed class Or extends Group {
+public non-sealed class Or extends Group {
     private final List<Node> children;
 
     public Or(List<? extends Node> children) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Or.java
@@ -19,11 +19,6 @@ public non-sealed class Or extends Group {
     }
 
     @Override
-    public Map<String, Object> toEs(ESSettings esSettings) {
-        return shouldWrap(childrenToEs(esSettings));
-    }
-
-    @Override
     public Node getInverse() {
         return new And(children.stream().map(Node::getInverse).toList());
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -113,6 +113,11 @@ public final class Path implements Selector {
     }
 
     @Override
+    public boolean isLdSetContainer() {
+        return last().isLdSetContainer();
+    }
+
+    @Override
     public boolean mayAppearOnType(String type, JsonLd jsonLd) {
         return first().mayAppearOnType(type, jsonLd);
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -45,6 +45,7 @@ public non-sealed class Property extends PathElement {
     protected String inverseOf;
     protected String langAlias;
     protected boolean isVocabTerm;
+    protected boolean isLdSetContainer;
 
     protected Property superProperty;
     protected List<Restrictions.OnProperty> objectOnPropertyRestrictions;
@@ -62,6 +63,7 @@ public non-sealed class Property extends PathElement {
         this.name = name;
         this.langAlias =(String) jsonLd.langContainerAlias.get(name);
         this.isVocabTerm = jsonLd.isVocabTerm(name);
+        this.isLdSetContainer = jsonLd.isSetContainer(name);
     }
 
     protected Property(Map<String, Object> definition, JsonLd jsonLd) {
@@ -157,6 +159,11 @@ public non-sealed class Property extends PathElement {
     @Override
     public boolean isObjectProperty() {
         return ((List<?>) asList(definition.get(TYPE_KEY))).stream().anyMatch(OBJECT_PROPERTY::equals);
+    }
+
+    @Override
+    public boolean isLdSetContainer() {
+        return isLdSetContainer;
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Selector.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Selector.java
@@ -22,6 +22,7 @@ public sealed interface Selector permits Path, PathElement {
     boolean isType();
 
     boolean isObjectProperty();
+    boolean isLdSetContainer();
 
     boolean mayAppearOnType(String type, JsonLd jsonLd);
     boolean appearsOnType(String type, JsonLd jsonLd);

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -111,49 +111,6 @@ class ConditionSpec extends Specification {
         "bibliography:x"    | ["T3"]       | "meta.bibliography:x"
     }
 
-    def "To ES query (negation + nested field)"() {
-        given:
-        var tree = QueryTreeBuilder.buildTree("NOT p3:\"https://id.kb.se/x\"", disambiguate)
-        ESSettings esSettings = new ESSettings(esMappings, new ESSettings.Boost([:]))
-
-        expect:
-        tree.toEs(esSettings) == [
-                "bool": [
-                        "must_not": [
-                                "nested": [
-                                        "query": [
-                                                "bool": [
-                                                        "filter": [
-                                                                "term": [
-                                                                        "p3.@id": "https://id.kb.se/x"
-                                                                ]
-                                                        ]
-                                                ]
-                                        ],
-                                        "path" : "p3"
-                                ]
-                        ]
-                ]
-        ]
-    }
-
-    def "To ES query (nested field with include_in_parent=true)"() {
-        given:
-        var tree = QueryTreeBuilder.buildTree("p15:\"https://id.kb.se/x\"", disambiguate)
-        ESSettings esSettings = new ESSettings(esMappings, new ESSettings.Boost([:]))
-
-        expect:
-        tree.toEs(esSettings) == [
-            "bool" : [
-                "filter" : [
-                    "term" : [
-                        "p15.@id" : "https://id.kb.se/x"
-                    ]
-                ]
-            ]
-        ]
-    }
-
     def "To ES exists query"() {
         given:
         var exists = QueryTreeBuilder.buildTree(q, disambiguate)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -137,6 +137,23 @@ class ConditionSpec extends Specification {
         ]
     }
 
+    def "To ES query (nested field with include_in_parent=true)"() {
+        given:
+        var tree = QueryTreeBuilder.buildTree("p15:\"https://id.kb.se/x\"", disambiguate)
+        ESSettings esSettings = new ESSettings(esMappings, new ESSettings.Boost([:]))
+
+        expect:
+        tree.toEs(esSettings) == [
+            "bool" : [
+                "filter" : [
+                    "term" : [
+                        "p15.@id" : "https://id.kb.se/x"
+                    ]
+                ]
+            ]
+        ]
+    }
+
     def "To ES exists query"() {
         given:
         var exists = QueryTreeBuilder.buildTree(q, disambiguate)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
@@ -193,6 +193,7 @@ class EsQueryTreeSpec extends Specification {
         expect:
         esQueryTree.getMainQuery() == [
                 "nested": [
+                        "ignore_unmapped": true,
                         "query": [
                                 "bool": [
                                         "filter": [
@@ -294,7 +295,8 @@ class EsQueryTreeSpec extends Specification {
                                                            ]
                                                    ]]
                                 ]
-                        ]
+                        ],
+                        "ignore_unmapped": true
                 ]
         ]
     }
@@ -340,7 +342,6 @@ class EsQueryTreeSpec extends Specification {
         expect:
         esQueryTree.getMainQuery() == [
                 "nested": [
-                        "ignore_unmapped" : true,
                         "path" : "p3",
                         "query": [
                                 "bool": [
@@ -386,7 +387,8 @@ class EsQueryTreeSpec extends Specification {
                                                          ]
                                                  ]]
                                 ]
-                        ]
+                        ],
+                        "ignore_unmapped" : true
                 ]
         ]
     }
@@ -424,7 +426,8 @@ class EsQueryTreeSpec extends Specification {
                                                                             ]]
                                                            ]
                                                    ],
-                                                   "path" : "p3"
+                                                   "path" : "p3",
+                                                   "ignore_unmapped": true
                                            ]
                                    ], [
                                            "nested": [
@@ -437,7 +440,8 @@ class EsQueryTreeSpec extends Specification {
                                                                    "fields"            : ["p3.p1^5.0"]
                                                            ]
                                                    ],
-                                                   "path" : "p3"
+                                                   "path" : "p3",
+                                                   "ignore_unmapped": true
                                            ]
                                    ]]
                 ]
@@ -465,7 +469,8 @@ class EsQueryTreeSpec extends Specification {
                                                                  ]
                                                          ]
                                                  ],
-                                                 "path" : "p3"
+                                                 "path" : "p3",
+                                                 "ignore_unmapped": true
                                          ]
                                  ], [
                                          "nested": [
@@ -478,7 +483,8 @@ class EsQueryTreeSpec extends Specification {
                                                                  ]
                                                          ]
                                                  ],
-                                                 "path" : "p3"
+                                                 "path" : "p3",
+                                                 "ignore_unmapped": true
                                          ]
                                  ]]
                 ]
@@ -547,7 +553,8 @@ class EsQueryTreeSpec extends Specification {
                                                            ]
                                                    ]]
                                 ]
-                        ]
+                        ],
+                        "ignore_unmapped" : true
                 ]
         ]
     }
@@ -573,7 +580,8 @@ class EsQueryTreeSpec extends Specification {
                                                                            ]
                                                                    ]
                                                            ]
-                                                   ]
+                                                   ],
+                                                   "ignore_unmapped": true
                                            ]
                                    ], [
                                            "bool": [
@@ -609,7 +617,8 @@ class EsQueryTreeSpec extends Specification {
                                                                            ]
                                                                    ]
                                                            ]
-                                                   ]
+                                                   ],
+                                                   "ignore_unmapped": true
                                            ]
                                    ], [
                                            "nested": [
@@ -622,7 +631,8 @@ class EsQueryTreeSpec extends Specification {
                                                                            ]
                                                                    ]
                                                            ]
-                                                   ]
+                                                   ],
+                                                   "ignore_unmapped": true
                                            ]
                                    ], [
                                            "bool": [
@@ -658,7 +668,8 @@ class EsQueryTreeSpec extends Specification {
                                                                  ]
                                                          ]
                                                  ],
-                                                 "path" : "p3"
+                                                 "path" : "p3",
+                                                 "ignore_unmapped": true
                                          ]
                                  ], [
                                          "bool": [
@@ -706,7 +717,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped": true
                                          ]
                                  ], [
                                          "bool": [
@@ -754,7 +766,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped": true
                                          ]
                                  ], [
                                          "nested": [
@@ -779,7 +792,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped": true
                                          ]
                                  ]]
                 ]
@@ -828,7 +842,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped": true
                                          ]
                                  ], [
                                          "nested": [
@@ -853,7 +868,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped": true
                                          ]
                                  ]]
                 ]
@@ -872,7 +888,6 @@ class EsQueryTreeSpec extends Specification {
                 "bool": [
                         "must": [[
                                          "nested": [
-                                                 "ignore_unmapped" : true,
                                                  "query": [
                                                          "bool": [
                                                                  "must": [[
@@ -902,7 +917,8 @@ class EsQueryTreeSpec extends Specification {
                                                                           ]]
                                                          ]
                                                  ],
-                                                 "path" : "p3"
+                                                 "path" : "p3",
+                                                 "ignore_unmapped" : true
                                          ]
                                  ], [
                                          "nested": [
@@ -915,7 +931,8 @@ class EsQueryTreeSpec extends Specification {
                                                                  ]
                                                          ]
                                                  ],
-                                                 "path" : "p3"
+                                                 "path" : "p3",
+                                                 "ignore_unmapped" : true
                                          ]
                                  ]]
                 ]
@@ -955,7 +972,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                   ]
                                                                           ]]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped" : true,
                                          ]
                                  ], [
                                          "nested": [
@@ -968,7 +986,8 @@ class EsQueryTreeSpec extends Specification {
                                                                          ]
                                                                  ]
                                                          ]
-                                                 ]
+                                                 ],
+                                                 "ignore_unmapped" : true,
                                          ]
                                  ], [
                                          "simple_query_string": [
@@ -1004,7 +1023,8 @@ class EsQueryTreeSpec extends Specification {
                                                         ]
                                                 ]
                                         ],
-                                        "path" : "p3"
+                                        "path" : "p3",
+                                        "ignore_unmapped" : true,
                                 ]
                         ]
                 ]
@@ -1044,7 +1064,6 @@ class EsQueryTreeSpec extends Specification {
         expect:
         esQueryTree.getMainQuery() == [
                 "nested": [
-                        "ignore_unmapped" : true,
                         "path" : "p3",
                         "query": [
                                 "bool": [
@@ -1070,7 +1089,8 @@ class EsQueryTreeSpec extends Specification {
                                                          ]
                                                  ]]
                                 ]
-                        ]
+                        ],
+                        "ignore_unmapped" : true
                 ]
         ]
     }
@@ -1085,7 +1105,6 @@ class EsQueryTreeSpec extends Specification {
         expect:
         esQueryTree.getMainQuery() == [
                 "nested": [
-                        "ignore_unmapped" : true,
                         "query": [
                                 "bool": [
                                         "must": [[
@@ -1135,7 +1154,8 @@ class EsQueryTreeSpec extends Specification {
                                                  ]]
                                 ]
                         ],
-                        "path" : "p3"
+                        "path" : "p3",
+                        "ignore_unmapped" : true
                 ]
         ]
     }
@@ -1163,7 +1183,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                          ]
                                                                                  ]
                                                                          ]
-                                                                 ]
+                                                                 ],
+                                                                 "ignore_unmapped" : true
                                                          ]
                                                  ]
                                          ]
@@ -1180,7 +1201,8 @@ class EsQueryTreeSpec extends Specification {
                                                                                          ]
                                                                                  ]
                                                                          ]
-                                                                 ]
+                                                                 ],
+                                                                 "ignore_unmapped" : true
                                                          ]
                                                  ]
                                          ]

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
@@ -183,7 +183,7 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested"() {
+    def "To ES query: group AND-nested"() {
         given:
         String q = 'p3.p1:x p3.p4:y'
         QueryTree qt = new QueryTree(q, disambiguate)
@@ -215,6 +215,73 @@ class EsQueryTreeSpec extends Specification {
                                                  ]]
                                 ]
                         ]
+                ]
+        ]
+    }
+
+    def "To ES query: group OR-nested"() {
+        given:
+        String q = 'p3.p4:\"https://id.kb.se/x\" OR p3.p4:\"https://id.kb.se/y\"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "nested": [
+                        "path" : "p3",
+                        "query": [
+                                "bool": [
+                                        "should": [[
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p4.@id": "https://id.kb.se/x"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ], [
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p4.@id": "https://id.kb.se/y"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ]]
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: group OR-nested (include_in_parent=true)"() {
+        given:
+        String q = 'p15.p4:\"https://id.kb.se/x\" OR p15.p4:\"https://id.kb.se/y\"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "should": [[
+                                           "bool": [
+                                                   "filter": [
+                                                           "term": [
+                                                                   "p15.p4.@id": "https://id.kb.se/x"
+                                                           ]
+                                                   ]
+                                           ]
+                                   ], [
+                                           "bool": [
+                                                   "filter": [
+                                                           "term": [
+                                                                   "p15.p4.@id": "https://id.kb.se/y"
+                                                           ]
+                                                   ]
+                                           ]
+                                   ]]
                 ]
         ]
     }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
@@ -183,9 +183,52 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group AND-nested"() {
+    def "To ES query: nested (CONDITION)"() {
         given:
-        String q = 'p3.p1:x p3.p4:y'
+        String q = 'p3.p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "nested": [
+                        "query": [
+                                "bool": [
+                                        "filter": [
+                                                "term": [
+                                                        "p3.p4.@id": "https://id.kb.se/x"
+                                                ]
+                                        ]
+                                ]
+                        ],
+                        "path" : "p3"
+                ]
+        ]
+    }
+
+    def "To ES query: nested (CONDITION, include_in_parent=true)"() {
+        given:
+        String q = 'p15.p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool" : [
+                        "filter" : [
+                                "term" : [
+                                        "p15.p4.@id" : "https://id.kb.se/x"
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND)"() {
+        given:
+        String q = 'p3.p2:E1 p3.p4:"https://id.kb.se/y"'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
         EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
@@ -197,20 +240,20 @@ class EsQueryTreeSpec extends Specification {
                         "query": [
                                 "bool": [
                                         "must": [[
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "x",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p1^5.0"]
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
                                                          ]
                                                  ], [
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "y",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p4._str^5.0"]
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p4.@id": "https://id.kb.se/y"
+                                                                         ]
+                                                                 ]
                                                          ]
                                                  ]]
                                 ]
@@ -219,9 +262,9 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group OR-nested"() {
+    def "To ES query: group nested (OR)"() {
         given:
-        String q = 'p3.p4:\"https://id.kb.se/x\" OR p3.p4:\"https://id.kb.se/y\"'
+        String q = 'p3.p4:"https://id.kb.se/x" OR p3.p4:"https://id.kb.se/y"'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
         EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
@@ -255,9 +298,9 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group OR-nested (include_in_parent=true)"() {
+    def "To ES query: group nested (OR, include_in_parent=true)"() {
         given:
-        String q = 'p15.p4:\"https://id.kb.se/x\" OR p15.p4:\"https://id.kb.se/y\"'
+        String q = 'p15.p4:"https://id.kb.se/x" OR p15.p4:"https://id.kb.se/y"'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
         EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
@@ -286,57 +329,9 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested 2"() {
+    def "To ES query: group nested (OR in AND)"() {
         given:
-        String q = 'p3.p1:x p3.p4:y p2:e1'
-        QueryTree qt = new QueryTree(q, disambiguate)
-        ExpandedQueryTree eqt = qt.expand(jsonLd)
-        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
-
-        expect:
-        esQueryTree.getMainQuery() == [
-                "bool": [
-                        "must": [[
-                                         "nested": [
-                                                 "query": [
-                                                         "bool": [
-                                                                 "must": [[
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "x",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p1^5.0"]
-                                                                                  ]
-                                                                          ], [
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "y",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p4._str^5.0"]
-                                                                                  ]
-                                                                          ]]
-                                                         ]
-                                                 ],
-                                                 "path" : "p3"
-                                         ]
-                                 ], [
-                                         "bool": [
-                                                 "filter": [
-                                                         "term": [
-                                                                 "p2": "E1"
-                                                         ]
-                                                 ]
-                                         ]
-                                 ]]
-                ]
-        ]
-    }
-
-    def "To ES query: group nested 3"() {
-        given:
-        String q = 'p3.p1:x (p3.p4:y OR p3.p4:z)'
+        String q = '(p3.p4:"https://id.kb.se/x" OR p3.p4:"https://id.kb.se/y") (p3.p2:E1 OR p3.p2:E2)'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
         EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
@@ -348,30 +343,42 @@ class EsQueryTreeSpec extends Specification {
                         "query": [
                                 "bool": [
                                         "must": [[
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "x",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p1^5.0"]
+                                                         "bool": [
+                                                                 "should": [[
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p4.@id": "https://id.kb.se/x"
+                                                                                                    ]
+                                                                                            ]
+                                                                                    ]
+                                                                            ], [
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                    ]
+                                                                                            ]
+                                                                                    ]
+                                                                            ]]
                                                          ]
                                                  ], [
                                                          "bool": [
                                                                  "should": [[
-                                                                                    "simple_query_string": [
-                                                                                            "default_operator"  : "AND",
-                                                                                            "query"             : "y",
-                                                                                            "analyze_wildcard"  : true,
-                                                                                            "quote_field_suffix": ".exact",
-                                                                                            "fields"            : ["p3.p4._str^5.0"]
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p2": "E1"
+                                                                                                    ]
+                                                                                            ]
                                                                                     ]
                                                                             ], [
-                                                                                    "simple_query_string": [
-                                                                                            "default_operator"  : "AND",
-                                                                                            "query"             : "z",
-                                                                                            "analyze_wildcard"  : true,
-                                                                                            "quote_field_suffix": ".exact",
-                                                                                            "fields"            : ["p3.p4._str^5.0"]
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p2": "E2"
+                                                                                                    ]
+                                                                                            ]
                                                                                     ]
                                                                             ]]
                                                          ]
@@ -382,9 +389,291 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested 4"() {
+    def "To ES query: group nested (AND in OR)"() {
         given:
-        String q = 'p3.p1:x p3.p4:y p3.p1:a p3.p4:b'
+        String q = '(p3.p4:"https://id.kb.se/y" p3.p2:E1) OR p3.p1:a'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "should": [[
+                                           "nested": [
+                                                   "query": [
+                                                           "bool": [
+                                                                   "must": [[
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                    ]
+                                                                                            ]
+                                                                                    ]
+                                                                            ], [
+                                                                                    "bool": [
+                                                                                            "filter": [
+                                                                                                    "term": [
+                                                                                                            "p3.p2": "E1"
+                                                                                                    ]
+                                                                                            ]
+                                                                                    ]
+                                                                            ]]
+                                                           ]
+                                                   ],
+                                                   "path" : "p3"
+                                           ]
+                                   ], [
+                                           "nested": [
+                                                   "query": [
+                                                           "simple_query_string": [
+                                                                   "default_operator"  : "AND",
+                                                                   "query"             : "a",
+                                                                   "analyze_wildcard"  : true,
+                                                                   "quote_field_suffix": ".exact",
+                                                                   "fields"            : ["p3.p1^5.0"]
+                                                           ]
+                                                   ],
+                                                   "path" : "p3"
+                                           ]
+                                   ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, same non-repeatable field)"() {
+        given:
+        String q = 'p3.p2:E1 p3.p2:E2'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "query": [
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ],
+                                                 "path" : "p3"
+                                         ]
+                                 ], [
+                                         "nested": [
+                                                 "query": [
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E2"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ],
+                                                 "path" : "p3"
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, same non-repeatable field, include_in_parent=true)"() {
+        given:
+        String q = 'p15.p2:E1 p15.p2:E2'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "bool": [
+                                                 "filter": [
+                                                         "term": [
+                                                                 "p15.p2": "E1"
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "bool": [
+                                                 "filter": [
+                                                         "term": [
+                                                                 "p15.p2": "E2"
+                                                         ]
+                                                 ]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, same repeatable field)"() {
+        given:
+        String q = 'p3.p4:"https://id.kb.se/x" OR p3.p4:"https://id.kb.se/y"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "nested": [
+                        "path" : "p3",
+                        "query": [
+                                "bool": [
+                                        "should": [[
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p4.@id": "https://id.kb.se/x"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ], [
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p4.@id": "https://id.kb.se/y"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ]]
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (OR, non-nested child)"() {
+        given:
+        String q = 'p3.p2:E1 OR p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "should": [[
+                                           "nested": [
+                                                   "path" : "p3",
+                                                   "query": [
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p2": "E1"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ]
+                                           ]
+                                   ], [
+                                           "bool": [
+                                                   "filter": [
+                                                           "term": [
+                                                                   "p4.@id": "https://id.kb.se/x"
+                                                           ]
+                                                   ]
+                                           ]
+                                   ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (OR, non-nested child) 2"() {
+        given:
+        String q = 'p3.p2:E1 OR p3.p2:E2 OR p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "should": [[
+                                           "nested": [
+                                                   "path" : "p3",
+                                                   "query": [
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p2": "E1"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ]
+                                           ]
+                                   ], [
+                                           "nested": [
+                                                   "path" : "p3",
+                                                   "query": [
+                                                           "bool": [
+                                                                   "filter": [
+                                                                           "term": [
+                                                                                   "p3.p2": "E2"
+                                                                           ]
+                                                                   ]
+                                                           ]
+                                                   ]
+                                           ]
+                                   ], [
+                                           "bool": [
+                                                   "filter": [
+                                                           "term": [
+                                                                   "p4.@id": "https://id.kb.se/x"
+                                                           ]
+                                                   ]
+                                           ]
+                                   ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, non-nested child)"() {
+        given:
+        String q = 'p3.p2:E1 p4:"https://id.kb.se/y"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "query": [
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ],
+                                                 "path" : "p3"
+                                         ]
+                                 ], [
+                                         "bool": [
+                                                 "filter": [
+                                                         "term": [
+                                                                 "p4.@id": "https://id.kb.se/y"
+                                                         ]
+                                                 ]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, non-nested child) 2"() {
+        given:
+        String q = 'p3.p2:E1 p3.p4:"https://id.kb.se/y" p2:E2'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
         EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
@@ -398,20 +687,68 @@ class EsQueryTreeSpec extends Specification {
                                                  "query": [
                                                          "bool": [
                                                                  "must": [[
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "x",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p1^5.0"]
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E1"
+                                                                                                  ]
+                                                                                          ]
                                                                                   ]
                                                                           ], [
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "y",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p4._str^5.0"]
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ]]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "bool": [
+                                                 "filter": [
+                                                         "term": [
+                                                                 "p2": "E2"
+                                                         ]
+                                                 ]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, grouped by non-repeatable field)"() {
+        given:
+        String q = 'p3.p2:E1 p3.p4:"https://id.kb.se/x" p3.p2:E2 p3.p4:"https://id.kb.se/y"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E1"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/x"
+                                                                                                  ]
+                                                                                          ]
                                                                                   ]
                                                                           ]]
                                                          ]
@@ -423,20 +760,20 @@ class EsQueryTreeSpec extends Specification {
                                                  "query": [
                                                          "bool": [
                                                                  "must": [[
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "a",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p1^5.0"]
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E2"
+                                                                                                  ]
+                                                                                          ]
                                                                                   ]
                                                                           ], [
-                                                                                  "simple_query_string": [
-                                                                                          "default_operator"  : "AND",
-                                                                                          "query"             : "b",
-                                                                                          "analyze_wildcard"  : true,
-                                                                                          "quote_field_suffix": ".exact",
-                                                                                          "fields"            : ["p3.p4._str^5.0"]
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                  ]
+                                                                                          ]
                                                                                   ]
                                                                           ]]
                                                          ]
@@ -447,7 +784,407 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested + multi-selectable"() {
+    def "To ES query: group nested (AND, grouped by non-repeatable field) 2"() {
+        given:
+        String q = 'p3.p2:E1 p3.p4:"https://id.kb.se/x" p3.p4:"https://id.kb.se/y" p3.p2:E2 p3.p4:"https://id.kb.se/z"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E1"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/x"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ],
+                                                                          [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ]]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E2"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/z"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ]]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, grouped by non-repeatable field) 3"() {
+        given:
+        String q = 'p3.p2:E1 p3.p4:"https://id.kb.se/x" p3.p4:"https://id.kb.se/z" p3.p2:E2'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p2": "E1"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/x"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/z"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ]]
+                                                         ]
+                                                 ],
+                                                 "path" : "p3"
+                                         ]
+                                 ], [
+                                         "nested": [
+                                                 "query": [
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E2"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ],
+                                                 "path" : "p3"
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (AND, non-nested as boundary)"() {
+        given:
+        String q = 'p3.p2:E1 p1:x p3.p4:"https://id.kb.se/x" p3.p4:"https://id.kb.se/y"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/x"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "bool": [
+                                                                                          "filter": [
+                                                                                                  "term": [
+                                                                                                          "p3.p4.@id": "https://id.kb.se/y"
+                                                                                                  ]
+                                                                                          ]
+                                                                                  ]
+                                                                          ]]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "simple_query_string": [
+                                                 "default_operator"  : "AND",
+                                                 "query"             : "x",
+                                                 "analyze_wildcard"  : true,
+                                                 "quote_field_suffix": ".exact",
+                                                 "fields"            : ["p1^5.0"]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: nested (NOT)"() {
+        given:
+        String q = 'NOT p3:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must_not": [
+                                "nested": [
+                                        "query": [
+                                                "bool": [
+                                                        "filter": [
+                                                                "term": [
+                                                                        "p3.@id": "https://id.kb.se/x"
+                                                                ]
+                                                        ]
+                                                ]
+                                        ],
+                                        "path" : "p3"
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: nested (NOT, include_in_parent=true)"() {
+        given:
+        String q = 'NOT p15:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must_not": [
+                                "bool": [
+                                        "filter": [
+                                                "term": [
+                                                        "p15.@id": "https://id.kb.se/x"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (NOT in AND, mixed with non-negated)"() {
+        given:
+        String q = 'p3.p2:E1 NOT p3.p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "nested": [
+                        "path" : "p3",
+                        "query": [
+                                "bool": [
+                                        "must": [[
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ], [
+                                                         "bool": [
+                                                                 "must_not": [
+                                                                         "bool": [
+                                                                                 "filter": [
+                                                                                         "term": [
+                                                                                                 "p3.p4.@id": "https://id.kb.se/x"
+                                                                                         ]
+                                                                                 ]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ]]
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (NOT in AND, mixed with non-negated) 2"() {
+        given:
+        String q = 'p3.p2:E1 NOT p3.p4:"https://id.kb.se/x" NOT p3.p4:"https://id.kb.se/y" NOT p3.p1:1'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "nested": [
+                        "query": [
+                                "bool": [
+                                        "must": [[
+                                                         "bool": [
+                                                                 "filter": [
+                                                                         "term": [
+                                                                                 "p3.p2": "E1"
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ], [
+                                                         "bool": [
+                                                                 "must_not": [
+                                                                         "bool": [
+                                                                                 "filter": [
+                                                                                         "term": [
+                                                                                                 "p3.p4.@id": "https://id.kb.se/x"
+                                                                                         ]
+                                                                                 ]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ], [
+                                                         "bool": [
+                                                                 "must_not": [
+                                                                         "bool": [
+                                                                                 "filter": [
+                                                                                         "term": [
+                                                                                                 "p3.p4.@id": "https://id.kb.se/y"
+                                                                                         ]
+                                                                                 ]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ], [
+                                                         "bool": [
+                                                                 "must_not": [
+                                                                         "simple_query_string": [
+                                                                                 "default_operator"  : "AND",
+                                                                                 "query"             : "1",
+                                                                                 "analyze_wildcard"  : true,
+                                                                                 "quote_field_suffix": ".exact",
+                                                                                 "fields"            : ["p3.p1^5.0"]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ]]
+                                ]
+                        ],
+                        "path" : "p3"
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (NOT in AND, all negated)"() {
+        given:
+        String q = 'NOT p3.p2:E1 NOT p3.p4:"https://id.kb.se/x"'
+        QueryTree qt = new QueryTree(q, disambiguate)
+        ExpandedQueryTree eqt = qt.expand(jsonLd)
+        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
+
+        expect:
+        esQueryTree.getMainQuery() == [
+                "bool": [
+                        "must": [[
+                                         "bool": [
+                                                 "must_not": [
+                                                         "nested": [
+                                                                 "path" : "p3",
+                                                                 "query": [
+                                                                         "bool": [
+                                                                                 "filter": [
+                                                                                         "term": [
+                                                                                                 "p3.p2": "E1"
+                                                                                         ]
+                                                                                 ]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "bool": [
+                                                 "must_not": [
+                                                         "nested": [
+                                                                 "path" : "p3",
+                                                                 "query": [
+                                                                         "bool": [
+                                                                                 "filter": [
+                                                                                         "term": [
+                                                                                                 "p3.p4.@id": "https://id.kb.se/x"
+                                                                                         ]
+                                                                                 ]
+                                                                         ]
+                                                                 ]
+                                                         ]
+                                                 ]
+                                         ]
+                                 ]]
+                ]
+        ]
+    }
+
+    def "To ES query: group nested (multi-selectable to post filter)"() {
         given:
         String q = 'p2:E1 p3p1:y p3.p4:"https://id.kb.se/x"'
         QueryTree qt = new QueryTree(q, disambiguate)
@@ -501,7 +1238,7 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested + multi-selected"() {
+    def "To ES query: group nested (multi-selected to post filter)"() {
         given:
         String q = 'p2:E1 (p3p1:y OR p3p1:z) p3.p4:"https://id.kb.se/x"'
         QueryTree qt = new QueryTree(q, disambiguate)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
@@ -522,7 +522,7 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested (AND, same repeatable field)"() {
+    def "To ES query: group nested (OR, same repeatable field)"() {
         given:
         String q = 'p3.p4:"https://id.kb.se/x" OR p3.p4:"https://id.kb.se/y"'
         QueryTree qt = new QueryTree(q, disambiguate)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/EsQueryTreeSpec.groovy
@@ -219,42 +219,6 @@ class EsQueryTreeSpec extends Specification {
         ]
     }
 
-    def "To ES query: group nested (negated)"() {
-        given:
-        String q = 'p3.p1:x p3.p4:y'
-        QueryTree qt = new QueryTree(q, disambiguate)
-        ExpandedQueryTree eqt = qt.expand(jsonLd)
-        EsQueryTree esQueryTree = new EsQueryTree(eqt, esSettings)
-
-        expect:
-        esQueryTree.getMainQuery() == [
-                "nested": [
-                        "path" : "p3",
-                        "query": [
-                                "bool": [
-                                        "must": [[
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "x",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p1^5.0"]
-                                                         ]
-                                                 ], [
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "y",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p4._str^5.0"]
-                                                         ]
-                                                 ]]
-                                ]
-                        ]
-                ]
-        ]
-    }
-
     def "To ES query: group nested 2"() {
         given:
         String q = 'p3.p1:x p3.p4:y p2:e1'
@@ -353,7 +317,6 @@ class EsQueryTreeSpec extends Specification {
 
     def "To ES query: group nested 4"() {
         given:
-        // TODO: Interpret "(p3.p1:x p3.p4:y) (p3.p1:a p3.p4:b)" differently, i.e. don't flatten and treat each group as a distinct nested clause?
         String q = 'p3.p1:x p3.p4:y p3.p1:a p3.p4:b'
         QueryTree qt = new QueryTree(q, disambiguate)
         ExpandedQueryTree eqt = qt.expand(jsonLd)
@@ -361,45 +324,58 @@ class EsQueryTreeSpec extends Specification {
 
         expect:
         esQueryTree.getMainQuery() == [
-                "nested": [
-                        "query": [
-                                "bool": [
-                                        "must": [[
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "x",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p1^5.0"]
+                "bool": [
+                        "must": [[
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "simple_query_string": [
+                                                                                          "default_operator"  : "AND",
+                                                                                          "query"             : "x",
+                                                                                          "analyze_wildcard"  : true,
+                                                                                          "quote_field_suffix": ".exact",
+                                                                                          "fields"            : ["p3.p1^5.0"]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "simple_query_string": [
+                                                                                          "default_operator"  : "AND",
+                                                                                          "query"             : "y",
+                                                                                          "analyze_wildcard"  : true,
+                                                                                          "quote_field_suffix": ".exact",
+                                                                                          "fields"            : ["p3.p4._str^5.0"]
+                                                                                  ]
+                                                                          ]]
                                                          ]
-                                                 ], [
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "y",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p4._str^5.0"]
+                                                 ]
+                                         ]
+                                 ], [
+                                         "nested": [
+                                                 "path" : "p3",
+                                                 "query": [
+                                                         "bool": [
+                                                                 "must": [[
+                                                                                  "simple_query_string": [
+                                                                                          "default_operator"  : "AND",
+                                                                                          "query"             : "a",
+                                                                                          "analyze_wildcard"  : true,
+                                                                                          "quote_field_suffix": ".exact",
+                                                                                          "fields"            : ["p3.p1^5.0"]
+                                                                                  ]
+                                                                          ], [
+                                                                                  "simple_query_string": [
+                                                                                          "default_operator"  : "AND",
+                                                                                          "query"             : "b",
+                                                                                          "analyze_wildcard"  : true,
+                                                                                          "quote_field_suffix": ".exact",
+                                                                                          "fields"            : ["p3.p4._str^5.0"]
+                                                                                  ]
+                                                                          ]]
                                                          ]
-                                                 ], [
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "a",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p1^5.0"]
-                                                         ]
-                                                 ], [
-                                                         "simple_query_string": [
-                                                                 "default_operator"  : "AND",
-                                                                 "query"             : "b",
-                                                                 "analyze_wildcard"  : true,
-                                                                 "quote_field_suffix": ".exact",
-                                                                 "fields"            : ["p3.p4._str^5.0"]
-                                                         ]
-                                                 ]]
-                                ]
-                        ],
-                        "path" : "p3"
+                                                 ]
+                                         ]
+                                 ]]
                 ]
         ]
     }

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/NotSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/NotSpec.groovy
@@ -3,10 +3,13 @@ package whelk.search2.querytree
 import spock.lang.Specification
 import whelk.JsonLd
 import whelk.search2.Disambiguate
+import whelk.search2.ESSettings
+import whelk.search2.EsMappings
 
 class NotSpec extends Specification {
     Disambiguate disambiguate = TestData.getDisambiguate()
     JsonLd jsonLd = TestData.getJsonLd()
+    EsMappings esMappings = TestData.getEsMappings()
 
     def "expand filter alias"() {
         given:

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -268,7 +268,8 @@ class TestData {
         def ctx = [
                 '@context': [
                         '@vocab': 'https://id.kb.se/vocab/',
-                        'p2'    : ['@type': '@vocab']
+                        'p2'    : ['@type': '@vocab'],
+                        'p4'    : ['@container': '@set']
                 ]
         ]
         return new JsonLd(ctx, [:], vocab)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -29,6 +29,7 @@ class TestData {
                 'p12'             : ['p12'] as Set,
                 'p13'             : ['p13'] as Set,
                 'p14'             : ['p14'] as Set,
+                'p15'             : ['p15'] as Set,
                 'ctx.p'           : ['ctxProp'] as Set,
                 'type'            : ['rdf:type'] as Set,
                 'rdf:type'        : ['rdf:type'] as Set,
@@ -174,6 +175,10 @@ class TestData {
                         'domain': ['@id': 'T4']
                 ],
                 [
+                        '@id'  : 'p15',
+                        '@type': 'ObjectProperty'
+                ],
+                [
                         '@id'  : 'ctxProp',
                         '@type': 'DatatypeProperty',
                         'domain': ['@id': 'T4']
@@ -274,6 +279,7 @@ class TestData {
                 'properties': [
                         'p3'                                : ['type': 'nested'],
                         '@reverse.instanceOf.p3'            : ['type': 'nested'],
+                        'p15'                               : ['type': 'nested', "include_in_parent": true],
                         '@type'                             : ['type': 'keyword'],
                         'p2'                                : ['type': 'keyword'],
                         'p3.p4.@id'                         : ['type': 'keyword'],


### PR DESCRIPTION
- Fixes https://miro.com/app/board/uXjVNWf13kQ=/?moveToWidget=3458764664237252778&cot=14
- Implements behavior specified in https://kungliga-biblioteket.box.com/s/q2qqv2qbt00w7m117uo7fhn8aia70qfc
  - A slight adjustment in the new implementation is that repeated use of a repeatable field is interpreted as referring to the same nested object.
  - Unit tests should cover most relevant cases
- Refactors all nested logic into `EsQueryTree`
- TODO? Further document and clarify the behavior (e.g. code comments vs. Box document)