### PR TITLE
perf(search): don't do toCard on result items

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.java
@@ -122,11 +122,9 @@ public class SearchUtils {
     private Map<String, Object> applyLens(Map<String, Object> framedThing, String lens, String preserveId) {
         Set<String> preserveLinks = preserveId != null ? Collections.singleton(preserveId) : Collections.emptySet();
 
-        return switch (lens != null ? lens : "") {
-            case "chips" -> (Map<String, Object>) ld.toChip(framedThing, preserveLinks);
-            case "full" -> removeSystemInternalProperties(framedThing);
-            default -> (Map<String, Object>) ld.toCard(framedThing, false, false, false, preserveLinks, true);
-        };
+        return "chips".equals(lens)
+                ? (Map<String, Object>) ld.toChip(framedThing, preserveLinks)
+                : removeSystemInternalProperties(framedThing);
     }
 
     private Map<String, Object> queryElasticSearch(Map<String, String[]> queryParameters,
@@ -342,10 +340,15 @@ public class SearchUtils {
 
     Map<String, Object> removeSystemInternalProperties(Map<String, Object> framedThing) {
         DocumentUtil.traverse(framedThing, (value, path) -> {
-            if (path != null && !path.isEmpty() && ((String) path.getLast()).startsWith("_")) {
-                return new DocumentUtil.Remove();
+            if (value instanceof Map<?, ?> m) {
+                m.keySet().removeIf(k ->
+                        k instanceof String key
+                                && key.startsWith("_")
+                                && !JsonLd.Platform.CATEGORY_BY_COLLECTION.equals(key)
+                );
             }
-            return null;
+
+            return DocumentUtil.NOP;
         });
         return framedThing;
     }

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -19,10 +19,8 @@ import whelk.search2.querytree.Property;
 import whelk.search2.querytree.QueryTree;
 import whelk.search2.querytree.ReducedQueryTree;
 import whelk.search2.querytree.Resource;
-import whelk.search2.querytree.Type;
 import whelk.search2.querytree.Value;
 import whelk.search2.querytree.YearRange;
-
 import whelk.util.DocumentUtil;
 import whelk.util.FresnelUtil;
 import whelk.util.Restrictions;
@@ -393,20 +391,23 @@ public class Query {
     private Map<String, Object> applyLens(Map<String, Object> framedThing) {
         Set<String> preserveLinks = Stream.ofNullable(queryParams.object).collect(Collectors.toSet());
 
-        var res = switch (queryParams.lens) {
-            case "chips" -> whelk.getJsonld().toChip(framedThing, preserveLinks);
-            case "full" -> removeSystemInternalProperties(framedThing);
-            default -> whelk.getJsonld().toCard(framedThing, false, false, false, preserveLinks, true);
-        };
+        var res = "chips".equals(queryParams.lens)
+            ? whelk.getJsonld().toChip(framedThing, preserveLinks)
+            : removeSystemInternalProperties(framedThing);
 
         return castToStringObjectMap(res);
     }
 
     private static Map<String, Object> removeSystemInternalProperties(Map<String, Object> framedThing) {
         DocumentUtil.traverse(framedThing, (value, path) -> {
-            if (!path.isEmpty() && ((String) path.getLast()).startsWith("_")) {
-                return new DocumentUtil.Remove();
+            if (value instanceof Map<?, ?> m) {
+                m.keySet().removeIf(k ->
+                        k instanceof String key
+                                && key.startsWith("_")
+                                && !JsonLd.Platform.CATEGORY_BY_COLLECTION.equals(key)
+                );
             }
+
             return DocumentUtil.NOP;
         });
         return framedThing;


### PR DESCRIPTION
They are already (search) cards. toCard is an expensive operation

Profiling locally with [stress_search2_api_simple.py](https://github.com/libris/xl_stress/blob/master/locustfiles/stress_search2_api_simple.py)

All states (running, blocked, io, ...)

before:
elastic request ~78 %
collectItems...toCard ~7%

after:
elastic request ~88%

Response size does not grow.