### PR TITLE
perf(search2): cache chips for search mappings

### DIFF
--- a/whelk-core/src/main/groovy/whelk/ChipCache.java
+++ b/whelk-core/src/main/groovy/whelk/ChipCache.java
@@ -1,0 +1,77 @@
+package whelk;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.jspecify.annotations.NullMarked;
+import whelk.util.Metrics;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static whelk.search2.QueryUtil.castToStringObjectMap;
+
+public class ChipCache {
+    private static final int CACHE_SIZE = 5_000;
+    private static final int EXPIRE_MINS = 10;
+
+    private final LoadingCache<String, Map<String, Object>> cache;
+
+    ChipCache(Whelk whelk) {
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(CACHE_SIZE)
+                .expireAfterWrite(Duration.ofMinutes(EXPIRE_MINS))
+                .recordStats()
+                .build(buildLoader(whelk));
+
+        Metrics.cacheMetrics.addCache("chipCache", cache);
+    }
+
+    public Map<String, Map<String, Object>> getChips(Iterable<String> iris) {
+        try {
+            return cache.getAll(iris);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CacheLoader<String, Map<String, Object>> buildLoader(Whelk whelk) {
+        return new CacheLoader<>() {
+
+            @Override
+            @NullMarked
+            public Map<String, Object> load(String iri) {
+                return loadAll(List.of(iri)).get(iri);
+            }
+
+            @Override
+            @NullMarked
+            public Map<String, Map<String, Object>> loadAll(Iterable<? extends String> iris) {
+                var cards = whelk.getCards(iris);
+
+                var chips = new HashMap<String, Map<String, Object>>();
+                for (var iri : iris) {
+                    var cardGraph = cards.get(iri);
+                    if (cardGraph != null) {
+                        var chip = castToStringObjectMap(whelk.getJsonld().toChip(new Document(cardGraph).getThing()));
+                        // make top-level immutable to guard from accidental modification
+                        chips.put(iri, Map.copyOf(chip));
+                    } else {
+                        chips.put(iri, dummyChip(iri));
+                    }
+                }
+                return chips;
+            }
+
+            private static Map<String, Object> dummyChip(String id) {
+                return Map.of(
+                        JsonLd.ID_KEY, id,
+                        JsonLd.Rdfs.LABEL, id
+                );
+            }
+        };
+    }
+}

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -67,6 +67,7 @@ class Whelk {
     ResourceCache resourceCache
     ElasticFind elasticFind
     Relations relations
+    ChipCache chipCache
     DocumentNormalizer normalizer
     Romanizer romanizer
     FeatureFlags features = FeatureFlags.uninitialized()
@@ -154,6 +155,8 @@ class Whelk {
         logRoot = new File(System.getProperty("xl.logRoot", "./logs"))
 
         loadCoreData(systemContextUri)
+
+        chipCache = new ChipCache(this)
 
         if (this.esMode == EsMode.ELASTIC_ENABLED) {
             this.elastic = new ElasticSearch(configuration, jsonld)
@@ -711,7 +714,7 @@ class Whelk {
      * @param iris
      * @return map from all thing and record identifiers (including sameAs) to corresponding card of whole document 
      */
-    Map<String, Map> getCards(Iterable<String> iris) {
+    <T extends String> Map<String, Map> getCards(Iterable<T> iris) {
         Map<String, Map> result = [:]
         storage.getCards(iris).each { card ->
             List<Map> graph = (List<Map>) card[JsonLd.GRAPH_KEY]

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -25,7 +25,7 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     }
 
     @Override
-    Iterable<Map> getCards(Iterable<String> iris) {
+    <T extends String> Iterable<Map> getCards(Iterable<T> iris) {
         cardCache.getAll(iris).values().findAll{ !it.isEmpty() }
     }
 

--- a/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/DependencyCache.groovy
@@ -7,10 +7,10 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListenableFutureTask
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import groovy.util.logging.Log4j2 as Log
-import io.prometheus.client.guava.cache.CacheMetricsCollector
 import whelk.Document
 import whelk.Link
 import whelk.exception.MissingMainIriException
+import whelk.util.Metrics
 
 import java.util.concurrent.Callable
 import java.util.concurrent.Executor
@@ -25,8 +25,6 @@ import static whelk.component.PostgreSQLComponent.NotificationType.DEPENDENCY_CA
 class DependencyCache {
     private static final int CACHE_SIZE = 50_000
     private static final int REFRESH_INTERVAL_MINUTES = 5
-
-    private static final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register()
 
     PostgreSQLComponent storage
 
@@ -48,8 +46,8 @@ class DependencyCache {
     DependencyCache(PostgreSQLComponent storage) {
         this.storage = storage
 
-        cacheMetrics.addCache('dependersCache', dependersCache)
-        cacheMetrics.addCache('dependencyCache', dependenciesCache)
+        Metrics.cacheMetrics.addCache('dependersCache', dependersCache)
+        Metrics.cacheMetrics.addCache('dependencyCache', dependenciesCache)
     }
 
     Set<String> getDependenciesOfType(String iri, String typeOfRelation) {

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -1281,7 +1281,7 @@ class PostgreSQLComponent {
         return loadCard(systemId) ?: makeCardData(systemId)
     }
 
-    Iterable<Map> getCards(Iterable<String> iris) {
+    <T extends String> Iterable<Map> getCards(Iterable<T> iris) {
         return createAndAddMissingCards(bulkLoadCards(getSystemIdsByIris(iris).values())).values()
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -1,7 +1,6 @@
 package whelk.search2;
 
 import com.google.common.base.Predicates;
-import whelk.Document;
 import whelk.JsonLd;
 import whelk.Whelk;
 import whelk.exception.InvalidQueryException;
@@ -566,33 +565,21 @@ public class Query {
     }
 
     private class LinkLoader {
-        private final Map<String, Collection<Link>> links = new HashMap<>();
+        private final Map<String, Collection<Link>> linkMap = new HashMap<>();
 
         private void loadChips() {
-            var cards = whelk.getCards(links.keySet());
+            var chips = whelk.getChipCache().getChips(linkMap.keySet());
 
-            links.forEach((id, links) -> {
-                var cardGraph = cards.get(id);
-                if (cardGraph != null) {
-                    var chip = castToStringObjectMap(whelk.getJsonld().toChip(new Document(cardGraph).getThing()));
-                    links.forEach(link -> link.setChip(chip));
-                } else {
-                    links.forEach(link -> link.setChip(dummyChip(id)));
-                }
+            linkMap.forEach((id, links) -> {
+                var chip = chips.get(id);
+                links.forEach(link -> link.setChip(chip));
             });
 
-            links.clear();
-        }
-
-        private Map<String, Object> dummyChip(String id) {
-            return Map.of(
-                    JsonLd.ID_KEY, id,
-                    JsonLd.Rdfs.LABEL, id
-            );
+            linkMap.clear();
         }
 
         private void queue(Link link) {
-            links.computeIfAbsent(link.iri(), k -> new ArrayList<>()).add(link);
+            linkMap.computeIfAbsent(link.iri(), k -> new ArrayList<>()).add(link);
         }
 
         private void queue(Collection<Link> links) {

--- a/whelk-core/src/main/groovy/whelk/util/Metrics.groovy
+++ b/whelk-core/src/main/groovy/whelk/util/Metrics.groovy
@@ -2,8 +2,11 @@ package whelk.util
 
 import io.prometheus.client.Counter
 import io.prometheus.client.Summary
+import io.prometheus.client.guava.cache.CacheMetricsCollector
 
 class Metrics {
+    public static final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register()
+
     static final Summary clientTimer = Summary.build()
             .labelNames("target", "method")
             .quantile(0.5, 0.05)


### PR DESCRIPTION
defaultSiteFilters are the same for all queries (for one site). They are reflected in search mappings. Meaning their chips are needed in all requests. So cache them. 10 minutes for now. Serving stale mappings should be harmless. We could expand this with an invalidation mechanism like in dependencyCache.

profiling with simple queries - stress_search2_api_simple.py

All states
LinkLoader.loadChips 9.7% -> 3.3%

More than 91% of time is now spent on the elastic call

Runnable
LinkLoader.loadChips 20.7% -> 12.4%

cache stats - over 90% hit rate
```
$ curl -s "http://localhost:8180/metrics" | grep chipCache
guava_cache_hit_total{cache="chipCache",} 90584.0
guava_cache_miss_total{cache="chipCache",} 8038.0
...
```


Before
<img width="955" height="815" alt="Skärmbild från 2026-04-08 15-58-21" src="https://github.com/user-attachments/assets/f4fee3ed-d423-4ea0-915b-e09b80e9987a" />

After
<img width="759" height="462" alt="Skärmbild från 2026-04-08 17-20-03" src="https://github.com/user-attachments/assets/f830e3b0-1a81-4438-87df-14d47c16beeb" />

More than 91% of time is now spent in the elastic call
<img width="945" height="614" alt="Skärmbild från 2026-04-08 17-23-51" src="https://github.com/user-attachments/assets/f694dd58-c817-4b3f-b8ed-22c47d6eb7d3" />
