### PR TITLE
Various changes to improve indexing speed

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -618,6 +618,7 @@ class Document {
         return _preparePath(path, data)
     }
 
+    @CompileStatic
     static boolean _preparePath(List path, Object root) {
         // Start at root data node
         Object node = root
@@ -626,24 +627,24 @@ class Document {
             Object step = path.get(i)
 
             // use the next step to determine the type of the next object
-            Type nextReplacementType = (path.get(i + 1) instanceof Integer) ? ArrayList : HashMap
+            Class nextReplacementType = (path.get(i + 1) instanceof Integer) ? ArrayList : HashMap
 
             // Get the next object along the path (candidate)
             Object candidate = null
             if (node instanceof Map)
-                candidate = node.get(step)
+                candidate = ((Map) node).get(step)
             else if (node instanceof List) {
-                if (node.size() > step)
-                    candidate = node.get(step)
+                if (((List) node).size() > (int) step)
+                    candidate = ((List) node).get((int) step)
             }
 
             // If that step can't be taken in the current structure, expand the structure
             if (candidate == null) {
                 if (node instanceof Map)
-                    node.put(step, nextReplacementType.newInstance())
+                    ((Map) node).put(step, nextReplacementType.newInstance())
                 else if (node instanceof List) {
-                    while (node.size() < step + 1)
-                        node.add(nextReplacementType.newInstance())
+                    while (((List) node).size() < (int) step + 1)
+                        ((List) node).add(nextReplacementType.newInstance())
                 }
             }
             // Check path integrity, in all but the last step (which will presumably be replaced)
@@ -657,7 +658,10 @@ class Document {
                 return false
             }
 
-            node = node.get(step)
+            if (node instanceof Map)
+                node = ((Map) node).get(step)
+            else if (node instanceof List)
+                node = ((List) node).get((int) step)
         }
         return true
     }
@@ -669,6 +673,7 @@ class Document {
         return _set(path, value, data)
     }
 
+    @CompileStatic
     static boolean _set(List path, Object value, Object root) {
         if (!_preparePath(path, root))
             return false
@@ -679,23 +684,26 @@ class Document {
         for (int i = 0; i < path.size() - 1; ++i) // follow all but last step
         {
             Object step = path.get(i)
-            node = node.get(step)
+            if (node instanceof Map)
+                node = ((Map) node).get(step)
+            else if (node instanceof List)
+                node = ((List) node).get((int) step)
         }
 
         if ( node instanceof Map )
-            node.put(path.get(path.size() - 1), value)
+            ((Map) node).put(path.get(path.size() - 1), value)
         else if ( node instanceof List ) {
             List nodeAsList = (List) node
-            while (nodeAsList.size() < path.get(path.size() - 1))
+            while (nodeAsList.size() < (int) path.get(path.size() - 1))
                 nodeAsList.add(null)
-            nodeAsList.add(path.get(path.size() - 1), value)
-            //node.add(path.get(path.size() - 1), value)
+            nodeAsList.add((int) path.get(path.size() - 1), value)
         }
         else
             throw new RuntimeException("Was asked to insert at " + path.get(path.size() - 1) + " in " + node + " and could not match up the container types.")
         return true
     }
 
+    @CompileStatic
     static boolean _removeLeafObject(List path, Object root) {
         // Start at root data node
         Object node = root
@@ -703,10 +711,16 @@ class Document {
         for (int i = 0; i < path.size() - 1; ++i) // follow all but last step
         {
             Object step = path.get(i)
-            node = node.get(step)
+            if (node instanceof Map)
+                node = ((Map) node).get(step)
+            else if (node instanceof List)
+                node = ((List) node).get((int) step)
         }
 
-        node.remove(path.get(path.size() - 1))
+        if (node instanceof Map)
+            ((Map) node).remove(path.get(path.size() - 1))
+        else if (node instanceof List)
+            ((List) node).remove((int) path.get(path.size() - 1))
         return true
     }
 
@@ -718,23 +732,37 @@ class Document {
         return false
     }
 
+    @CompileStatic
     private Object get(List path) {
         return _get(path, data)
     }
 
+    @CompileStatic
     static Object _get(List path, Object root) {
         // Start at root data node
         Object node = root
 
         for (Object step : path) {
-            if ((node instanceof Map) && !(step instanceof String)) {
-                log.warn("Needed string as map key, but was given: " + step + ". (path was: " + path + ")")
-                return null
-            } else if ((node instanceof List) && !(step instanceof Integer)) {
-                log.warn("Needed integer as list index, but was given: " + step + ". (path was: " + path + ")")
+            if (node instanceof Map) {
+                if (!(step instanceof String)) {
+                    log.warn("Needed string as map key, but was given: " + step + ". (path was: " + path + ")")
+                    return null
+                }
+                node = ((Map) node).get((String) step)
+            } else if (node instanceof List) {
+                if (!(step instanceof Integer)) {
+                    log.warn("Needed integer as list index, but was given: " + step + ". (path was: " + path + ")")
+                    return null
+                }
+                int idx = (int) step
+                List list = (List) node
+                if (idx < 0 || idx >= list.size()) {
+                    return null
+                }
+                node = list.get(idx)
+            } else {
                 return null
             }
-            node = node[step]
 
             if (node == null) {
                 return null

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -772,25 +772,10 @@ class Document {
         return node
     }
 
+    // This assumes that orig is a JSON-compatible thing. It should always be fine for our use,
+    // since the stuff passed to it was initially deserialized by Jackson anyway.
     static Object deepCopy(Object orig) {
-        //TODO: see https://jira.kb.se/browse/LXL-270
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream()
-            ObjectOutputStream oos = new ObjectOutputStream(bos)
-            oos.writeObject(orig); oos.flush()
-            ByteArrayInputStream bin = new ByteArrayInputStream(bos.toByteArray())
-            ObjectInputStream ois = new ObjectInputStream(bin)
-            return ois.readObject()
-        } catch (any) {
-            //§println "ERROR! ${any.message} in deepCopy. Cloning using other approach"
-            def o = orig.inspect()
-            ByteArrayOutputStream bos = new ByteArrayOutputStream()
-            ObjectOutputStream oos = new ObjectOutputStream(bos)
-            oos.writeObject(o); oos.flush()
-            ByteArrayInputStream bin = new ByteArrayInputStream(bos.toByteArray())
-            ObjectInputStream ois = new ObjectInputStream(bin)
-            return Eval.me(ois.readObject())
-        }
+        return mapper.readValue(mapper.writeValueAsBytes(orig), Object)
     }
 
     /**

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -306,7 +306,11 @@ class Whelk {
             idMap.putAll(idToIri)
         }
 
-        return storage.bulkLoad(systemIds, asOf)
+        Map<String, Document> loaded = (asOf == null && storage instanceof CachingPostgreSQLComponent)
+                ? ((CachingPostgreSQLComponent) storage).cachedBulkLoad(systemIds)
+                : storage.bulkLoad(systemIds, asOf)
+
+        return loaded
                 .findAll { id, doc -> !doc.deleted }
                 .collectEntries { id, doc -> [(idMap.getOrDefault(id, id)): doc] }
     }

--- a/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/CachingPostgreSQLComponent.groovy
@@ -7,11 +7,19 @@ import groovy.util.logging.Log4j2 as Log
 import whelk.Document
 
 import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+
+import static whelk.util.Jackson.mapper
 
 @Log
 class CachingPostgreSQLComponent extends PostgreSQLComponent {
     private static final int CARD_CACHE_MAX_SIZE = 250_000
+    private static final int DOC_CACHE_MAX_SIZE = 250_000
+    private static final int IRI_CACHE_MAX_SIZE = 500_000
     private LoadingCache<String, Map> cardCache
+    private LoadingCache<String, byte[]> docCache
+    private LoadingCache<String, String> iriToSystemIdCache
 
     CachingPostgreSQLComponent(Properties properties) {
         super(properties)
@@ -22,6 +30,14 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     void logStats() {
         super.logStats()
         log.info("Card cache: ${cardCache.stats()}")
+        log.info("Doc cache: ${docCache.stats()}")
+        log.info("IRI->ID cache: ${iriToSystemIdCache.stats()}")
+    }
+
+    @Override
+    Map<String, String> getSystemIdsByIris(Iterable iris) {
+        Map<String, String> result = iriToSystemIdCache.getAll(iris)
+        return result.findAll { k, v -> !v.isEmpty() }
     }
 
     @Override
@@ -32,6 +48,17 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
     @Override
     Map getCard(String iri) {
         return cardCache.get(iri)
+    }
+
+    Map<String, Document> cachedBulkLoad(Iterable<String> systemIds) {
+        Map<String, byte[]> cached = docCache.getAll(systemIds)
+        Map<String, Document> result = new TreeMap<>()
+        cached.each { id, bytes ->
+            if (bytes.length > 0) {
+                result[id] = new Document(mapper.readValue(bytes, Map))
+            }
+        }
+        return result
     }
 
     @Override
@@ -57,6 +84,50 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
         return super.getCard(iri)
     }
 
+    private Map<String, String> loadIriMappingsFromDb(Iterable iris) {
+        Map<String, String> ids = new HashMap<>()
+        withDbConnection {
+            Connection connection = getMyConnection()
+            PreparedStatement stmt = null
+            ResultSet rs = null
+            try {
+                stmt = connection.prepareStatement(GET_SYSTEMIDS_BY_IRIS)
+                stmt.setArray(1, connection.createArrayOf("TEXT", iris as String[]))
+                rs = stmt.executeQuery()
+                while (rs.next()) {
+                    ids.put(rs.getString(1), rs.getString(2))
+                }
+            } finally {
+                if (rs != null) { try { rs.close() } catch (Exception ignore) {} }
+                if (stmt != null) { try { stmt.close() } catch (Exception ignore) {} }
+            }
+        }
+        return ids
+    }
+
+    private static final byte[] EMPTY_BYTES = new byte[0]
+
+    private Map<String, Document> loadFromDb(Iterable<String> systemIds) {
+        return withDbConnection {
+            Connection connection = getMyConnection()
+            PreparedStatement preparedStatement = null
+            ResultSet rs = null
+            try {
+                preparedStatement = connection.prepareStatement(BULK_LOAD_DOCUMENTS)
+                preparedStatement.setArray(1, connection.createArrayOf("TEXT", systemIds as String[]))
+                rs = preparedStatement.executeQuery()
+                Map<String, Document> result = new TreeMap<>()
+                while (rs.next()) {
+                    result[rs.getString("id")] = assembleDocument(rs)
+                }
+                return result
+            } finally {
+                if (rs != null) { try { rs.close() } catch (Exception ignore) {} }
+                if (preparedStatement != null) { try { preparedStatement.close() } catch (Exception ignore) {} }
+            }
+        }
+    }
+
     void initCaches() {
         cardCache = CacheBuilder.newBuilder()
                 .maximumSize(CARD_CACHE_MAX_SIZE)
@@ -73,6 +144,57 @@ class CachingPostgreSQLComponent extends PostgreSQLComponent {
                         def cards = createAndAddMissingCards(bulkLoadCards(irisToIds.values()))
                         cards.put('NON-EXISTING', Collections.emptyMap())
                         return iris.collectEntries { [it, cards.get(irisToIds.get(it) ?: "NON-EXISTING")] }
+                    }
+                })
+
+        iriToSystemIdCache = CacheBuilder.newBuilder()
+                .maximumSize(IRI_CACHE_MAX_SIZE)
+                .recordStats()
+                .build(new CacheLoader<String, String>() {
+                    @Override
+                    String load(String iri) throws Exception {
+                        Map<String, String> result = loadIriMappingsFromDb([iri])
+                        return result.containsKey(iri) ? result[iri] : ""
+                    }
+
+                    @Override
+                    Map<String, String> loadAll(Iterable<? extends String> iris) throws Exception {
+                        Map<String, String> result = loadIriMappingsFromDb(iris.collect())
+                        Map<String, String> all = [:]
+                        for (String iri : iris) {
+                            all[iri] = result.containsKey(iri) ? result[iri] : ""
+                        }
+                        return all
+                    }
+                })
+
+        docCache = CacheBuilder.newBuilder()
+                .maximumSize(DOC_CACHE_MAX_SIZE)
+                .recordStats()
+                .build(new CacheLoader<String, byte[]>() {
+                    @Override
+                    byte[] load(String systemId) throws Exception {
+                        Map<String, Document> loaded = loadFromDb([systemId])
+                        Document doc = loaded[systemId]
+                        if (doc == null || doc.deleted) {
+                            return EMPTY_BYTES
+                        }
+                        return mapper.writeValueAsBytes(doc.data)
+                    }
+
+                    @Override
+                    Map<String, byte[]> loadAll(Iterable<? extends String> systemIds) throws Exception {
+                        Map<String, Document> loaded = loadFromDb(systemIds.collect())
+                        Map<String, byte[]> result = [:]
+                        for (String id : systemIds) {
+                            Document doc = loaded[id]
+                            if (doc == null || doc.deleted) {
+                                result[id] = EMPTY_BYTES
+                            } else {
+                                result[id] = mapper.writeValueAsBytes(doc.data)
+                            }
+                        }
+                        return result
                     }
                 })
     }

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -47,8 +47,8 @@ import static whelk.util.Jackson.mapper
 
 @Log
 class ElasticClient {
-    static final int MAX_CONNECTIONS_PER_HOST = 12
-    static final int CONNECTION_POOL_SIZE = 30
+    static final int MAX_CONNECTIONS_PER_HOST = 20
+    static final int CONNECTION_POOL_SIZE = 60
 
     static final int CONNECT_TIMEOUT_MS = 5 * 1000
     static final int READ_TIMEOUT_MS = 15 * 1000

--- a/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticClient.groovy
@@ -47,8 +47,8 @@ import static whelk.util.Jackson.mapper
 
 @Log
 class ElasticClient {
-    static final int MAX_CONNECTIONS_PER_HOST = 20
-    static final int CONNECTION_POOL_SIZE = 60
+    static final int MAX_CONNECTIONS_PER_HOST = 40
+    static final int CONNECTION_POOL_SIZE = 120
 
     static final int CONNECT_TIMEOUT_MS = 5 * 1000
     static final int READ_TIMEOUT_MS = 15 * 1000

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -1,5 +1,6 @@
 package whelk.component
 
+import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.util.logging.Log4j2 as Log
 import org.apache.commons.codec.binary.Base64
@@ -522,6 +523,7 @@ class ElasticSearch {
         }
     }
 
+    @CompileStatic
     static String getShapeForIndex(Document document, Whelk whelk) {
         Document copy = document.clone()
 
@@ -531,7 +533,7 @@ class ElasticSearch {
             log.debug("Framing ${document.getShortId()}")
         }
 
-        Set<String> links = whelk.jsonld.expandLinks(document.getExternalRefs()).collect{ it.iri }
+        Set<String> links = whelk.jsonld.expandLinks(document.getExternalRefs()).collect{ it.iri } as Set<String>
 
         var embellishedGraph = ((List) copy.data[GRAPH_KEY])
         var originalGraphSize = ((List) document.data[GRAPH_KEY]).size()
@@ -606,7 +608,7 @@ class ElasticSearch {
         var itemPath = ["@reverse", "instanceOf", "*", "@reverse", "itemOf", "*"]
         var itemCount = ((List) DocumentUtil.getAtPath(searchCard, itemPath, []))
                 .collect{ it['heldBy']?[JsonLd.ID_KEY] }.grep().unique().size()
-        incomingLinkCountByRelation.put('itemOf.instanceOf', itemCount)
+        incomingLinkCountByRelation.put('itemOf.instanceOf', (long) itemCount)
 
         searchCard['reverseLinks'] = [
                 (JsonLd.TYPE_KEY) : 'PartialCollectionView',
@@ -635,7 +637,7 @@ class ElasticSearch {
                 // TODO: replace with elastic ICU Analysis plugin?
                 // https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html
                 if (value instanceof List) {
-                    return new DocumentUtil.Replace(value.collect { !Unicode.isNormalizedForSearch(it) ? Unicode.normalizeForSearch(it) : it })
+                    return new DocumentUtil.Replace(((List<String>) value).collect { String s -> !Unicode.isNormalizedForSearch(s) ? Unicode.normalizeForSearch(s) : s })
                 }
                 if (value instanceof String && !Unicode.isNormalizedForSearch(value)) {
                     return new DocumentUtil.Replace(Unicode.normalizeForSearch(value))
@@ -658,14 +660,14 @@ class ElasticSearch {
                 // { "foo": "FOO", "fooByLang": { "en": "EN", "sv": "SV" } }
                 // -->
                 // { "foo": "FOO", "fooByLang": { "en": "EN", "sv": "SV" }, "__foo": ["FOO", "EN", "SV"] }
-                var flattened = [:]
+                Map<String, List> flattened = [:]
                 value.each { k, v ->
                     if (k in whelk.jsonld.langContainerAlias) {
-                        var __k = flattenedLangMapKey(k)
-                        flattened[__k] = (flattened[__k] ?: []) + asList(v)
+                        var __k = flattenedLangMapKey((String) k)
+                        flattened[__k] = ((List) (flattened[__k] ?: [])) + asList(v)
                     } else if (k in whelk.jsonld.langContainerAliasInverted) {
-                        var __k = flattenedLangMapKey(whelk.jsonld.langContainerAliasInverted[k])
-                        flattened[__k] = (flattened[__k] ?: []) + ((Map) v).values().flatten()
+                        var __k = flattenedLangMapKey((String) whelk.jsonld.langContainerAliasInverted[k])
+                        flattened[__k] = ((List) (flattened[__k] ?: [])) + ((Map) v).values().flatten()
                     }
                 }
                 if (!flattened.isEmpty()) {
@@ -706,7 +708,8 @@ class ElasticSearch {
         return mapper.writeValueAsString(searchCard)
     }
     
-    static String flattenedLangMapKey(key) {
+    @CompileStatic
+    static String flattenedLangMapKey(String key) {
         return '__' + key
     }
 
@@ -725,6 +728,7 @@ class ElasticSearch {
         return ids
     }
 
+    @CompileStatic
     private static Map<String, String> buildSortKeyByLang(Map<String, Object> thing, Whelk whelk) {
         List<String> locales =  whelk.jsonld.locales
 
@@ -752,6 +756,7 @@ class ElasticSearch {
         return s.replaceFirst(/^[^\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{N}]+/, "")
     }
 
+    @CompileStatic
     private static void addSearchStr(Map<String, Object> thing, Whelk whelk, Lens lens, String key) {
         if (!thing[TYPE_KEY]) {
             return
@@ -767,6 +772,7 @@ class ElasticSearch {
         }
     }
 
+    @CompileStatic
     private static Set<String> collectIntegralIds(List<Map> graph, JsonLd jsonLd) {
         return JsonLd.getExternalReferences([(GRAPH_KEY): graph])
                 .findAll {
@@ -781,16 +787,18 @@ class ElasticSearch {
                 .toSet()
     }
 
+    @CompileStatic
     private static Map getShapeForEmbellishment(FresnelUtil fresnelUtil, Map embellishData, Set<String> integralIds, Closure restoreCategoryByCollection) {
-        def graph = ((List) embellishData[GRAPH_KEY])
+        List graph = ((List) embellishData[GRAPH_KEY])
         if (graph) {
-            def (record, thing) = graph
+            Map record = (Map) graph[0]
+            Map thing = (Map) graph[1]
             thing[RECORD_KEY] = record
-            def shapedThing = integralIds.contains(thing[ID_KEY])
+            Map<String, Object> shapedThing = integralIds.contains(thing[ID_KEY])
                     ? toSearchCard(fresnelUtil, thing) // Do we really want the full search card here?
                     : toSearchChip(fresnelUtil, thing)
-            def shapedRecord = minimalRecord((Map) record) + ((Map) shapedThing.remove(RECORD_KEY) ?: [:])
-            def shapedGraph = [shapedRecord, shapedThing]
+            Map shapedRecord = minimalRecord(record) + ((Map) shapedThing.remove(RECORD_KEY) ?: [:])
+            List shapedGraph = [shapedRecord, shapedThing]
             if (integralIds.contains(thing[ID_KEY]) && restoreCategoryByCollection) {
                 restoreCategoryByCollection(shapedGraph, graph)
             }
@@ -800,22 +808,27 @@ class ElasticSearch {
         return embellishData
     }
 
+    @CompileStatic
     private static Map<String, Object> toSearchChip(FresnelUtil fresnelUtil, Map thing) {
         return mapThroughLensForIndex(fresnelUtil, thing, FresnelUtil.Lenses.SEARCH_CHIP)
     }
 
+    @CompileStatic
     private static Map<String, Object> toSearchCard(FresnelUtil fresnelUtil, Map thing) {
         return mapThroughLensForIndex(fresnelUtil, thing, FresnelUtil.Lenses.SEARCH_CARD)
     }
 
+    @CompileStatic
     private static Map<String, Object> mapThroughLensForIndex(FresnelUtil fresnelUtil, Map thing, Lens lens) {
         return fresnelUtil.mapThroughLens(thing, lens, [TAKE_ALL_ALTERNATE, SKIP_MAP_VOCAB_TERMS], [])
     }
 
+    @CompileStatic
     private static FresnelUtil.LensMappingBatch batchToSearchCard(FresnelUtil fresnelUtil, List<Map<String, Object>> thing, Collection<String> preserveLinks) {
         return fresnelUtil.mapBatchThroughLens(thing, FresnelUtil.Lenses.SEARCH_CARD, [TAKE_ALL_ALTERNATE, SKIP_MAP_VOCAB_TERMS], preserveLinks)
     }
 
+    @CompileStatic
     private static Map minimalRecord(Map record) {
         return record.subMap([ID_KEY, TYPE_KEY, THING_KEY])
     }
@@ -848,10 +861,12 @@ class ElasticSearch {
         }
     }
 
-    private static lastPathSegment(String uri) {
+    @CompileStatic
+    private static String lastPathSegment(String uri) {
         uri.contains('/') ? uri.substring(uri.lastIndexOf('/') + 1) : uri
     }
 
+    @CompileStatic
     private static String stripHash(String s) {
         s.contains('#') ? s.substring(0, s.indexOf('#')) : s
     }

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -126,7 +126,7 @@ class PostgreSQLComponent {
     private static final String GET_DOCUMENT_VERSION =
             "SELECT id, data FROM lddb__versions WHERE id = ? AND checksum = ?"
 
-    private static final String BULK_LOAD_DOCUMENTS = """
+    protected static final String BULK_LOAD_DOCUMENTS = """
             SELECT id, data, created, modified, deleted
             FROM unnest(?) AS in_id, lddb l 
             WHERE in_id = l.id
@@ -356,7 +356,7 @@ class PostgreSQLComponent {
             JOIN lddb ON lddb__identifiers.id = lddb.id WHERE lddb__identifiers.iri = ? 
             """.stripIndent()
 
-    private static final String GET_SYSTEMIDS_BY_IRIS = """
+    protected static final String GET_SYSTEMIDS_BY_IRIS = """
             SELECT lddb__identifiers.iri, lddb__identifiers.id, lddb.deleted
             FROM lddb__identifiers, lddb, unnest(?) as in_iri
             WHERE lddb__identifiers.iri = in_iri
@@ -2586,7 +2586,7 @@ class PostgreSQLComponent {
         }
     }
 
-    private static Document assembleDocument(ResultSet rs) {
+    protected static Document assembleDocument(ResultSet rs) {
         Document doc = new Document(mapper.readValue(rs.getString("data"), Map))
         doc.setModified(new Date(rs.getTimestamp("modified").getTime()))
         doc.setDeleted(rs.getBoolean("deleted"))

--- a/whelk-core/src/main/groovy/whelk/util/DFS.java
+++ b/whelk-core/src/main/groovy/whelk/util/DFS.java
@@ -4,56 +4,46 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 // This is a straightforward port of the old groovy version in DocumentUtil. Can probably be improved
 class DFS {
-    private Stack<Object> path;
+    private ArrayList<Object> path;
     private DocumentUtil.Visitor visitor;
     private List<DocumentUtil.Operation> operations;
 
-    private record Node(Object value, Object keyOrIndex) {}
-
     public boolean traverse(final Object obj, DocumentUtil.Visitor visitor) {
         this.visitor = visitor;
-        path = new Stack<>();
+        path = new ArrayList<>();
         operations = new ArrayList<>();
 
         node(obj);
 
         Collections.reverse(operations);
-        for  (DocumentUtil.Operation op : operations) {
+        for (DocumentUtil.Operation op : operations) {
             op.perform(obj);
-        };
+        }
         return !operations.isEmpty();
     }
 
     private void node(Object obj) {
-        var op = visitor.visitElement(obj, Collections.unmodifiableList(path));
+        var op = visitor.visitElement(obj, path);
         if (op != null && !(op instanceof DocumentUtil.Nop)) {
             op.setPath(path);
             operations.add(op);
         }
 
         if (obj instanceof Map<?, ?> map) {
-            var nodes = map.entrySet().stream()
-                    .map(e -> new Node(e.getValue(), e.getKey()))
-                    .toList();
-            descend(nodes);
-        } else if (obj instanceof List<?> list) {
-            var nodes = new ArrayList<Node>(list.size());
-            for (int i = 0 ; i < list.size() ; i++) {
-                nodes.add(new Node(list.get(i), i));
+            for (var e : map.entrySet()) {
+                path.add(e.getKey());
+                node(e.getValue());
+                path.removeLast();
             }
-            descend(nodes);
-        }
-    }
-
-    private void descend(List<Node> nodes) {
-        for (var n : nodes) {
-            path.push(n.keyOrIndex);
-            node(n.value);
-            path.pop();
+        } else if (obj instanceof List<?> list) {
+            for (int i = 0; i < list.size(); i++) {
+                path.add(i);
+                node(list.get(i));
+                path.removeLast();
+            }
         }
     }
 }

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -26,6 +26,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static whelk.JsonLd.ID_KEY;
@@ -1222,13 +1223,15 @@ public class FresnelUtil {
         private static final String SUB = "^";
 
         private final String path;
+        private final String[] pathParts;
 
         FslPath(String path) {
             this.path = path;
+            this.pathParts = path.split("/");
         }
 
         List<Node.Selected> select(Map<String, Object> sourceEntity) {
-            return select(sourceEntity, new ArrayList<>(List.of(path.split("/"))));
+            return select(sourceEntity, new ArrayList<>(List.of(pathParts)));
         }
 
         boolean isIntegralProperty() {
@@ -1305,6 +1308,8 @@ public class FresnelUtil {
         }
 
         private final class ArcStep extends LocationStep {
+            private static final Pattern BRACKET_PATTERN = Pattern.compile(".+\\[.+]");
+
             private boolean reverse = false;
             private final List<String> allowedTypes = new ArrayList<>();
             private final List<String> candidateKeys = new ArrayList<>();
@@ -1366,7 +1371,7 @@ public class FresnelUtil {
                     arcStep = arcStep.substring(IN.length());
                 }
 
-                if (arcStep.matches(".+\\[.+]")) {
+                if (BRACKET_PATTERN.matcher(arcStep).matches()) {
                     String allowedType = arcStep.substring(arcStep.indexOf('[') + 1, arcStep.indexOf(']'));
                     arcStep = arcStep.substring(0, arcStep.indexOf('['));
                     if (allowedType.startsWith(SUB)) {


### PR DESCRIPTION
I did a whole lot of profiling (locally) while reindexing and before/after each of the following, plus full reindexes.

### Don't re-split path on every FslPath.select() call; pre-compile ArcStep regex

Straight-forward.

### Remove unnecessary/intermediate stuff in DFS

* Stack in synchronized, but we don't need that overhead here. So let's use a plain old ArrayList instead.
* Getting rid of `Collections.unmodifiableList(path)`: this was originally (when DFS was elsewhere) `path.collect()`, which was later changed to `Collections.unmodifiableList()`, which is cheaper. But this still allocates a wrapper on every node visit, and I'm not sure the defensiveness is justified.
* We don't need intermediate Node objects and thus not `descend()` either. The list/map isn't mutated during traversal so this should also be fine.

13-15% reduction in index time with this change (and the ArcStep regex).

### `@CompileStatic` all the things!
Well, at least some more. And the changes to make it work (e.g. explicit casts), including some restructuring of `_get`.

### doc and IRI->ID cache

I also added a doc and IRI->ID cache to CachingPostgreSQLComponent (which also necessitated some access modifierchanges). This reduced indexing time by about 15%. This also affects the card cache but I _think_ it's fine because the card cache is only used when reindexing (right?).

Stats after a full QA reindex:

INFO  whelk.component.CachingPostgreSQLComponent - Doc cache: CacheStats{hitCount=642912128, missCount=112343106, loadSuccessCount=60485781, loadExceptionCount=0, totalLoadTime=309437839975245, evictionCount=112088908}
INFO  whelk.component.CachingPostgreSQLComponent - IRI->ID cache: CacheStats{hitCount=1019271475, missCount=2146846, loadSuccessCount=1775640, loadExceptionCount=0, totalLoadTime=12590020579073, evictionCount=1646821}

99.8% hit rate for IRI-ID, 85% for the doc cache (lots of evictions, should try increasing DOC_CACHE_MAX_SIZE) for the latter.

### Jackson in Document.deepCopy

Should also be fine (see comment). Haven't done a full reindex with this but saw a 10-15% reduction in indexing time when testing locally.

### MAX_CONNECTIONS_PER_HOST + CONNECTION_POOL_SIZE

Was previously too low, at least when reindexing with lots of CPUs to the cluster. Needs more testing to figure out what's best. Maybe set it dynamically or make it configurable.

With all these changes, the ES cluster is still never the bottleneck. In the future we should do more Groovy-to-Java porting and maybe some larger restructuring/rethinking of the whole process.