### PR TITLE
perf(search): reuse app desc

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SiteSearch.java
+++ b/rest/src/main/groovy/whelk/rest/api/SiteSearch.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import whelk.JsonLd;
 import whelk.Whelk;
 import whelk.exception.InvalidQueryException;
+import whelk.search2.QueryParams;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import static whelk.JsonLd.findInData;
+import static whelk.search2.QueryParams.ApiParams.APP_CONFIG;
 import static whelk.util.Jackson.mapper;
 
 class SiteSearch {
@@ -137,8 +139,8 @@ class SiteSearch {
             Map appDesc = getAndIndexDescription(appId);
             if (appDesc != null) {
                 Map findDesc = getAndIndexDescription(appId + "find");
-                if (!queryParameters.containsKey("_appConfig")) {
-                    queryParameters.put("_appConfig", new String[]{mapper.writeValueAsString(search2.buildAppConfig(findDesc))});
+                if (!queryParameters.containsKey(APP_CONFIG)) {
+                    queryParameters.put(APP_CONFIG, new String[]{mapper.writeValueAsString(search2.buildAppConfig(findDesc))});
                 }
             }
             return search2.doSearch(queryParameters);

--- a/rest/src/main/groovy/whelk/rest/api/SiteSearch.java
+++ b/rest/src/main/groovy/whelk/rest/api/SiteSearch.java
@@ -74,6 +74,10 @@ class SiteSearch {
     }
 
     protected Map<?, ?> getAndIndexDescription(String id) {
+        if (appsIndex.containsKey(id)) {
+            return appsIndex.get(id);
+        }
+
         Map<?, ?> data = localDevAppsJsonLd();
 
         if (data == null) {

--- a/whelk-core/src/main/groovy/whelk/search2/AppParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/AppParams.java
@@ -22,9 +22,9 @@ public class AppParams {
     public final Filters filters;
 
     public AppParams(Map<String, Object> appConfig, JsonLd jsonLd) {
-        this.sliceList = getSliceList(appConfig, jsonLd);
-        this.filterAliases = getFilterAliases(appConfig);
-        this.filters = getFilters(appConfig);
+        this.sliceList = parseSliceList(appConfig, jsonLd);
+        this.filterAliases = parseFilterAliases(appConfig);
+        this.filters = parseFilters(appConfig);
     }
 
     public Map<String, FilterAlias> getFilterByAlias() {
@@ -55,16 +55,16 @@ public class AppParams {
 
         public Slice(Map<?, ?> settings, JsonLd jsonLd) {
             var chain = ((List<?>) settings.get("dimensionChain")).stream().map(String::valueOf).toList();
-            this.sortOrder = getSortOrder(settings);
-            this.bucketSortKey = getBucketSortKey(settings);
-            this.itemLimit = itemLimit(settings);
-            this.isRange = getRangeFlag(settings);
-            this.defaultConnective = getConnective(settings);
-            this.subSlice = getSubSlice(settings, jsonLd);
-            this.showIf = getShowIf(settings);
+            this.sortOrder = parseSortOrder(settings);
+            this.bucketSortKey = parseBucketSortKey(settings);
+            this.itemLimit = parseItemLimit(settings);
+            this.isRange = parseRangeFlag(settings);
+            this.defaultConnective = parseConnective(settings);
+            this.subSlice = parseSubSlice(settings, jsonLd);
+            this.showIf = parseShowIf(settings);
             this.property = Property.getProperty(String.join(".", chain), jsonLd);
             this.propertyKey = property.name();
-            this.shouldCountTopLevelDocs = getShouldCountTopLevelDocs(settings);
+            this.shouldCountTopLevelDocs = parseShouldCountTopLevelDocs(settings);
         }
 
         public Slice(Map<?, ?> settings, Slice parent, JsonLd jsonLd) {
@@ -112,57 +112,56 @@ public class AppParams {
             return shouldCountTopLevelDocs;
         }
 
-        private Sort.Order getSortOrder(Map<?, ?> settings) {
+        public List<String> getShowIf() {
+            return showIf;
+        }
+        
+        private Sort.Order parseSortOrder(Map<?, ?> settings) {
             return Optional.ofNullable((String) settings.get("sortOrder"))
                     .map(Sort.Order::valueOf)
                     .orElse(Sort.Order.desc);
         }
 
-        private Sort.BucketSortKey getBucketSortKey(Map<?, ?> settings) {
+        private Sort.BucketSortKey parseBucketSortKey(Map<?, ?> settings) {
             return Optional.ofNullable((String) settings.get("sort"))
                     .map(Sort.BucketSortKey::valueOf)
                     .orElse(Sort.BucketSortKey.count);
         }
 
-        private int itemLimit(Map<?, ?> settings) {
+        private int parseItemLimit(Map<?, ?> settings) {
             return Optional.ofNullable((Integer) settings.get("itemLimit")).orElse(DEFAULT_BUCKET_SIZE);
         }
 
-        private boolean getRangeFlag(Map<?, ?> settings) {
+        private boolean parseRangeFlag(Map<?, ?> settings) {
             return Optional.ofNullable((Boolean) settings.get("range"))
                     .orElse(false);
         }
 
-        private Query.Connective getConnective(Map<?, ?> settings) {
+        private Query.Connective parseConnective(Map<?, ?> settings) {
             return Optional.ofNullable((String) settings.get("connective"))
                     .map(Query.Connective::valueOf)
                     .orElse(Query.Connective.AND);
         }
 
-        private Slice getSubSlice(Map<?, ?> settings, JsonLd jsonLd) {
+        private Slice parseSubSlice(Map<?, ?> settings, JsonLd jsonLd) {
             return Optional.ofNullable((Map<?,?>) settings.get("slice"))
                     .map(s -> new Slice(s, this, jsonLd))
                     .orElse(null);
         }
 
-
-        private List<String> getShowIf(Map<?, ?> settings) {
+        private List<String> parseShowIf(Map<?, ?> settings) {
             return Optional.ofNullable((List<?>) settings.get("showIf"))
                     .map(l -> l.stream().map(String::valueOf).collect(Collectors.toList()))
                     .orElse(Collections.emptyList());
         }
 
-        public List<String> getShowIf() {
-            return showIf;
-        }
-
-        private boolean getShouldCountTopLevelDocs(Map<?, ?> settings) {
+        private boolean parseShouldCountTopLevelDocs(Map<?, ?> settings) {
             return Optional.ofNullable((Boolean) settings.get("countTopLevelDocs")).orElse(false);
         }
     }
 
 
-    private List<Slice> getSliceList(Map<String, Object> appConfig, JsonLd jsonLd) {
+    private List<Slice> parseSliceList(Map<String, Object> appConfig, JsonLd jsonLd) {
         if (appConfig.containsKey("statistics")) {
             var s = (Map<?, ?>) appConfig.get("statistics");
             if (s.containsKey("sliceList")) {
@@ -174,7 +173,7 @@ public class AppParams {
         return Collections.emptyList();
     }
 
-    private static List<FilterAlias> getFilterAliases(Map<String, Object> appConfig) {
+    private static List<FilterAlias> parseFilterAliases(Map<String, Object> appConfig) {
         return getAsListOfMap(appConfig, "filterAliases").stream()
                 .map(m -> new FilterAlias((String) m.get("alias"),
                         (String) m.get("filter"),
@@ -182,20 +181,20 @@ public class AppParams {
                 .toList();
     }
 
-    private static Filters getFilters(Map<String, Object> appConfig) {
-        return new Filters(getFilter(appConfig, DEFAULT_SITE_FILTERS),
-                getFilter(appConfig, "optionalSiteFilters"),
-                getRelationFilters(appConfig)
+    private static Filters parseFilters(Map<String, Object> appConfig) {
+        return new Filters(parseFilter(appConfig, DEFAULT_SITE_FILTERS),
+                parseFilter(appConfig, "optionalSiteFilters"),
+                parseRelationFilters(appConfig)
         );
     }
 
-    private static List<String> getFilter(Map<String, Object> appConfig, String key) {
+    private static List<String> parseFilter(Map<String, Object> appConfig, String key) {
         return getAsListOfMap(appConfig, key).stream()
                 .map(m -> (String) m.get("filter"))
                 .toList();
     }
 
-    private static List<RelationFilter> getRelationFilters(Map<String, Object> appConfig) {
+    private static List<RelationFilter> parseRelationFilters(Map<String, Object> appConfig) {
         return getAsListOfMap(appConfig, "relationFilters").stream()
                 .map(m -> new RelationFilter((String) m.get("objectType"),
                         getAsList(m, "predicates").stream().map(String.class::cast).toList()))


### PR DESCRIPTION
AppConfig is static. Actually use the cached version...
Saves a couple of percent CPU.
[perf(search): reuse app desc](https://github.com/libris/librisxl/commit/5b63408e652b3cecae1d84c64d8bc4665673583d)
TODO: don't pass the serialized version through queryParameters.

naming stuff:
[chore(search2): naming in AppParams](https://github.com/libris/librisxl/commit/00efafdc651454c945fd828ecf1f3161d7bfbadc)