### PR TITLE
feat(api): format parameter in /compilemarc. Set file extension.

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.java
+++ b/rest/src/main/groovy/whelk/rest/api/LegacyMarcAPI.java
@@ -160,10 +160,14 @@ public class LegacyMarcAPI extends WhelkHttpServlet {
 
             Vector<MarcRecord> result = MarcExport.compileVirtualMarcRecord(profile, rootDocument, whelk, toMarcXmlConverter);
 
+            boolean isXml = "MARCXML".equalsIgnoreCase(request.getParameter("format"))
+                    || profile.getProperty("format", "ISO2709").equalsIgnoreCase("MARCXML");
+
             response.setContentType("application/octet-stream");
             response.setHeader("Cache-Control", "no-cache");
-            response.setHeader("Content-Disposition", "attachment; filename=\"libris_marc_" + rootDocument.getShortId() + "\"");
-            MarcRecordWriter writer = profile.getProperty("format", "ISO2709").equalsIgnoreCase("MARCXML") ?
+            var fileName = rootDocument.getShortId() + (isXml ? ".marc.xml" : ".marc");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+            MarcRecordWriter writer = isXml ?
                     new MarcXmlRecordWriter(response.getOutputStream(), "UTF-8") :
                     new Iso2709MarcRecordWriter(response.getOutputStream(), "UTF-8");
             for (MarcRecord record : result) {


### PR DESCRIPTION
to be used in link from lxl-web
- Add format parameter that overrides profile if present
- Change downloaded file name to <fnurgel>.marc / <fnurgel>.marc.xml
    - could break some script somewhere out there?
