### PR TITLE
perf(search): Add settings for _source.excludes

### DIFF
--- a/librisxl-tools/elasticsearch/libris_search_boost.json
+++ b/librisxl-tools/elasticsearch/libris_search_boost.json
@@ -120,5 +120,27 @@
       "value": "VirtualRecord",
       "score": 1000
     }
+  ],
+  "source_excludes": [
+    "@reverse.instanceOf.@reverse.itemOf.hasComponent",
+    "@reverse.instanceOf.@reverse.itemOf.itemOf",
+    "@reverse.instanceOf.@reverse.itemOf.librissearch:itemNote",
+    "@reverse.instanceOf.@reverse.itemOf.librissearch:shelf",
+    "@reverse.instanceOf.@reverse.itemOf.meta",
+    "@reverse.instanceOf.@reverse.itemOf.sameAs",
+    "@reverse.instanceOf.@reverse.itemOf.shelfControlNumber",
+    "@reverse.instanceOf.@reverse.itemOf.shelfMark",
+    "@reverse.instanceOf.@reverse.itemOf.subject",
+    "@reverse.instanceOf.@reverse.itemOf.summary",
+    "@reverse.itemOf.hasComponent",
+    "@reverse.itemOf.itemOf",
+    "@reverse.itemOf.librissearch:itemNote",
+    "@reverse.itemOf.librissearch:shelf",
+    "@reverse.itemOf.meta",
+    "@reverse.itemOf.sameAs",
+    "@reverse.itemOf.shelfControlNumber",
+    "@reverse.itemOf.shelfMark",
+    "@reverse.itemOf.subject",
+    "@reverse.itemOf.summary"
   ]
 }

--- a/whelk-core/src/main/groovy/whelk/search2/ESSettings.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ESSettings.java
@@ -4,6 +4,7 @@ import whelk.Whelk;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,7 @@ public class ESSettings {
 
     private EsMappings mappings;
     private final Boost boost;
+    private final List<String> sourceExcludes;
 
     private int maxItems;
 
@@ -28,6 +30,7 @@ public class ESSettings {
             this.maxItems = whelk.elastic.maxResultWindow;
         }
         this.boost = loadBoostSettings();
+        this.sourceExcludes = loadSourceExcludesSettings();
     }
 
     // For test only
@@ -43,6 +46,7 @@ public class ESSettings {
         this.mappings = mappings;
         this.boost = boost;
         this.maxItems = maxItems;
+        this.sourceExcludes = Collections.emptyList();
     }
 
     public boolean isConfigured() {
@@ -57,6 +61,10 @@ public class ESSettings {
         return boost;
     }
 
+    public List<String> sourceExcludes() {
+        return sourceExcludes;
+    }
+
     public int maxItems() {
         return maxItems;
     }
@@ -64,6 +72,11 @@ public class ESSettings {
     public Boost loadBoostSettings() {
         Map<?, ?> settings = toMap(Boost.class.getClassLoader().getResourceAsStream(BOOST_SETTINGS_FILE));
         return new Boost(settings);
+    }
+
+    private List<String> loadSourceExcludesSettings() {
+        Map<?, ?> settings = toMap(Boost.class.getClassLoader().getResourceAsStream(BOOST_SETTINGS_FILE));
+        return getAsStream(settings, "source_excludes").map(String.class::cast).toList();
     }
 
     public static Boost loadBoostSettings(String json) {
@@ -226,10 +239,6 @@ public class ESSettings {
             }
         }
 
-        private static Stream<?> getAsStream(Map<?, ?> m, String k) {
-            return getOrDefault(m, k, List.of()).stream();
-        }
-
         private static Map<String, Object> getAsMap(Map<?, ?> m, String k) {
             return getOrDefault(m, k, Map.of());
         }
@@ -237,11 +246,15 @@ public class ESSettings {
         private static float getAsFloat(Map<?, ?> m, String k) {
             return ((Number) m.get(k)).floatValue();
         }
+    }
 
-        @SuppressWarnings("unchecked")
-        private static <T> T getOrDefault(Map<?, ?> m, String k, T defaultTo) {
-            return m.containsKey(k) ? (T) m.get(k) : defaultTo;
-        }
+    private static Stream<?> getAsStream(Map<?, ?> m, String k) {
+        return getOrDefault(m, k, List.of()).stream();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getOrDefault(Map<?, ?> m, String k, T defaultTo) {
+        return m.containsKey(k) ? (T) m.get(k) : defaultTo;
     }
 
     private static Map<?, ?> toMap(Object json) {

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -143,6 +143,7 @@ public class Query {
         EsQueryTree esQueryTree = new EsQueryTree(expandedQueryTree, currentEsSettings, getSelectedFacets());
         var esQueryDsl = buildEsQueryDsl(esQueryTree.getMainQuery(), esQueryTree.getPostFilter());
         esQueryDsl.put("aggs", getEsAggQuery(getFullQueryTree().getRdfSubjectTypesList()));
+
         return new EsQuery(esQueryDsl, indexNames);
     }
 
@@ -266,6 +267,10 @@ public class Query {
             // Scores won't be calculated when also using sort unless explicitly asked for
             queryDsl.put("track_scores", true);
             queryDsl.put("fields", List.of("*"));
+        }
+
+        if (!esSettings.sourceExcludes().isEmpty()) {
+            queryDsl.put("_source", Map.of("excludes", esSettings.sourceExcludes()));
         }
 
         return queryDsl;


### PR DESCRIPTION
- Add settings for elastic _source.excludes
- Filter out unused Item props -> cuts search response size in ~half
    - Less JSON to parse and mangle in both BE+FE

TODO:
- filter internal fields here, e.g. _links, _str, _topStr
- rename+refactor libris_search_boost.json

### example
`_q=boll`

before:
<img width="936" height="369" alt="Skärmbild från 2026-04-14 15-52-20" src="https://github.com/user-attachments/assets/c1054af3-0231-482b-86aa-c91737908929" />

after:
<img width="939" height="558" alt="Skärmbild från 2026-04-14 18-16-07" src="https://github.com/user-attachments/assets/9d4054d9-6e2a-4d7f-8ea8-f7dbd0d8e31e" />
