### PR TITLE
fix(marcframe): ContributionByRoleStep missing required resources

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -163,6 +163,8 @@ class Whelk {
             elasticFind = new ElasticFind(new ESQuery(this))
         }
 
+        initDocumentNormalizers()
+
         sparqlUpdater = SparqlUpdater.build(storage, jsonld.context, configuration)
         sparqlQueryClient = new SparqlQueryClient(configuration.getProperty('sparqlEndpoint', null), jsonld);
     }
@@ -254,7 +256,6 @@ class Whelk {
     void setJsonld(JsonLd jsonld) {
         this.jsonld = jsonld
         storage.setJsonld(jsonld)
-        initDocumentNormalizers()
         this.fresnelUtil = new FresnelUtil(jsonld)
     }
 


### PR DESCRIPTION
ContributionByRoleStep missing required resources
https://github.com/libris/librisxl/blob/540e92146f1f450d8c8e941aa6161849137e15b5/whelk-core/src/main/groovy/whelk/converter/marc/ContributionByRoleStep.groovy#L42

relatorResources was not initialized because elasticFind wasn't yet initialized. Because elastic initialization was moved in cf91b2066

Guarded because when running only core whelk elastic+elasticFind are not available. 
https://github.com/libris/librisxl/blob/540e92146f1f450d8c8e941aa6161849137e15b5/whelk-core/src/main/groovy/whelk/ResourceCache.groovy#L34