### PR TITLE
fix(search): Boost for lang container props

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQuery.groovy
@@ -14,6 +14,7 @@ import whelk.util.Unicode
 import java.util.function.Function
 
 import static whelk.component.ElasticSearch.SystemFields.CHIP_STR
+import static whelk.component.ElasticSearch.SystemFields.FLATTENED_LANG_MAP_PREFIX
 import static whelk.component.ElasticSearch.SystemFields.LINKS
 import static whelk.component.ElasticSearch.SystemFields.SORT_KEY_BY_LANG
 import static whelk.component.ElasticSearch.flattenedLangMapKey
@@ -405,16 +406,13 @@ class ESQuery {
     }
 
     private static final List<String> CONCEPT_BOOST = [
-            'prefLabel^1500',
-            'prefLabelByLang.sv^1500',
-            'label^500',
-            'labelByLang.sv^500',
+            FLATTENED_LANG_MAP_PREFIX + 'prefLabel^1500',
+            FLATTENED_LANG_MAP_PREFIX + 'label^500',
             'code^200',
             'termComponentList._str.exact^125',
             'termComponentList._str^75',
-            'altLabel^150',
-            'altLabelByLang.sv^150',
-            'hasVariant.prefLabel.exact^150',
+            FLATTENED_LANG_MAP_PREFIX + 'altLabel^150',
+            'hasVariant.' + FLATTENED_LANG_MAP_PREFIX + 'prefLabel.exact^150',
             '_str.exact^100',
             'inScheme._str.exact^100',
             'inScheme._str^100',

--- a/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
+++ b/whelk-core/src/main/groovy/whelk/search/ESQueryLensBoost.groovy
@@ -3,6 +3,7 @@ package whelk.search
 import whelk.JsonLd
 
 import static whelk.JsonLd.asList
+import static whelk.component.ElasticSearch.SystemFields.FLATTENED_LANG_MAP_PREFIX
 
 /**
  * A utility to compute a list of boosted fields for ElasticSearch.
@@ -95,7 +96,7 @@ class ESQueryLensBoost {
             if (termType == 'ObjectProperty') {
                 key = "${key}.${JsonLd.SEARCH_KEY}"
             } else if (jsonld.isLangContainer(jsonld.context[it])) {
-                key = "${key}.${jsonld.locales[0]}"
+                key = FLATTENED_LANG_MAP_PREFIX + key
             } else {
                 // this property is part of the JsonLd.SEARCH_KEY value
                 // but keep it anyway
@@ -132,7 +133,7 @@ class ESQueryLensBoost {
                 key = "${key}.${JsonLd.SEARCH_KEY}"
             }
         } else if (jsonld.isLangContainer(jsonld.context[prop])) {
-            key = "${key}.${jsonld.locales[0]}"
+            key = FLATTENED_LANG_MAP_PREFIX + key
         }
 
         if (key in seenKeys) {


### PR DESCRIPTION
fooByLang is no longer indexed.
Boost on flattened __foo instead

broken by cc86a031c4517d89953aa765eac0f99cd5400795