### PR TITLE
Feature/classification search

### DIFF
--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -692,9 +692,6 @@ class ElasticSearch {
                 if (!flattened.isEmpty()) {
                     value.putAll(flattened)
                 }
-
-
-                (asList(value['classification']))
             }
 
             if (path && path.last() == 'classification') {

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -29,8 +29,10 @@ import static whelk.JsonLd.JSONLD_ALT_ID_KEY
 import static whelk.JsonLd.Platform.CATEGORY_BY_COLLECTION
 import static whelk.JsonLd.RECORD_KEY
 import static whelk.JsonLd.REVERSE_KEY
+import static whelk.JsonLd.SEARCH_KEY
 import static whelk.JsonLd.THING_KEY
 import static whelk.JsonLd.TYPE_KEY
+import static whelk.JsonLd.WORK_KEY
 import static whelk.JsonLd.asList
 import static whelk.component.ElasticSearch.SystemFields.CARD_STR
 import static whelk.component.ElasticSearch.SystemFields.CHIP_STR
@@ -690,6 +692,13 @@ class ElasticSearch {
                 if (!flattened.isEmpty()) {
                     value.putAll(flattened)
                 }
+
+
+                (asList(value['classification']))
+            }
+
+            if (path && path.last() == 'classification') {
+                addFlattenedClassificationFields(asList(value))
             }
 
             if ('Item' != searchCard[TYPE_KEY]
@@ -719,6 +728,30 @@ class ElasticSearch {
         }
 
         return mapper.writeValueAsString(searchCard)
+    }
+
+    private static void addFlattenedClassificationFields(List<Map> classification) {
+        classification.each { Map c ->
+            String type = c[TYPE_KEY]
+            String code = c['code']
+            if (!code || !type) return
+            String flattenedKey = switch (type) {
+                case "Classification" -> {
+                    String schemeCode = DocumentUtil.getAtPath(c, ['inScheme', 'code'], "")
+                    if (schemeCode.toLowerCase().contains('kssb')) {
+                        yield '_sab'
+                    }
+                }
+                case "ClassificationDdc" -> '_ddc'
+                case "ClassificationUdc" -> '_udc'
+                case "ClassificationLcc" -> '_lcc'
+                case "ClassificationNlm" -> '_nlm'
+                default -> ""
+            }
+            if (flattenedKey) {
+                c[flattenedKey] = code
+            }
+        }
     }
     
     @CompileStatic

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -99,7 +99,7 @@ public non-sealed class Property extends PathElement {
         if (isComposite(propDef)) {
             return new CompositeProperty(propertyKey, jsonLd, queryKey);
         }
-        if (isShorthand(propDef)) {
+        if (isShorthand(propDef) && !propDef.containsKey("ls:indexKey")) {
             return new ShorthandProperty(propertyKey, jsonLd, queryKey);
         }
         if (isCoercing(propDef)) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTreeBuilder.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTreeBuilder.java
@@ -247,7 +247,10 @@ public class QueryTreeBuilder {
             BIBN,
 
             /** "Sekundärt materialtypsindex. Kompletterande materialtyper på mer detaljerad nivå. Varje katalogpost kan ha 0, 1 eller flera sådana sekundära typer" */
-            MTAG
+            MTAG,
+
+            /** "Kod för trunkerad sökning på Deweyklassifikation" */
+            DDCT
         }
 
         static final List<String> CODES = Arrays.stream(LegacyCode.values()).map(LegacyCode::toString).toList();
@@ -326,6 +329,8 @@ public class QueryTreeBuilder {
                     case "free" -> "freeOnline"; // the only one seen in logs
                     default -> value;
                 };
+
+                case DDCT -> String.format("ddc:%s%s", value, Operator.WILDCARD);
             };
 
             return buildTree(mappedQuery, disambiguate);


### PR DESCRIPTION
Support using search filters defined in https://github.com/libris/definitions/pull/584

Also support legacy code `DDCT` ([c86022f](https://github.com/libris/librisxl/pull/1755/commits/c86022fa42c29f58625153cdf3ba50a93e1686bb)). 

**TODO**? Support "numeric only" queries for Dewey? For example `ddc:839738` instead of  `ddc:839.738`?