### PR TITLE
Feature/o search  predicates

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ObjectQuery.java
@@ -29,10 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static whelk.component.ElasticSearch.SystemFields.LINKS;
-import static whelk.search2.QueryParams.ApiParams.CUSTOM_SITE_FILTER;
-import static whelk.search2.QueryParams.ApiParams.OBJECT;
-import static whelk.search2.QueryParams.ApiParams.PREDICATES;
-import static whelk.search2.QueryParams.ApiParams.SORT;
+import static whelk.search2.QueryParams.ApiParams.QUERY;
 import static whelk.search2.QueryUtil.makeFindUrl;
 
 public class ObjectQuery extends Query {
@@ -104,26 +101,23 @@ public class ObjectQuery extends Query {
         Map<String, Integer> counts = getQueryResult().pAggs.stream()
                 .collect(Collectors.toMap(QueryResult.Bucket::value, QueryResult.Bucket::count));
 
-        curatedPredicates.stream()
-                .map(Property::name)
-                .forEach(p -> {
-                    if (!counts.containsKey(p)) {
-                        return;
-                    }
+        curatedPredicates.forEach(p -> {
+            if (!counts.containsKey(p.name())) {
+                return;
+            }
 
-                    int count = counts.get(p);
+            int count = counts.get(p.name());
 
-                    if (count > 0) {
-                        Map<String, String> params = queryParams.getCustomParamsMap(List.of(CUSTOM_SITE_FILTER, SORT, OBJECT));
-                        params.put(PREDICATES, p);
-                        result.add(Map.of(
-                                "totalItems", count,
-                                "view", Map.of(JsonLd.ID_KEY, makeFindUrl(params)),
-                                "object", whelk.getJsonld().vocabIndex.get(p),
-                                "_selected", queryParams.predicates.contains(p)
-                        ));
-                    }
-                });
+            if (count > 0) {
+                var q = new Condition(p, p.isPreferLike() ? Operator.LIKE : Operator.EQUALS, object).toQueryString(true);
+                result.add(Map.of(
+                        "totalItems", count,
+                        "view", Map.of(JsonLd.ID_KEY, makeFindUrl(Map.of(QUERY, q))),
+                        "predicate", whelk.getJsonld().vocabIndex.get(p.name()),
+                        "object", object.description()
+                ));
+            }
+        });
 
         return result;
     }
@@ -164,7 +158,8 @@ public class ObjectQuery extends Query {
         if (o != null) {
             Map<String, Object> thing = QueryUtil.loadThing(o, whelk);
             if (!thing.isEmpty()) {
-                return new Link(o, thing);
+                var chip = QueryUtil.castToStringObjectMap(whelk.jsonld.toChip(thing));
+                return new Link(o, chip);
             }
         }
         throw new InvalidQueryException("No resource with id " + o + " was found");

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Link.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Link.java
@@ -12,7 +12,6 @@ import static whelk.JsonLd.asList;
 
 public final class Link extends Resource {
     private final String iri;
-    private final Map<String, Object> thing = new LinkedHashMap<>();
     private final Map<String, Object> chip = new LinkedHashMap<>();
 
     private boolean mappedFromCode = false;
@@ -35,19 +34,14 @@ public final class Link extends Resource {
         this.mappedFromCode = mappedFromCode;
     }
 
-    public Link(String iri, Map<String, Object> thing) {
+    public Link(String iri, Map<String, Object> chip) {
         this.iri = iri;
-        setThing(thing);
+        setChip(chip);
     }
 
     public void setChip(Map<String, Object> chip) {
         this.chip.clear();
         this.chip.putAll(chip);
-    }
-
-    public void setThing(Map<String, Object> thing) {
-        this.chip.clear();
-        this.thing.putAll(thing);
     }
 
     public void setSearchNeedle(String needle) {
@@ -60,10 +54,6 @@ public final class Link extends Resource {
 
     public String iri() {
         return iri;
-    }
-
-    public Map<String, Object> thing() {
-        return thing;
     }
 
     public Token token() {
@@ -110,6 +100,6 @@ public final class Link extends Resource {
 
     @Override
     public String getType() {
-        return (String) asList(thing.get(TYPE_KEY)).getFirst();
+        return (String) asList(chip.get(TYPE_KEY)).getFirst();
     }
 }


### PR DESCRIPTION
Provide observations in `stats._predicates` in a more complete and intuitive format:

```
{
  "predicate": "<PREDICATE_DEFINITION>",
  "object": "<OBJECT_DESCRIPTION>",
  "view": { "@id": "/find?_q=p:o" },
  "totalItems": 100
}
```

Before, the `object` key confusingly held the predicate definition. This change puts the predicate definition under `predicate` and the actual object description under `object`. It also includes a ready-to-use `p:o` query in the `view` URL.

By moving query construction (`_q=p:o`) to the backend we prevent inconsistent query formatting which caused a recent bug, see https://github.com/libris/lxlviewer/pull/1576.