### PR TITLE
fix: bulkLoad missing non-fnurgel links starting with BASE_URI

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -926,7 +926,7 @@ class Document {
         def work = get(["@graph", 1, "instanceOf"])
         return (!work || work !instanceof Map || JsonLd.isLink(work) || isSuppressedRecord())
             ? []
-            : [ "${getShortId()}#work-record" ]
+            : [ "${getShortId()}#work-record".toString() ]
     }
 
     // All these "virtual record" methods are hardcoded for blank Works

--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -26,6 +26,7 @@ import whelk.util.DocumentUtil
 import whelk.util.FresnelUtil
 import whelk.util.PropertyLoader
 import whelk.util.Romanizer
+import whelk.util.Unicode
 
 import java.time.Instant
 import java.time.ZoneId
@@ -292,7 +293,7 @@ class Whelk {
         def otherIris = []
         List<String> systemIds = []
         ids.each { id ->
-            if (id.startsWith(Document.BASE_URI.toString())) {
+            if (id.startsWith(Document.BASE_URI.toString()) && !Unicode.stripPrefix(id, Document.BASE_URI.toString()).contains("/")) {
                 def systemId = Document.BASE_URI.resolve(id).getPath().substring(1)
                 idMap[systemId] = id
                 systemIds << systemId


### PR DESCRIPTION
Which caused Embellisher -> fetchNonVisited() -> load() -> getDocs() to miss e.g.
- https://libris.kb.se/library/...
- https://libris.kb.se/dataset/images/...

toString() in Document::getVirtualRecordIds() because GString fails in java->groovy bridging in RefreshApi.java