### PR TITLE
Bugfix/instance modified created

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -185,10 +185,6 @@
             },
             "meta": {
                 "properties": {
-                    "encodingLevel": {
-                      "type": "keyword",
-                      "copy_to": "_all"
-                    },
                     "recordStatus": {
                       "type": "keyword",
                       "copy_to": "_all"
@@ -350,6 +346,15 @@
             {
                 "issuanceType_template": {
                     "match": ["issuanceType"],
+                    "mapping": {
+                        "type": "keyword",
+                        "copy_to": "_all"
+                    }
+                }
+            },
+            {
+                "encodingLevel_template": {
+                    "match": ["encodingLevel"],
                     "mapping": {
                         "type": "keyword",
                         "copy_to": "_all"

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -15,8 +15,10 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Predicate
 
+import static whelk.JsonLd.CREATED_KEY
 import static whelk.JsonLd.GRAPH_KEY
 import static whelk.JsonLd.ID_KEY
+import static whelk.JsonLd.MODIFIED_KEY
 import static whelk.JsonLd.RECORD_KEY
 import static whelk.JsonLd.REVERSE_KEY
 import static whelk.JsonLd.THING_KEY
@@ -985,15 +987,19 @@ class Document {
         instance[RECORD_KEY] = record + [(ID_KEY): instanceRecordId]
 
         Map workRecord = [
-                (ID_KEY)   : workRecordId,
+                (ID_KEY)      : workRecordId,
                 // TODO
                 // For now these will not be found by the search API since it has a boost on RECORD_TYPE and CACHE_RECORD_TYPE
                 // This is what we want since VirtualRecords should not be visible in the cataloguing interface.
                 // When we have unified the new "query language" search API with the current search API we need a different mechanism
                 // for separating them
-                (TYPE_KEY) : JsonLd.VIRTUAL_RECORD_TYPE,
-                (THING_KEY): [(ID_KEY): workId]
+                (TYPE_KEY)    : JsonLd.VIRTUAL_RECORD_TYPE,
+                (THING_KEY)   : [(ID_KEY): workId],
+                // Keep original timestamps for consistent sorting behavior
+                (CREATED_KEY) : record[CREATED_KEY],
+                (MODIFIED_KEY): record[MODIFIED_KEY]
         ]
+        workRecord.putAll((Map) record.subMap([CREATED_KEY, MODIFIED_KEY]))
         
         def work = instance.remove(WORK_KEY) as Map
         work[ID_KEY] = workId

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -15,7 +15,13 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Predicate
 
+import static whelk.JsonLd.GRAPH_KEY
+import static whelk.JsonLd.ID_KEY
+import static whelk.JsonLd.RECORD_KEY
+import static whelk.JsonLd.REVERSE_KEY
+import static whelk.JsonLd.THING_KEY
 import static whelk.JsonLd.TYPE_KEY
+import static whelk.JsonLd.WORK_KEY
 import static whelk.JsonLd.asList
 import static whelk.util.Jackson.mapper
 
@@ -969,30 +975,38 @@ class Document {
             throw new IllegalStateException()
         }
 
-        Map record = get(["@graph", 0]) as Map
-        Map work = get(["@graph", 1, "instanceOf"]) as Map
-        Map instance = get(["@graph", 1]) as Map
-        def workId = (instance["@id"] as String).replace('#it', '') + "#work"
+        Map record = get(recordPath) as Map
+        Map instance = get(thingPath) as Map
+
+        def workId = (instance[ID_KEY] as String).replace(HASH_IT, '') + "#work"
+        def workRecordId = record[ID_KEY] as String
+        def instanceRecordId = workRecordId.replace('#work-record', '')
+
+        instance[RECORD_KEY] = record + [(ID_KEY): instanceRecordId]
+
+        Map workRecord = [
+                (ID_KEY)   : workRecordId,
+                // TODO
+                // For now these will not be found by the search API since it has a boost on RECORD_TYPE and CACHE_RECORD_TYPE
+                // This is what we want since VirtualRecords should not be visible in the cataloguing interface.
+                // When we have unified the new "query language" search API with the current search API we need a different mechanism
+                // for separating them
+                (TYPE_KEY) : JsonLd.VIRTUAL_RECORD_TYPE,
+                (THING_KEY): [(ID_KEY): workId]
+        ]
         
-        record["mainEntity"]["@id"] = workId
-        // TODO
-        // For now these will not be found by the search API since it has a boost on RECORD_TYPE and CACHE_RECORD_TYPE
-        // This is what we want since VirtualRecords should not be visible in the cataloguing interface.
-        // When we have unified the new "query language" search API with the current search API we need a different mechanism
-        // for separating them
-        record["@type"] = JsonLd.VIRTUAL_RECORD_TYPE
-        
-        instance.remove('instanceOf')
-        
-        work["@id"] = workId
-        work["@reverse"] = ["instanceOf": [instance]]
+        def work = instance.remove(WORK_KEY) as Map
+        work[ID_KEY] = workId
+        work[REVERSE_KEY] = [(WORK_KEY): [instance]]
 
         // TODO...
         if (!work['hasTitle']) {
             work['hasTitle'] = JsonLd.asList(instance['hasTitle']).findAll{ it['@type'] == 'Title' || it['@type'] == 'KeyTitle' }
         }
 
-        set(["@graph", 1], work)
+        def graph = data[GRAPH_KEY] as List
+        graph[0] = workRecord
+        graph[1] = work
     }
 
     private boolean isSuppressedRecord() {

--- a/whelk-core/src/main/groovy/whelk/Document.groovy
+++ b/whelk-core/src/main/groovy/whelk/Document.groovy
@@ -999,7 +999,6 @@ class Document {
                 (CREATED_KEY) : record[CREATED_KEY],
                 (MODIFIED_KEY): record[MODIFIED_KEY]
         ]
-        workRecord.putAll((Map) record.subMap([CREATED_KEY, MODIFIED_KEY]))
         
         def work = instance.remove(WORK_KEY) as Map
         work[ID_KEY] = workId

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -550,6 +550,10 @@ class ElasticSearch {
             log.debug("Framing ${document.getShortId()}")
         }
 
+        if (copy.isVirtual()) {
+            copy.centerOnVirtualMainEntity()
+        }
+
         Set<String> links = whelk.jsonld.expandLinks(document.getExternalRefs()).collect{ it.iri } as Set<String>
 
         var embellishedGraph = ((List) copy.data[GRAPH_KEY])
@@ -598,10 +602,6 @@ class ElasticSearch {
         copy.data[GRAPH_KEY] = shapedMainGraph + shapedEmbellished
 
         setIdentifiers(copy)
-        boolean isVirtualWork = copy.isVirtual()
-        if (isVirtualWork) {
-            copy.centerOnVirtualMainEntity()
-        }
         copy.setThingMeta(document.getCompleteId())
         List<String> thingIds = copy.getThingIdentifiers()
         if (thingIds.isEmpty()) {
@@ -672,7 +672,7 @@ class ElasticSearch {
                     log.warn("Couldn't create search key for node with type {} in document {}", value.get(TYPE_KEY), document.shortId);
                 }
 
-                lensedMainGraph.restoreLinks(value, isVirtualWork)
+                lensedMainGraph.restoreLinks(value)
 
                 // { "foo": "FOO", "fooByLang": { "en": "EN", "sv": "SV" } }
                 // -->

--- a/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/ElasticSearch.groovy
@@ -556,8 +556,9 @@ class ElasticSearch {
 
         Set<String> links = whelk.jsonld.expandLinks(document.getExternalRefs()).collect{ it.iri } as Set<String>
 
+        var originalGraph = ((List) document.data[GRAPH_KEY])
         var embellishedGraph = ((List) copy.data[GRAPH_KEY])
-        var originalGraphSize = ((List) document.data[GRAPH_KEY]).size()
+        var originalGraphSize = originalGraph.size()
 
         Set<String> categoryLinks = [] as Set
         if (whelk.features.isEnabled(EXPERIMENTAL_CATEGORY_COLLECTION)) {
@@ -647,7 +648,7 @@ class ElasticSearch {
             log.error("Couldn't create search fields for {}: {}", document.shortId, e, e)
         }
 
-        searchCard[IDS] = collectIds(embellishedGraph, integralIds)
+        searchCard[IDS] = collectRecordIds(originalGraph, embellishedGraph, integralIds)
 
         DocumentUtil.traverse(searchCard) { value, path ->
             if (path && SEARCH_STRINGS.contains(path.last())) {
@@ -754,8 +755,8 @@ class ElasticSearch {
         return FLATTENED_LANG_MAP_PREFIX + key
     }
 
-    private static Set<String> collectIds(List embellishedGraph, Collection<String> integralIds) {
-        var records = embellishedGraph.take(1) + embellishedGraph.findAll { ((String) DocumentUtil.getAtPath(it, Document.thingIdPath2)) in integralIds }
+    private static Set<String> collectRecordIds(List originalGraph, List embellishedGraph, Collection<String> integralIds) {
+        var records = originalGraph.take(1) + embellishedGraph.findAll { ((String) DocumentUtil.getAtPath(it, Document.thingIdPath2)) in integralIds }
                 .collect { DocumentUtil.getAtPath(it, Document.recordPath) }
 
         Set ids = [] as Set

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -68,8 +68,11 @@ public final class Path implements Selector {
     public Selector withPrependedMetaProperty(JsonLd jsonLd) {
         List<PathElement> newPath = new ArrayList<>();
         for (PathElement pe : path()) {
-            if (pe.appearsOnlyOnRecord(jsonLd) && (newPath.isEmpty() || !(newPath.getLast() instanceof Property.Meta))) {
-                newPath.add(new Property.Meta(jsonLd));
+            if (pe.appearsOnlyOnRecord(jsonLd)) {
+                boolean isPrecededByMeta = !newPath.isEmpty() && newPath.getLast() instanceof Property p && p.isMeta();
+                if (!isPrecededByMeta) {
+                    newPath.add(new Property.Meta(jsonLd));
+                }
             }
             newPath.add(pe);
         }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -219,6 +219,10 @@ public non-sealed class Property extends PathElement {
         return RDF_TYPE.equals(name);
     }
 
+    public boolean isMeta() {
+        return false;
+    }
+
     public boolean isVocabTerm() {
         return isVocabTerm;
     }
@@ -493,6 +497,11 @@ public non-sealed class Property extends PathElement {
         public Meta(JsonLd jsonLd, Key.RecognizedKey key) {
             super(RECORD_KEY, jsonLd, key);
         }
+
+        @Override
+        public boolean isMeta() {
+            return true;
+        }
     }
 
     public static final class CoercingSubProperty extends Property {
@@ -580,6 +589,11 @@ public non-sealed class Property extends PathElement {
                     :value ) .
             */
             return Property.buildObjectRestrictions(definition, jsonLd, true);
+        }
+
+        @Override
+        public boolean isMeta() {
+            return superProperty instanceof Meta;
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
+++ b/whelk-core/src/main/groovy/whelk/util/FresnelUtil.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import static whelk.JsonLd.ID_KEY;
 import static whelk.JsonLd.JSONLD_ALT_ID_KEY;
+import static whelk.JsonLd.RECORD_TYPE;
 import static whelk.JsonLd.REVERSE_KEY;
 import static whelk.JsonLd.THING_KEY;
 import static whelk.JsonLd.TYPE_KEY;
@@ -266,20 +267,9 @@ public class FresnelUtil {
             return lensedThings;
         }
 
-        public void restoreLinks(Map<String, Object> thing, boolean isVirtualRecord) {
-            var id = (String) thing.get(ID_KEY);
-            if (id != null && !JsonLd.isLink(thing)) {
-                if (id.endsWith("#work") && isVirtualRecord) {
-                    // FIXME
-                    preservedLinksMap.getOrDefault(id.replace("#work", "#it"), List.of())
-                            .stream()
-                            .map(lr -> !lr.path().isEmpty() && WORK_KEY.equals(lr.path().getFirst())
-                                    ? new LinkRestoration(lr.path().subList(1, lr.path().size()), lr.key(), lr.links())
-                                    : lr)
-                            .forEach(lr -> lr.restoreTo(thing));
-                } else {
-                    preservedLinksMap.getOrDefault(id, List.of()).forEach(lr -> lr.restoreTo(thing));
-                }
+        public void restoreLinks(Map<String, Object> thing) {
+            if (thing.get(ID_KEY) instanceof String id && !JsonLd.isLink(thing)) {
+                preservedLinksMap.getOrDefault(id, List.of()).forEach(lr -> lr.restoreTo(thing));
             }
         }
     }

--- a/whelk-core/src/test/groovy/DocumentSpec.groovy
+++ b/whelk-core/src/test/groovy/DocumentSpec.groovy
@@ -418,7 +418,9 @@ class DocumentSpec extends Specification {
                                    "mainEntity": [
                                            "@id": "/id#it"
                                    ],
-                                   "prop": "x"
+                                   "prop": "x",
+                                   "created": "2026-05-25T10:59:03.035+02:00",
+                                   "modified": "2026-05-25T10:59:03.035+02:00",
                            ], [
                                    "@id"       : "/id#it",
                                    "@type"     : "Instance",
@@ -440,7 +442,9 @@ class DocumentSpec extends Specification {
                                    "@type"     : "VirtualRecord",
                                    "mainEntity": [
                                            "@id": "/id#work"
-                                   ]
+                                   ],
+                                   "created": "2026-05-25T10:59:03.035+02:00",
+                                   "modified": "2026-05-25T10:59:03.035+02:00",
                            ], [
                                    "@type"   : "Work",
                                    "@id"     : "/id#work",
@@ -458,7 +462,9 @@ class DocumentSpec extends Specification {
                                                                           "mainEntity": [
                                                                                   "@id": "/id#it"
                                                                           ],
-                                                                          "prop"      : "x"
+                                                                          "prop"      : "x",
+                                                                          "created": "2026-05-25T10:59:03.035+02:00",
+                                                                          "modified": "2026-05-25T10:59:03.035+02:00",
                                                                   ]
                                                           ]]
                                    ],

--- a/whelk-core/src/test/groovy/DocumentSpec.groovy
+++ b/whelk-core/src/test/groovy/DocumentSpec.groovy
@@ -409,6 +409,67 @@ class DocumentSpec extends Specification {
         set1.getChecksum(jsonld) != set2.getChecksum(jsonld)
     }
 
+    def "flip work/instance in virtual work graph"() {
+        given:
+        def virtualWorkRecord = new Document([
+                "@graph": [[
+                                   "@id"       : "/id#work-record",
+                                   "@type"     : "Record",
+                                   "mainEntity": [
+                                           "@id": "/id#it"
+                                   ],
+                                   "prop": "x"
+                           ], [
+                                   "@id"       : "/id#it",
+                                   "@type"     : "Instance",
+                                   "hasTitle"     : [[
+                                                             "@type": "Title",
+                                                             "mainTitle": "title"
+                                                     ]],
+                                   "instanceOf": [
+                                           "@type": "Work"
+                                   ]
+                           ]]
+        ])
+        virtualWorkRecord.centerOnVirtualMainEntity()
+
+        expect:
+        virtualWorkRecord.data == [
+                "@graph": [[
+                                   "@id"       : "/id#work-record",
+                                   "@type"     : "VirtualRecord",
+                                   "mainEntity": [
+                                           "@id": "/id#work"
+                                   ]
+                           ], [
+                                   "@type"   : "Work",
+                                   "@id"     : "/id#work",
+                                   "@reverse": [
+                                           "instanceOf": [[
+                                                                  "@id"     : "/id#it",
+                                                                  "@type"   : "Instance",
+                                                                  "hasTitle": [[
+                                                                                       "@type"    : "Title",
+                                                                                       "mainTitle": "title"
+                                                                               ]],
+                                                                  "meta"    : [
+                                                                          "@id"       : "/id",
+                                                                          "@type"     : "Record",
+                                                                          "mainEntity": [
+                                                                                  "@id": "/id#it"
+                                                                          ],
+                                                                          "prop"      : "x"
+                                                                  ]
+                                                          ]]
+                                   ],
+                                   "hasTitle": [[
+                                                        "@type"    : "Title",
+                                                        "mainTitle": "title"
+                                                ]]
+                           ]]
+        ]
+    }
+
     static String readFile(String filename) {
         return DocumentSpec.class.getClassLoader()
                 .getResourceAsStream(filename).getText("UTF-8")

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -107,6 +107,9 @@ class ConditionSpec extends Specification {
         "bibliography:x"    | ["T1"]       | "instanceOf.meta.bibliography:x OR meta.bibliography:x"
         "bibliography:x"    | ["T2"]       | "hasInstance.meta.bibliography:x OR meta.bibliography:x"
         "bibliography:x"    | ["T3"]       | "meta.bibliography:x"
+        "t1MetaP1:x"        | ["T1"]       | "meta.p1:x"
+        "t1MetaP1:x"        | ["T2"]       | "hasInstance.meta.p1:x"
+        "t1MetaP1:x"        | ["T3"]       | "meta.p1:x"
     }
 
     def "To ES exists query"() {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -46,7 +46,8 @@ class TestData {
                 'nonecategory'    : ['librissearch:noneCategory'] as Set,
                 'p3p1'            : ['p3p1'] as Set,
                 'bibliography'    : ['bibliography'] as Set,
-                'meta'            : ['meta'] as Set
+                'meta'            : ['meta'] as Set,
+                't1metap1'        : ['t1MetaP1'] as Set
         ]
         def classMappings = [
                 't1' : ['T1'] as Set,
@@ -283,6 +284,19 @@ class TestData {
                         ]]]
                 ],
                 ['@id': 'bibliography', '@type': 'ObjectProperty', 'domain': ['@id': 'https://id.kb.se/vocab/AdminMetadata']],
+                [
+                        '@id'               : 't1MetaP1',
+                        '@type'             : 'DatatypeProperty',
+                        'category'          : ['@id': "https://id.kb.se/vocab/shorthand"],
+                        'domain'            : ['@id': 'T1'],
+                        'propertyChainAxiom': [['@list': [
+                                [
+                                        'domain'       : [['@id': 'T1']],
+                                        'subPropertyOf': [['@id': 'meta']]
+                                ],
+                                ['@id': 'p1']
+                        ]]]
+                ]
         ]]
         def ctx = [
                 '@context': [

--- a/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/FresnelUtilSpec.groovy
@@ -1317,7 +1317,7 @@ class FresnelUtilSpec extends Specification {
         var fresnel = new FresnelUtil(ld)
         var searchCardBatch = fresnel.mapBatchThroughLens([thing], FresnelUtil.Lenses.SEARCH_CARD, [FresnelUtil.Options.TAKE_ALL_ALTERNATE], ['https://id.kb.se/x'])
         var searchCard = searchCardBatch.lensedThings().first()
-        searchCardBatch.restoreLinks(searchCard, false)
+        searchCardBatch.restoreLinks(searchCard)
 
         expect:
         searchCard == [


### PR DESCRIPTION
This complements https://github.com/libris/definitions/pull/596 to fix instance created/modified queries and improves consistency in handling of record properties in queries.

- d9a63be: Fixes repeated `meta.meta` segment in expanded query paths introduced by the definitions change. However, I'm leaning towards removing the special handling of record properties entirely, see comment in https://github.com/libris/definitions/pull/596.
- 04930f7: After the definition change, e.g. `instanceRecordCreated` now correctly expands to `@reverse.instanceOf.meta.created` when querying works. However, in virtual work records the original record data was embedded directly on the virtual work entity (`meta`) rather than on the embedded instance (`@reverse.instanceOf.meta`). Thus only linked works were matched by these queries. This commit aligns the shape of virtual work records with linked work records, with the only difference that `meta` for virtual works will always have this minimal shape:
```
{
    "@id" : "http://libris.kb.se/xxxxxxxxxxxxxxx#work-record",
    "@type" : "VirtualRecord",
    "mainEntity" : {
      "@id" : "http://libris.kb.se/xxxxxxxxxxxxxxx#work"
    }
}
```
Although this solution should work well, I also experimented with an alternative shape that's even more like the linked work graphs: https://github.com/libris/librisxl/commit/d382f3b1ef0da0f9f44066909bd17e60cf39a6e3
Not sure which option is better.
- 1f211cb: The previous commit caused some links to be restored in the wrong place after shrinking to search card. The simple solution to this was do the work/instance flip earlier in `getShapeForIndex()`, which also made it possible to remove some awkward ad hoc logic: 1d9af2c
- c2d44c4: Ensures `@reverse.instanceOf.encodingLevel` is indexed as keyword in ES. This issue was discovered through a failing test: https://github.com/libris/lxl_api_tests/blob/1f20a14dd2d780ea19c1c7e19d64e1388ec03d6a/tests/test_restapi_2.py#L56. All tests now pass locally.

See new related API tests: https://github.com/libris/lxl_api_tests/pull/49