### PR TITLE
feat: add index to speed up reindexFrom

### DIFF
--- a/librisxl-tools/postgresql/migrations/00000025-index-greatest-modified-generationDate-lddb.plsql
+++ b/librisxl-tools/postgresql/migrations/00000025-index-greatest-modified-generationDate-lddb.plsql
@@ -1,0 +1,30 @@
+BEGIN;
+
+DO $$DECLARE
+   -- THESE MUST BE CHANGED WHEN YOU COPY THE SCRIPT!
+
+   -- The version you expect the database to have _before_ the migration
+   old_version numeric := 24;
+   -- The version the database should have _after_ the migration
+   new_version numeric := 25;
+
+   -- hands off
+   existing_version numeric;
+
+BEGIN
+
+   -- Check existing version
+   SELECT version from lddb__schema INTO existing_version;
+   IF ( existing_version <> old_version) THEN
+      RAISE EXCEPTION 'ASKED TO MIGRATE FROM INCORRECT EXISTING VERSION!';
+      ROLLBACK;
+   END IF;
+   UPDATE lddb__schema SET version = new_version;
+
+   -- ACTUAL SCHEMA CHANGES HERE:
+
+   CREATE INDEX IF NOT EXISTS idx_lddb_greatest_modified ON lddb (GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')));
+
+END$$;
+
+COMMIT;

--- a/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/PostgreSQLComponent.groovy
@@ -205,15 +205,15 @@ class PostgreSQLComponent {
     private static final String LOAD_ALL_DOCUMENTS = """
             SELECT id, data, created, modified, deleted 
             FROM lddb 
-            WHERE GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) >= ? 
-              AND GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) <= ?
+            WHERE GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) >= ?
+              AND GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) <= ?
             """.stripIndent()
 
     private static final String LOAD_ALL_DOCUMENTS_BY_COLLECTION = """
             SELECT id, data, created, modified, deleted
             FROM lddb 
-            WHERE GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) >= ? 
-              AND GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) <= ? 
+            WHERE GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) >= ?
+              AND GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) <= ?
               AND collection = ? 
               AND deleted = false
             """.stripIndent()
@@ -434,8 +434,8 @@ class PostgreSQLComponent {
     private static final String LOAD_ALL_DOCUMENTS_BY_DATASET = """
             SELECT id, data, created, modified, deleted
             FROM lddb
-            WHERE GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) >= ?
-            AND GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) <= ?
+            WHERE GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) >= ?
+            AND GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) <= ?
             AND data#>'{@graph,0,inDataset}' @> ?::jsonb
             AND deleted = false
             """.stripIndent()


### PR DESCRIPTION
Currently `reindexFrom` at the end of each reindex takes about 20 minutes or so, even when there's almost nothing to reindex, because of very slow SQL queries. So let's add an index to make them not slow. tl;dr: 100x speedup, 520 rows scanned instead of 20 million (on a QA example query).

For each collection we do a query like this:
```
SELECT id, data, created, modified, deleted
      FROM lddb
      WHERE GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) >= '2026-05-25 11:57:51+02'
        AND GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) <= 'infinity'
        AND collection = 'bib'
        AND deleted = false;
```

Previously on QA:
```
EXPLAIN ANALYZE SELECT id, data, created, modified, deleted
      FROM lddb
      WHERE GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) >= '2026-05-25 11:57:51+02'
        AND GREATEST(modified, (data#>>'{@graph,0,generationDate}')::timestamptz) <= 'infinity'
        AND collection = 'bib'
        AND deleted = false;
   Gather  (cost=221799.77..27499839.54 rows=47163 width=1229) (actual time=7681.396..262575.392 rows=244 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Bitmap Heap Scan on lddb  (cost=220799.77..27494123.24 rows=19651 width=1229) (actual time=7660.604..262056.823 rows=81 loops=3)
         Recheck Cond: (collection = 'bib'::text)
         Filter: ((NOT deleted) AND (GREATEST(modified, ((data #>> '{@graph,0,generationDate}'::text[]))::timestamp with time zone) >= '2026-05-25 11:57:51+02'::timestamp with time zone) AND (GREATEST(modified, ((data #>> '{@graph,0,generationDate}'::text[]))::timestamp with time zone) <= 'infinity'::timestamp with time zone))
         Rows Removed by Filter: 6686232
         Heap Blocks: exact=2832009
         ->  Bitmap Index Scan on idx_lddb_collection  (cost=0.00..220787.98 rows=19408455 width=0) (actual time=3103.190..3103.191 rows=20079895 loops=1)
               Index Cond: (collection = 'bib'::text)
 Planning Time: 0.162 ms
 Execution Time: 262576.044 ms
```

QA with the new index (note: it's no longer there, I added it temporarily for testing):
```
EXPLAIN ANALYZE SELECT id, data, created, modified, deleted
      FROM lddb
      WHERE GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) >= '2026-05-25 11:57:51+02'
        AND GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}')) <= 'infinity'
        AND collection = 'bib'
        AND deleted = false;

 Bitmap Heap Scan on lddb  (cost=241772.62..677457.22 rows=48754 width=1229) (actual time=2557.584..2599.301 rows=244 loops=1)
   Recheck Cond: ((GREATEST(modified, totstz((data #>> '{@graph,0,generationDate}'::text[]))) >= '2026-05-25 11:57:51+02'::timestamp with time zone) AND (GREATEST(modified, totstz((data #>> '{@graph,0,generationDate}'::text[]))) <= 'infinity'::timestamp with time zone) AND (collection = 'bib'::text))
   Filter: (NOT deleted)
   Heap Blocks: exact=154
   ->  BitmapAnd  (cost=241772.62..241772.62 rows=100318 width=0) (actual time=2556.991..2556.993 rows=0 loops=1)
         ->  Bitmap Index Scan on idx__lddb_greatest_modified  (cost=0.00..16047.11 rows=774254 width=0) (actual time=0.104..0.104 rows=520 loops=1)
               Index Cond: ((GREATEST(modified, totstz((data #>> '{@graph,0,generationDate}'::text[]))) >= '2026-05-25 11:57:51+02'::timestamp with time zone) AND (GREATEST(modified, totstz((data #>> '{@graph,0,generationDate}'::text[]))) <= 'infinity'::timestamp with time zone))
         ->  Bitmap Index Scan on idx_lddb_collection  (cost=0.00..225700.89 rows=20063509 width=0) (actual time=2531.675..2531.675 rows=20079895 loops=1)
               Index Cond: (collection = 'bib'::text)
 Planning Time: 1.323 ms
 Execution Time: 2599.357 ms
```

Note that I also changed from `::timestamptz` to our `totstz()` function because it's not possible to create an index with `::timestamptz` as it's not marked IMMUTABLE (unlike `totstz()`).