### PR TITLE
Feature/search2 various

### DIFF
--- a/librisxl-tools/elasticsearch/libris_config.json
+++ b/librisxl-tools/elasticsearch/libris_config.json
@@ -394,7 +394,15 @@
             },
             {
                 "contribution_template": {
-                    "path_match": ["contribution", "instanceOf.contribution", "@reverse.instanceOf.contribution"],
+                    "path_match": [
+                        "contribution",
+                        "instanceOf.contribution",
+                        "@reverse.instanceOf.contribution",
+                        "hasPart.contribution",
+                        "instanceOf.hasPart.contribution",
+                        "relationship.entity.contribution",
+                        "instanceOf.relationship.entity.contribution"
+                    ],
                     "mapping": {
                         "type": "nested",
                         "include_in_parent": true

--- a/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Disambiguate.java
@@ -160,7 +160,7 @@ public class Disambiguate {
     }
 
     private Property getProperty(String propertyKey, Token token) {
-        return Property.buildProperty(propertyKey, jsonLd, new Key.RecognizedKey(token));
+        return Property.getProperty(propertyKey, jsonLd, new Key.RecognizedKey(token));
     }
 
     private Optional<Value> mapValueForProperty(Property property, String value, Token token) {

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -462,7 +462,7 @@ public class Query {
             return;
         }
 
-        if (property.isRestrictedSubProperty() && !property.hasIndexKey()) {
+        if (property instanceof Property.RestrictedSubProperty && !property.hasIndexKey()) {
             // TODO: E.g. author (combining contribution.role and contribution.agent)
             throw new RuntimeException("Can't handle combined fields in aggs query");
         }

--- a/whelk-core/src/main/groovy/whelk/search2/Query.java
+++ b/whelk-core/src/main/groovy/whelk/search2/Query.java
@@ -467,49 +467,47 @@ public class Query {
             throw new RuntimeException("Can't handle combined fields in aggs query");
         }
 
-        property.getAltSelectors(ctx.jsonLd, ctx.rdfSubjectTypes, false).stream()
-                .map(s -> s.withPrependedMetaProperty(ctx.jsonLd))
-                .forEach(selector -> {
-                    String field = selector.esField();
-                    if (ctx.esSettings.mappings().hasFourDigitsKeywordField(field)) {
-                        field = String.format("%s%s", field, FOUR_DIGITS_KEYWORD_SUFFIX);
-                    } else if (ctx.esSettings.mappings().hasKeywordSubfield(field)) {
-                        field = String.format("%s.%s", field, KEYWORD);
-                    } else if (property.isObjectProperty() && !property.isVocabTerm() && !property.isType()) {
-                        field = String.format("%s.%s", field, JsonLd.ID_KEY);
-                    }
-                    if (!ctx.esSettings.mappings().isAggregatable(field)) {
-                        return;
-                    }
-                    Optional<String> nestedStem = selector.getEsNestedStem(ctx.esSettings.mappings());
-                    Map<String, Object> aggs = nestedStem.isPresent()
-                            ? buildNestedAggQuery(field, slice, nestedStem.get(), ctx)
-                            : buildCoreAqqQuery(field, slice, ctx);
-                    Map<String, List<Condition>> mSelected = ctx.selectedFacets.isMultiOrRadio(pKey)
-                            ? with(new HashMap<>(ctx.mmSelected), m -> {
-                        m.remove(pKey);
-                        // FIXME
-                        if (slice.parentSlice() != null) {
-                            m.remove(slice.parentSlice().propertyKey());
-                        }
-                        if (slice.subSlice() != null) {
-                            m.remove(slice.subSlice().propertyKey());
-                        }
-                        // TODO don't hardcode this if we decide it is what we want
-                        if (FIND_CATEGORY.equals(pKey) || IDENTIFY_CATEGORY.equals(pKey)) {
-                            m.remove(NONE_CATEGORY);
-                        }
-                        //if ("_categoryByCollection.@none".equals(pKey)) {
-                        //    m.remove("_categoryByCollection.find");
-                        //    m.remove("_categoryByCollection.identify");
-                        //}
-                    })
-                            : ctx.mmSelected;
-                    Map<String, Object> filter = SelectedFacets.buildMultiSelectedTree(mSelected.values())
-                            .expand(ctx.jsonLd, ctx.rdfSubjectTypes)
-                            .toEs(ctx.esSettings);
-                    query.put(field, filterWrap(aggs, property.name(), filter));
-                });
+        property.getAltSelectors(ctx.jsonLd, ctx.rdfSubjectTypes, false).forEach(selector -> {
+            String field = selector.esField();
+            if (ctx.esSettings.mappings().hasFourDigitsKeywordField(field)) {
+                field = String.format("%s%s", field, FOUR_DIGITS_KEYWORD_SUFFIX);
+            } else if (ctx.esSettings.mappings().hasKeywordSubfield(field)) {
+                field = String.format("%s.%s", field, KEYWORD);
+            } else if (property.isObjectProperty() && !property.isVocabTerm() && !property.isType()) {
+                field = String.format("%s.%s", field, JsonLd.ID_KEY);
+            }
+            if (!ctx.esSettings.mappings().isAggregatable(field)) {
+                return;
+            }
+            Optional<String> nestedStem = selector.getEsNestedStem(ctx.esSettings.mappings());
+            Map<String, Object> aggs = nestedStem.isPresent()
+                    ? buildNestedAggQuery(field, slice, nestedStem.get(), ctx)
+                    : buildCoreAqqQuery(field, slice, ctx);
+            Map<String, List<Condition>> mSelected = ctx.selectedFacets.isMultiOrRadio(pKey)
+                    ? with(new HashMap<>(ctx.mmSelected), m -> {
+                m.remove(pKey);
+                // FIXME
+                if (slice.parentSlice() != null) {
+                    m.remove(slice.parentSlice().propertyKey());
+                }
+                if (slice.subSlice() != null) {
+                    m.remove(slice.subSlice().propertyKey());
+                }
+                // TODO don't hardcode this if we decide it is what we want
+                if (FIND_CATEGORY.equals(pKey) || IDENTIFY_CATEGORY.equals(pKey)) {
+                    m.remove(NONE_CATEGORY);
+                }
+                //if ("_categoryByCollection.@none".equals(pKey)) {
+                //    m.remove("_categoryByCollection.find");
+                //    m.remove("_categoryByCollection.identify");
+                //}
+            })
+                    : ctx.mmSelected;
+            Map<String, Object> filter = SelectedFacets.buildMultiSelectedTree(mSelected.values())
+                    .expand(ctx.jsonLd, ctx.rdfSubjectTypes)
+                    .toEs(ctx.esSettings);
+            query.put(field, filterWrap(aggs, property.name(), filter));
+        });
     }
 
     private static Map<String, Object> buildCoreAqqQuery(String field, AppParams.Slice slice, AggContext ctx) {

--- a/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
+++ b/whelk-core/src/main/groovy/whelk/search2/QueryUtil.java
@@ -150,7 +150,7 @@ public class QueryUtil {
 //              .map(p -> new Property(p, jsonLd))
 //              .toList();
         List<Property> integralRelations = Stream.of("hasInstance", "instanceOf", "hasComponent")
-                .map(p -> new Property(p, jsonLd))
+                .map(p -> Property.getProperty(p, jsonLd))
                 .toList();
 
         return integralRelations.stream()

--- a/whelk-core/src/main/groovy/whelk/search2/ResourceLookup.java
+++ b/whelk-core/src/main/groovy/whelk/search2/ResourceLookup.java
@@ -24,13 +24,10 @@ import java.util.stream.Stream;
 
 import static whelk.JsonLd.ID_KEY;
 import static whelk.JsonLd.Owl.DATATYPE_PROPERTY;
-import static whelk.JsonLd.Owl.EQUIVALENT_CLASS;
-import static whelk.JsonLd.Owl.EQUIVALENT_PROPERTY;
 import static whelk.JsonLd.Owl.OBJECT_PROPERTY;
 import static whelk.JsonLd.Rdfs.RDF_TYPE;
 import static whelk.JsonLd.VOCAB_KEY;
 import static whelk.JsonLd.asList;
-import static whelk.search2.QueryUtil.loadThing;
 import static whelk.util.DocumentUtil.getAtPath;
 
 public record ResourceLookup(VocabMappings vocabMappings, ExternalMappings externalMappings) {
@@ -106,14 +103,14 @@ public record ResourceLookup(VocabMappings vocabMappings, ExternalMappings exter
             vocab.forEach((termKey, termDefinition) -> {
                 String ns = getNs(termKey, systemVocabNs);
                 if (isProperty(termDefinition)) {
-                    addAllMappings(termKey, ns, properties, whelk);
+                    addAllMappings(termKey, ns, properties, jsonLd);
                     if (jsonLd.getCategoryMembers("librissearch:coercing").contains(termKey)) {
                         coercingProperties.add(termKey);
                     }
                 } else if (isClass(termDefinition, jsonLd)) {
-                    addAllMappings(termKey, ns, classes, whelk);
+                    addAllMappings(termKey, ns, classes, jsonLd);
                 } else if (isEnum(termDefinition, jsonLd)) {
-                    addAllMappings(termKey, ns, enums, whelk);
+                    addAllMappings(termKey, ns, enums, jsonLd);
                 }
             });
 
@@ -128,10 +125,9 @@ public record ResourceLookup(VocabMappings vocabMappings, ExternalMappings exter
                     : (termKey.contains(":") ? termKey.substring(0, termKey.indexOf(":")) : systemVocabNs);
         }
 
-        private static void addAllMappings(String termKey, String ns, Map<String, Map<String, Set<String>>> mappings, Whelk whelk) {
+        private static void addAllMappings(String termKey, String ns, Map<String, Map<String, Set<String>>> mappings, JsonLd jsonLd) {
             addMapping(termKey, termKey, ns, mappings);
-            addMappings(termKey, ns, mappings, whelk.getJsonld());
-            addEquivTermMappings(termKey, ns, mappings, whelk);
+            addMappings(termKey, ns, mappings, jsonLd);
         }
 
         private static void addMapping(String from, String to, String ns, Map<String, Map<String, Set<String>>> mappings) {
@@ -169,29 +165,6 @@ public record ResourceLookup(VocabMappings vocabMappings, ExternalMappings exter
 
         private static String dropNs(String termIri) {
             return termIri.substring(termIri.lastIndexOf("/") + 1);
-        }
-
-        private static void addEquivTermMappings(String termKey, String ns, Map<String, Map<String, Set<String>>> mappings, Whelk whelk) {
-            var jsonLd = whelk.getJsonld();
-            var vocab = jsonLd.vocabIndex;
-
-            String mappingProperty = isProperty(vocab.get(termKey)) ? EQUIVALENT_PROPERTY : EQUIVALENT_CLASS;
-
-            getAsList(vocab, List.of(termKey, mappingProperty)).forEach(term -> {
-                String equivPropIri = get(term, List.of(ID_KEY), "");
-                if (!equivPropIri.isEmpty()) {
-                    String equivPropKey = jsonLd.toTermKey(equivPropIri);
-                    if (!vocab.containsKey(equivPropKey)) {
-                        var thing = loadThing(equivPropIri, whelk);
-                        if (!thing.isEmpty()) {
-                            addMappings(termKey, ns, mappings, jsonLd, thing);
-                        } else {
-                            addMapping(equivPropIri, termKey, ns, mappings);
-                            addMapping(toPrefixed(equivPropIri), termKey, ns, mappings);
-                        }
-                    }
-                }
-            });
         }
 
         private static boolean isClass(Map<String, Object> termDefinition, JsonLd jsonLd) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -145,7 +145,6 @@ public non-sealed class Condition implements Node {
 
     private ExpandedNode expandWithAltSelectors(JsonLd jsonLd, Collection<String> rdfSubjectTypes) {
         List<Node> withAltSelectors = selector.getAltSelectors(jsonLd, rdfSubjectTypes, true).stream()
-                .map(s -> s.withPrependedMetaProperty(jsonLd))
                 .map(this::withSelector)
                 .map(s -> s._expand(jsonLd))
                 .toList();

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Condition.java
@@ -167,8 +167,8 @@ public non-sealed class Condition implements Node {
         List<PathElement> currentPath = new ArrayList<>();
         for (PathElement pe : path) {
             currentPath.add(pe);
-            if (pe instanceof Property p && p.isRestrictedSubProperty() && !p.hasIndexKey()) {
-                for (Restrictions.HasValue r : p.objectOnPropertyRestrictions()) {
+            if (pe instanceof Property.RestrictedSubProperty p && !p.hasIndexKey()) {
+                for (Restrictions.HasValue r : p.getObjectRestrictions()) {
                     var restrictedPath = new Path(Stream.concat(currentPath.stream(), r.onProperty().path().stream()).toList());
                     prefilledFields.add(new Condition(restrictedPath, EQUALS, r.value()));
                 }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Key.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Key.java
@@ -36,11 +36,6 @@ public sealed abstract class Key extends PathElement permits Key.AmbiguousKey, K
     }
 
     @Override
-    public Selector withPrependedMetaProperty(JsonLd jsonLd) {
-        return this;
-    }
-
-    @Override
     public boolean isType() {
         return token.value().equals(TYPE_KEY);
     }
@@ -72,11 +67,6 @@ public sealed abstract class Key extends PathElement permits Key.AmbiguousKey, K
 
     @Override
     public boolean indirectlyAppearsOnType(String type, JsonLd jsonLd) {
-        return false;
-    }
-
-    @Override
-    public boolean appearsOnlyOnRecord(JsonLd jsonLd) {
         return false;
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -64,21 +64,6 @@ public final class Path implements Selector {
         return altSelectors;
     }
 
-    @Override
-    public Selector withPrependedMetaProperty(JsonLd jsonLd) {
-        List<PathElement> newPath = new ArrayList<>();
-        for (PathElement pe : path()) {
-            if (pe.appearsOnlyOnRecord(jsonLd)) {
-                boolean isPrecededByMeta = !newPath.isEmpty() && newPath.getLast() instanceof Property p && p.isMeta();
-                if (!isPrecededByMeta) {
-                    newPath.add(new Property.Meta(jsonLd));
-                }
-            }
-            newPath.add(pe);
-        }
-        return new Path(newPath);
-    }
-
     private List<List<PathElement>> getAltPaths(List<? extends PathElement> tail, JsonLd jsonLd, Collection<String> rdfSubjectTypes, boolean allowIncompatible) {
         if (tail.isEmpty()) {
             return List.of(List.of());
@@ -131,11 +116,6 @@ public final class Path implements Selector {
     @Override
     public boolean indirectlyAppearsOnType(String type, JsonLd jsonLd) {
         return first().indirectlyAppearsOnType(type, jsonLd);
-    }
-
-    @Override
-    public boolean appearsOnlyOnRecord(JsonLd jsonLd) {
-        return first().appearsOnlyOnRecord(jsonLd);
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java
@@ -61,7 +61,7 @@ public final class Path implements Selector {
                 altSelectors.add(new Path(l));
             }
         });
-        return altSelectors;
+        return excludeInverseIntegralRoundTrips(altSelectors);
     }
 
     private List<List<PathElement>> getAltPaths(List<? extends PathElement> tail, JsonLd jsonLd, Collection<String> rdfSubjectTypes, boolean allowIncompatible) {
@@ -76,6 +76,22 @@ public final class Path implements Selector {
                         .map(altPath -> Stream.concat(s.path().stream(), altPath.stream())))
                 .map(Stream::toList)
                 .toList();
+    }
+
+    private List<Selector> excludeInverseIntegralRoundTrips(List<Selector> altSelectors) {
+        List<Selector> res = new ArrayList<>();
+        for (Selector s : altSelectors) {
+            List<Property.IntegralProperty> integralsInPath = s.path().stream()
+                    .filter(Property.IntegralProperty.class::isInstance)
+                    .map(Property.IntegralProperty.class::cast)
+                    .toList();
+            boolean hasInversePair = integralsInPath.stream()
+                    .anyMatch(integral -> integralsInPath.stream().anyMatch(integral::isInverseOf));
+            if (!hasInversePair) {
+                res.add(s);
+            }
+        }
+        return res;
     }
 
     @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -115,6 +115,9 @@ public non-sealed class Property extends PathElement {
         if (isCoercing(definition)) {
             return new CoercingSubProperty(definition, jsonLd, propertyKey, queryKey);
         }
+        if (jsonLd.isIntegral(propertyKey)) {
+            return new IntegralProperty(definition, jsonLd, propertyKey, queryKey);
+        }
         if (RDF_TYPE.equals(propertyKey)) {
             return new RdfType(jsonLd, queryKey);
         }
@@ -502,6 +505,12 @@ public non-sealed class Property extends PathElement {
         public RdfType(JsonLd jsonLd, Key.RecognizedKey key) {
             super(RDF_TYPE, jsonLd, key);
             this.indexKey = TYPE_KEY;
+        }
+    }
+
+    public static final class IntegralProperty extends Property {
+        IntegralProperty(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey queryKey) {
+            super(definition, jsonLd, name, queryKey);
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -566,6 +566,16 @@ public non-sealed class Property extends PathElement {
             }
             return definition.toString();
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof AnonymousProperty p && definition.equals(p.definition());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(definition);
+        }
     }
 
     private static class CompositeProperty extends Property {
@@ -577,6 +587,7 @@ public non-sealed class Property extends PathElement {
         public List<Selector> getAltSelectors(JsonLd jsonLd, Collection<String> rdfSubjectTypes, boolean allowIncompatible) {
             return getComponents(jsonLd).stream()
                     .flatMap(s -> s.getAltSelectors(jsonLd, rdfSubjectTypes, allowIncompatible).stream())
+                    .distinct()
                     .toList();
         }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -558,10 +558,13 @@ public non-sealed class Property extends PathElement {
 
         @Override
         public String toString() {
-            if (superProperty != null) {
-                return superProperty.toString();
+            if (superProperty != null && !objectRestrictions.isEmpty()) {
+                var restrictionsStr = objectRestrictions.stream()
+                        .map(r -> String.format("%s=%s", r.onProperty().toString(), r.value().toString()))
+                        .collect(Collectors.joining(", "));
+                return String.format("%s[%s]", superProperty.toString(),  restrictionsStr);
             }
-            return "AnonymousProperty";
+            return definition.toString();
         }
     }
 

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -83,14 +83,18 @@ public non-sealed class Property extends PathElement {
     }
 
     public static Property getProperty(String propertyKey, JsonLd jsonLd) {
-        return buildProperty(propertyKey, jsonLd, null);
+        return getProperty(propertyKey, jsonLd, null);
     }
 
-    public static Property buildProperty(String propertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
+    public static Property getProperty(String propertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
         if (jsonLd.vocabIndex.containsKey(LIBRIS_SEARCH_NS + propertyKey)) {
             // FIXME: This is only temporary to avoid having to include the prefix for terms in the libris search namespace
             return buildProperty(LIBRIS_SEARCH_NS + propertyKey, jsonLd, new Key.RecognizedKey(new Token.Raw(propertyKey)));
         }
+        return buildProperty(propertyKey, jsonLd, queryKey);
+    }
+
+    protected static Property buildProperty(String propertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
         var propDef = jsonLd.vocabIndex.get(propertyKey);
         if (propDef == null) {
             throw new IllegalArgumentException("No such property: " + propertyKey);
@@ -646,9 +650,14 @@ public non-sealed class Property extends PathElement {
 
             return c.stream()
                     .map(QueryUtil::castToStringObjectMap)
-                    .map(prop -> isLink(prop)
-                            ? getProperty(jsonLd.toTermKey((String) prop.get(ID_KEY)), jsonLd)
-                            : new AnonymousProperty(prop, jsonLd))
+                    .map(prop -> {
+                        if (isLink(prop)) {
+                            var pKey = jsonLd.toTermKey((String) prop.get(ID_KEY));
+                            return buildProperty(pKey, jsonLd, new Key.RecognizedKey(new Token.Raw(pKey)));
+                        } else {
+                            return new AnonymousProperty(prop, jsonLd);
+                        }
+                    })
                     .toList();
         }
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -24,7 +24,6 @@ import static whelk.JsonLd.Owl.OBJECT_PROPERTY;
 import static whelk.JsonLd.Owl.ON_PROPERTY;
 import static whelk.JsonLd.Owl.PROPERTY_CHAIN_AXIOM;
 import static whelk.JsonLd.Owl.RESTRICTION;
-import static whelk.JsonLd.RECORD_KEY;
 import static whelk.JsonLd.Rdfs.DOMAIN;
 import static whelk.JsonLd.Rdfs.RANGE;
 import static whelk.JsonLd.Rdfs.RDF_TYPE;
@@ -108,9 +107,6 @@ public non-sealed class Property extends PathElement {
         if (RDF_TYPE.equals(propertyKey)) {
             return new RdfType(jsonLd, queryKey);
         }
-        if (RECORD_KEY.equals(propertyKey)) {
-            return new Meta(jsonLd, queryKey);
-        }
         if ("textQuery".equals(propertyKey)) {
             return new TextQuery(jsonLd, queryKey);
         }
@@ -139,13 +135,6 @@ public non-sealed class Property extends PathElement {
     @Override
     public List<Selector> getAltSelectors(JsonLd jsonLd, Collection<String> rdfSubjectTypes, boolean allowIncompatible) {
         return _getAltSelectors(jsonLd, rdfSubjectTypes, allowIncompatible);
-    }
-
-    @Override
-    public Selector withPrependedMetaProperty(JsonLd jsonLd) {
-        return hasDomainAdminMetadata(jsonLd)
-                ? new Path(List.of(new Meta(jsonLd), this))
-                : this;
     }
 
     @Override
@@ -189,11 +178,6 @@ public non-sealed class Property extends PathElement {
     public boolean indirectlyAppearsOnType(String type, JsonLd jsonLd) {
         return QueryUtil.getIntegralRelationsForType(type, jsonLd).stream()
                 .anyMatch(relation -> relation.range().stream().anyMatch(t -> appearsOnType(t, jsonLd)));
-    }
-
-    @Override
-    public boolean appearsOnlyOnRecord(JsonLd jsonLd) {
-        return hasDomainAdminMetadata(jsonLd);
     }
 
     @Override
@@ -351,17 +335,15 @@ public non-sealed class Property extends PathElement {
                 .flatMap(List::stream)
                 .collect(Collectors.toSet());
 
-        boolean isRecordProperty = this.hasDomainAdminMetadata(jsonLd);
-
         Predicate<Property> followIntegralRelation = integralProp ->
-                isRecordProperty || integralProp.range().stream().anyMatch(irRangeType -> this.mayAppearOnType(irRangeType, jsonLd));
+                integralProp.range().stream().anyMatch(irRangeType -> this.mayAppearOnType(irRangeType, jsonLd));
 
         List<List<Property>> altPaths = integralRelations.stream()
                 .filter(followIntegralRelation)
                 .map(ir -> Stream.concat(Stream.of(ir), path().stream()).toList())
                 .collect(Collectors.toList());
 
-        if (isRecordProperty || rdfSubjectTypes.stream().anyMatch(t -> this.mayAppearOnType(t, jsonLd))) {
+        if (rdfSubjectTypes.stream().anyMatch(t -> this.mayAppearOnType(t, jsonLd))) {
             altPaths.add(List.of(this));
         }
 
@@ -373,12 +355,6 @@ public non-sealed class Property extends PathElement {
                 .filter(Predicate.not(List::isEmpty))
                 .map(altPath -> altPath.size() > 1 ? new Path(altPath) : altPath.getFirst())
                 .toList();
-    }
-
-    private boolean hasDomainAdminMetadata(JsonLd jsonLd) {
-        return !domain.isEmpty() && domain.stream()
-                .filter(d -> jsonLd.isSubClassOf(d, "AdminMetadata"))
-                .count() == domain.size();
     }
 
     private List<String> getDomain(JsonLd jsonLd) {
@@ -489,21 +465,6 @@ public non-sealed class Property extends PathElement {
         }
     }
 
-    public static final class Meta extends Property {
-        public Meta(JsonLd jsonLd) {
-            super(RECORD_KEY, jsonLd);
-        }
-
-        public Meta(JsonLd jsonLd, Key.RecognizedKey key) {
-            super(RECORD_KEY, jsonLd, key);
-        }
-
-        @Override
-        public boolean isMeta() {
-            return true;
-        }
-    }
-
     public static final class CoercingSubProperty extends Property {
         public CoercingSubProperty(Property superProperty, String subPropertyKey, JsonLd jsonLd) {
             super(subPropertyKey, jsonLd);
@@ -589,11 +550,6 @@ public non-sealed class Property extends PathElement {
                     :value ) .
             */
             return Property.buildObjectRestrictions(definition, jsonLd, true);
-        }
-
-        @Override
-        public boolean isMeta() {
-            return superProperty instanceof Meta;
         }
 
         @Override

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -63,7 +63,7 @@ public non-sealed class Property extends PathElement {
         this.queryKey = queryKey;
         if (name != null) {
             this.name = name;
-            this.langAlias =(String) jsonLd.langContainerAlias.get(name);
+            this.langAlias = (String) jsonLd.langContainerAlias.get(name);
             this.isVocabTerm = jsonLd.isVocabTerm(name);
             this.isLdSetContainer = jsonLd.isSetContainer(name);
         }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Property.java
@@ -3,6 +3,7 @@ package whelk.search2.querytree;
 import whelk.JsonLd;
 import whelk.component.ElasticSearch;
 import whelk.search2.QueryUtil;
+import whelk.util.DocumentUtil;
 import whelk.util.Restrictions;
 
 import java.util.ArrayList;
@@ -31,7 +32,6 @@ import static whelk.JsonLd.Rdfs.SUBCLASS_OF;
 import static whelk.JsonLd.Rdfs.SUB_PROPERTY_OF;
 import static whelk.JsonLd.TYPE_KEY;
 import static whelk.JsonLd.asList;
-import static whelk.JsonLd.isLink;
 
 public non-sealed class Property extends PathElement {
     protected String name;
@@ -46,9 +46,6 @@ public non-sealed class Property extends PathElement {
     protected boolean isVocabTerm;
     protected boolean isLdSetContainer;
 
-    protected Property superProperty;
-    protected List<Restrictions.HasValue> objectRestrictions;
-
     private static final String LIBRIS_SEARCH_NS = "librissearch:";
 
     // TODO: Get substitutions from context instead?
@@ -57,29 +54,23 @@ public non-sealed class Property extends PathElement {
             "hasInstance", String.format("%s.instanceOf", JsonLd.REVERSE_KEY)
     );
 
-    public Property(String name, JsonLd jsonLd) {
-        this(jsonLd.vocabIndex.get(name), jsonLd);
-        this.name = name;
-        this.langAlias =(String) jsonLd.langContainerAlias.get(name);
-        this.isVocabTerm = jsonLd.isVocabTerm(name);
-        this.isLdSetContainer = jsonLd.isSetContainer(name);
-    }
-
-    protected Property(Map<String, Object> definition, JsonLd jsonLd) {
+    protected Property(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey queryKey) {
         this.definition = definition;
         this.domain = getDomain(jsonLd);
         this.range = getRange(jsonLd);
         this.inverseOf = getInverseOf(jsonLd);
         this.indexKey = (String) definition.get("ls:indexKey"); // FIXME: This shouldn't have a different prefix (ls: vs librissearch:)
-        this.objectRestrictions = getObjectRestrictions(jsonLd);
-    }
-
-    private Property(String name, JsonLd jsonLd, Key.RecognizedKey queryKey) {
-        this(name, jsonLd);
         this.queryKey = queryKey;
+        if (name != null) {
+            this.name = name;
+            this.langAlias =(String) jsonLd.langContainerAlias.get(name);
+            this.isVocabTerm = jsonLd.isVocabTerm(name);
+            this.isLdSetContainer = jsonLd.isSetContainer(name);
+        }
     }
 
-    protected Property() {
+    protected Property(String name, JsonLd jsonLd, Key.RecognizedKey queryKey) {
+        this(jsonLd.vocabIndex.get(name), jsonLd, name, queryKey);
     }
 
     public static Property getProperty(String propertyKey, JsonLd jsonLd) {
@@ -87,26 +78,42 @@ public non-sealed class Property extends PathElement {
     }
 
     public static Property getProperty(String propertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
-        if (jsonLd.vocabIndex.containsKey(LIBRIS_SEARCH_NS + propertyKey)) {
+        var vocab = jsonLd.vocabIndex;
+        if (vocab.containsKey(LIBRIS_SEARCH_NS + propertyKey)) {
             // FIXME: This is only temporary to avoid having to include the prefix for terms in the libris search namespace
             return buildProperty(LIBRIS_SEARCH_NS + propertyKey, jsonLd, new Key.RecognizedKey(new Token.Raw(propertyKey)));
+        }
+        if (!vocab.containsKey(propertyKey)) {
+            throw new IllegalArgumentException("No such property: " + propertyKey);
         }
         return buildProperty(propertyKey, jsonLd, queryKey);
     }
 
+    protected static Property buildProperty(Map<String, Object> propertyNode, JsonLd jsonLd) {
+        if (isAnonymous(propertyNode)) {
+            var definition = hasBNodeId(propertyNode)
+                    ? jsonLd.vocabIndex.get((String) propertyNode.get(ID_KEY))
+                    : propertyNode;
+            return buildProperty(definition, jsonLd, null, null);
+        } else {
+            var pKey = jsonLd.toTermKey((String) propertyNode.get(ID_KEY));
+            return buildProperty(pKey, jsonLd, new Key.RecognizedKey(new Token.Raw(pKey)));
+        }
+    }
+
     protected static Property buildProperty(String propertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
-        var propDef = jsonLd.vocabIndex.get(propertyKey);
-        if (propDef == null) {
-            throw new IllegalArgumentException("No such property: " + propertyKey);
+        return buildProperty(jsonLd.vocabIndex.get(propertyKey), jsonLd, propertyKey, queryKey);
+    }
+
+    private static Property buildProperty(Map<String, Object> definition, JsonLd jsonLd, String propertyKey, Key.RecognizedKey queryKey) {
+        if (isComposite(definition)) {
+            return new CompositeProperty(definition, jsonLd, propertyKey, queryKey);
         }
-        if (isComposite(propDef)) {
-            return new CompositeProperty(propertyKey, jsonLd, queryKey);
+        if (isShorthand(definition) && !definition.containsKey("ls:indexKey")) {
+            return new ShorthandProperty(definition, jsonLd, propertyKey, queryKey);
         }
-        if (isShorthand(propDef) && !propDef.containsKey("ls:indexKey")) {
-            return new ShorthandProperty(propertyKey, jsonLd, queryKey);
-        }
-        if (isCoercing(propDef)) {
-            return new CoercingSubProperty(propertyKey, jsonLd, queryKey);
+        if (isCoercing(definition)) {
+            return new CoercingSubProperty(definition, jsonLd, propertyKey, queryKey);
         }
         if (RDF_TYPE.equals(propertyKey)) {
             return new RdfType(jsonLd, queryKey);
@@ -114,7 +121,32 @@ public non-sealed class Property extends PathElement {
         if ("textQuery".equals(propertyKey)) {
             return new TextQuery(jsonLd, queryKey);
         }
-        return new Property(propertyKey, jsonLd, queryKey);
+        if (definition.containsKey(SUB_PROPERTY_OF)) {
+            if (isAnonymous(definition)) {
+                /*
+                    We interpret unambiguous range of an anonymous sub-property as a restriction.
+
+                    For example
+
+                    :isbn owl:propertyChainAxiom (
+                        [ rdfs:subPropertyOf :identifiedBy ; rdfs:range :ISBN ]
+                        :value ) .
+
+                    is interpreted as
+
+                    :isbn owl:propertyChainAxiom (
+                        [ rdfs:subPropertyOf :identifiedBy ;
+                            rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty rdf:type ; owl:hasValue :ISBN ] ] ]
+                        :value ) .
+                */
+                return hasUnambiguousRange(definition) || hasRangeRestriction(definition)
+                        ? new AnonymousRestrictedSubProperty(definition, jsonLd)
+                        : new AnonymousSubProperty(definition, jsonLd);
+            } else if (hasRangeRestriction(definition)) {
+                return new RestrictedSubProperty(definition, jsonLd, propertyKey, queryKey);
+            }
+        }
+        return new Property(definition, jsonLd, propertyKey, queryKey);
     }
 
     @Override
@@ -227,20 +259,8 @@ public non-sealed class Property extends PathElement {
         return inverseOf != null && inverseOf.equals(property.name());
     }
 
-    public boolean isRestrictedSubProperty() {
-        return definition.containsKey(SUB_PROPERTY_OF) && !objectOnPropertyRestrictions().isEmpty();
-    }
-
     public boolean hasIndexKey() {
         return indexKey != null;
-    }
-
-    public List<Restrictions.HasValue> objectOnPropertyRestrictions() {
-        return objectRestrictions != null ? objectRestrictions : List.of();
-    }
-
-    protected List<Restrictions.HasValue> getObjectRestrictions(JsonLd jsonLd) {
-        return buildObjectRestrictions(definition, jsonLd, false);
     }
 
     public static List<Restrictions.HasValue> buildObjectRestrictions(Map<String, Object> definition, JsonLd jsonLd, boolean restrictByRangeType) {
@@ -257,10 +277,6 @@ public non-sealed class Property extends PathElement {
         }
 
         return buildObjectOnPropertyRestrictions(rdfsRange, jsonLd);
-    }
-
-    protected Property getSuperProperty(JsonLd jsonLd) {
-        return getProperty(getSuperKey(definition, jsonLd), jsonLd);
     }
 
     @Override
@@ -411,6 +427,23 @@ public non-sealed class Property extends PathElement {
                 .anyMatch(c -> Map.of(ID_KEY, categoryIri).equals(c));
     }
 
+    private static boolean isAnonymous(Map<String, Object> definition) {
+        return !definition.containsKey(ID_KEY) || hasBNodeId(definition);
+    }
+
+    private static boolean hasBNodeId(Map<String, Object> definition) {
+        return ((String) definition.getOrDefault(ID_KEY, "")).startsWith("_:");
+    }
+
+    private static boolean hasUnambiguousRange(Map<String, Object> definition) {
+        return asList(definition.get(RANGE)).size() == 1;
+    }
+
+    private static boolean hasRangeRestriction(Map<String, Object> definition) {
+        var rangeSuperType = DocumentUtil.getAtPath(definition, List.of(RANGE, SUBCLASS_OF, TYPE_KEY), List.of(), false);
+        return ((List<?>) rangeSuperType).contains(RESTRICTION);
+    }
+
     private List<String> findDomainOrRange(String domainOrRange, JsonLd jsonLd) {
         return findDomainOrRange(definition, domainOrRange, jsonLd);
     }
@@ -422,18 +455,21 @@ public non-sealed class Property extends PathElement {
     }
 
     private static List<String> inheritFromSuper(Map<String, Object> definition, String domainOrRange, JsonLd jsonLd) {
-        return getSuperKeys(definition, jsonLd)
+        return getSuperPropertyKeys(definition, jsonLd)
                 .map(jsonLd.vocabIndex::get)
                 .filter(Objects::nonNull)
                 .flatMap(superDef -> findDomainOrRange(superDef, domainOrRange, jsonLd).stream())
                 .toList();
     }
 
-    private static String getSuperKey(Map<String, Object> definition, JsonLd jsonLd) {
-        return getSuperKeys(definition, jsonLd).findFirst().orElse(null);
+    protected Property getSuperProperty(JsonLd jsonLd) {
+        return getSuperPropertyKeys(definition, jsonLd)
+                .findFirst()
+                .map(pKey -> getProperty(pKey, jsonLd))
+                .orElse(null);
     }
 
-    private static Stream<String> getSuperKeys(Map<String, Object> definition, JsonLd jsonLd) {
+    private static Stream<String> getSuperPropertyKeys(Map<String, Object> definition, JsonLd jsonLd) {
         return getTermKeys(asList(definition.get(SUB_PROPERTY_OF)), jsonLd);
     }
 
@@ -450,7 +486,7 @@ public non-sealed class Property extends PathElement {
 
     public static final class TextQuery extends Property {
         public TextQuery(JsonLd jsonLd) {
-            super("textQuery", jsonLd);
+            this(jsonLd, null);
         }
 
         public TextQuery(JsonLd jsonLd, Key.RecognizedKey key) {
@@ -469,24 +505,79 @@ public non-sealed class Property extends PathElement {
         }
     }
 
-    public static final class CoercingSubProperty extends Property {
-        public CoercingSubProperty(Property superProperty, String subPropertyKey, JsonLd jsonLd) {
-            super(subPropertyKey, jsonLd);
-            this.superProperty = superProperty;
-        }
+    public static class RestrictedSubProperty extends Property {
+        protected Property superProperty;
+        private List<Restrictions.HasValue> objectRestrictions;
 
-        public CoercingSubProperty(String subPropertyKey, JsonLd jsonLd, Key.RecognizedKey queryKey) {
-            super(subPropertyKey, jsonLd, queryKey);
-            this.superProperty = getSuperProperty(jsonLd);
+        RestrictedSubProperty(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey queryKey) {
+            super(definition, jsonLd, name, queryKey);
+            if (!hasIndexKey()) {
+                this.superProperty = getSuperProperty(jsonLd);
+                this.objectRestrictions = buildObjectRestrictions(jsonLd);
+            }
         }
 
         public Property getSuperProperty() {
             return superProperty;
         }
 
+        public List<Restrictions.HasValue> getObjectRestrictions() {
+            return objectRestrictions;
+        }
+
+        protected List<Restrictions.HasValue> buildObjectRestrictions(JsonLd jsonLd) {
+            return buildObjectRestrictions(definition, jsonLd, false);
+        }
+
         @Override
         public String queryKey() {
             return superProperty.queryKey();
+        }
+
+        @Override
+        public String esField() {
+            return hasIndexKey() ? indexKey : superProperty.esField();
+        }
+    }
+
+    private static final class AnonymousRestrictedSubProperty extends RestrictedSubProperty {
+        AnonymousRestrictedSubProperty(Map<String, Object> definition, JsonLd jsonLd) {
+            super(definition, jsonLd, null, null);
+        }
+
+        @Override
+        protected List<Restrictions.HasValue> buildObjectRestrictions(JsonLd jsonLd) {
+            return buildObjectRestrictions(definition, jsonLd, true);
+        }
+
+        @Override
+        public String toString() {
+            var restrictionsStr = getObjectRestrictions().stream()
+                    .map(r -> String.format("%s=%s", r.onProperty().toString(), r.value().toString()))
+                    .collect(Collectors.joining(", "));
+            return String.format("%s[%s]", superProperty.toString(),  restrictionsStr);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof AnonymousRestrictedSubProperty p && definition.equals(p.definition());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(definition);
+        }
+    }
+
+    public static final class CoercingSubProperty extends RestrictedSubProperty {
+        public CoercingSubProperty(Property superProperty, String subPropertyKey, JsonLd jsonLd) {
+            super(jsonLd.vocabIndex.get(subPropertyKey), jsonLd, subPropertyKey, null);
+            this.superProperty = superProperty;
+        }
+
+        CoercingSubProperty(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey queryKey) {
+            super(definition, jsonLd, name, queryKey);
+            this.superProperty = getSuperProperty(jsonLd);
         }
 
         @Override
@@ -501,75 +592,34 @@ public non-sealed class Property extends PathElement {
             }
             throw new IllegalStateException();
         }
-
-        @Override
-        public boolean isRestrictedSubProperty() {
-            return true;
-        }
     }
 
-    private static final class AnonymousProperty extends Property {
-        public AnonymousProperty(Map<String, Object> definition, JsonLd jsonLd) {
-            super(definition, jsonLd);
-            if (definition.containsKey(SUB_PROPERTY_OF)) {
-                this.superProperty = getSuperProperty(jsonLd);
-            }
+    private static final class AnonymousSubProperty extends Property {
+        private final Property superProperty;
+
+        AnonymousSubProperty(Map<String, Object> definition, JsonLd jsonLd) {
+            super(definition, jsonLd, null, null);
+            this.superProperty = getSuperProperty(jsonLd);
         }
 
         @Override
         public String queryKey() {
-            if (superProperty != null) {
-                return superProperty.queryKey();
-            }
-            throw new IllegalStateException();
+            return superProperty.queryKey();
         }
 
         @Override
         public String esField() {
-            if (hasIndexKey()) {
-                return indexKey;
-            }
-            if (superProperty != null) {
-                return superProperty.esField();
-            }
-            throw new IllegalStateException();
-        }
-
-        @Override
-        protected List<Restrictions.HasValue> getObjectRestrictions(JsonLd jsonLd) {
-            /*
-                We interpret the range of an anonymous sub-property as a restriction.
-
-                For example
-
-                :isbn owl:propertyChainAxiom (
-                    [ rdfs:subPropertyOf :identifiedBy ; rdfs:range :ISBN ]
-                    :value ) .
-
-                is interpreted as
-
-                :isbn owl:propertyChainAxiom (
-                    [ rdfs:subPropertyOf :identifiedBy ;
-                        rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty rdf:type ; owl:hasValue :ISBN ] ] ]
-                    :value ) .
-            */
-            return Property.buildObjectRestrictions(definition, jsonLd, true);
+            return hasIndexKey() ? indexKey : superProperty.esField();
         }
 
         @Override
         public String toString() {
-            if (superProperty != null && !objectRestrictions.isEmpty()) {
-                var restrictionsStr = objectRestrictions.stream()
-                        .map(r -> String.format("%s=%s", r.onProperty().toString(), r.value().toString()))
-                        .collect(Collectors.joining(", "));
-                return String.format("%s[%s]", superProperty.toString(),  restrictionsStr);
-            }
             return definition.toString();
         }
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof AnonymousProperty p && definition.equals(p.definition());
+            return obj instanceof AnonymousSubProperty p && definition.equals(p.definition());
         }
 
         @Override
@@ -579,8 +629,8 @@ public non-sealed class Property extends PathElement {
     }
 
     private static class CompositeProperty extends Property {
-        public CompositeProperty(String name, JsonLd jsonLd, Key.RecognizedKey key) {
-            super(name, jsonLd, key);
+        public CompositeProperty(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey key) {
+            super(definition, jsonLd, name, key);
         }
 
         @Override
@@ -620,9 +670,7 @@ public non-sealed class Property extends PathElement {
             return chainDef.stream()
                     .filter(Map.class::isInstance)
                     .map(QueryUtil::castToStringObjectMap)
-                    .map(prop -> isLink(prop)
-                            ? getProperty(jsonLd.toTermKey((String) prop.get(ID_KEY)), jsonLd)
-                            : new AnonymousProperty(prop, jsonLd))
+                    .map(prop -> buildProperty(prop, jsonLd))
                     .map(PathElement.class::cast)
                     .toList();
         }
@@ -631,8 +679,8 @@ public non-sealed class Property extends PathElement {
     private static class ShorthandProperty extends Property {
         private final List<Property> propertyChain;
 
-        public ShorthandProperty(String name, JsonLd jsonLd, Key.RecognizedKey key) {
-            super(name, jsonLd, key);
+        public ShorthandProperty(Map<String, Object> definition, JsonLd jsonLd, String name, Key.RecognizedKey key) {
+            super(definition, jsonLd, name, key);
             this.propertyChain = getPropertyChain(jsonLd);
         }
 
@@ -664,14 +712,7 @@ public non-sealed class Property extends PathElement {
 
             return c.stream()
                     .map(QueryUtil::castToStringObjectMap)
-                    .map(prop -> {
-                        if (isLink(prop)) {
-                            var pKey = jsonLd.toTermKey((String) prop.get(ID_KEY));
-                            return buildProperty(pKey, jsonLd, new Key.RecognizedKey(new Token.Raw(pKey)));
-                        } else {
-                            return new AnonymousProperty(prop, jsonLd);
-                        }
-                    })
+                    .map(prop -> buildProperty(prop, jsonLd))
                     .toList();
         }
     }

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/QueryTree.java
@@ -319,8 +319,7 @@ public class QueryTree {
     }
 
     private static Node compatibleByDomain(String rdfSubjectType, Node tree, JsonLd jsonLd) {
-        Predicate<Condition> isCompatibleByDomain = c -> c.selector().appearsOnlyOnRecord(jsonLd)
-                || c.selector().appearsOnType(rdfSubjectType, jsonLd)
+        Predicate<Condition> isCompatibleByDomain = c -> c.selector().appearsOnType(rdfSubjectType, jsonLd)
                 || c.selector().indirectlyAppearsOnType(rdfSubjectType, jsonLd);
 
         Predicate<Node> isIncompatible = node -> switch (node) {

--- a/whelk-core/src/main/groovy/whelk/search2/querytree/Selector.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/Selector.java
@@ -16,7 +16,6 @@ public sealed interface Selector permits Path, PathElement {
     List<? extends PathElement> path();
 
     List<Selector> getAltSelectors(JsonLd jsonLd, Collection<String> rdfSubjectTypes, boolean allowIncompatible);
-    Selector withPrependedMetaProperty(JsonLd jsonLd);
 
     boolean isValid();
     boolean isType();
@@ -28,7 +27,6 @@ public sealed interface Selector permits Path, PathElement {
     boolean mayAppearOnType(String type, JsonLd jsonLd);
     boolean appearsOnType(String type, JsonLd jsonLd);
     boolean indirectlyAppearsOnType(String type, JsonLd jsonLd);
-    boolean appearsOnlyOnRecord(JsonLd jsonLd);
 
     Map<String, Object> definition();
 

--- a/whelk-core/src/test/groovy/whelk/search2/DisambiguateSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/DisambiguateSpec.groovy
@@ -26,21 +26,21 @@ class DisambiguateSpec extends Specification {
 
         where:
         s                   | result
-        'p1'                | new Property('p1', jsonLd)
-        'p1Label'           | new Property('p1', jsonLd)
+        'p1'                | Property.getProperty('p1', jsonLd)
+        'p1Label'           | Property.getProperty('p1', jsonLd)
         'unrecognizedLabel' | new Key.UnrecognizedKey(new Token.Raw('unrecognizedLabel'))
         '@id'               | new Key.RecognizedKey(new Token.Raw('@id'))
         '_str'              | new Key.RecognizedKey(new Token.Raw('_str'))
-        'p'                 | new Property('p', jsonLd)
-        'pLabel'            | new Property('p2', jsonLd)
+        'p'                 | Property.getProperty('p', jsonLd)
+        'pLabel'            | Property.getProperty('p2', jsonLd)
         'pp'                | new Key.AmbiguousKey(new Token.Raw('pp'))
-        'ctx.p'             | new Property('ctxProp', jsonLd)
-        'p3.p4'             | new Path(List.of(new Property('p3', jsonLd), new Property('p4', jsonLd)))
+        'ctx.p'             | Property.getProperty('ctxProp', jsonLd)
+        'p3.p4'             | new Path(List.of(Property.getProperty('p3', jsonLd), Property.getProperty('p4', jsonLd)))
     }
 
     def "try map string to a recognized value type for the associated property"() {
         given:
-        def res = disambiguate.mapValueForProperty(new Property(p, jsonLd), v)
+        def res = disambiguate.mapValueForProperty(Property.getProperty(p, jsonLd), v)
 
         expect:
         res == Optional.ofNullable(result)

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -81,10 +81,12 @@ class ConditionSpec extends Specification {
         statement.expand(jsonLd, []).toString() == result
 
         where:
-        query                        | result
-        "type:T3"                    | "type:T3 OR type:T3x"
-        "p10:v1"                     | "p4.p1:v1 p4.p3:\"https://id.kb.se/x\""
-        "p11:v1"                     | "p3.p4:v1 (\"p3.rdf:type\":T3 OR \"p3.rdf:type\":T3x)"
+        query                 | result
+        "type:T3"             | "type:T3 OR type:T3x"
+        "p10:v1"              | "p4.p1:v1 p4.p3:\"https://id.kb.se/x\""
+        "p11:v1"              | "p3.p4:v1 (\"p3.rdf:type\":T3 OR \"p3.rdf:type\":T3x)"
+        "restrictedP_p1:v1"   | "p3.p1:v1 p3.p4:\"https://id.kb.se/x\""
+        "restrictedP_p1_2:v1" | "p3.p1:v1 p3.p4:\"https://id.kb.se/x\""
     }
 
     def "expand 2"() {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/ConditionSpec.groovy
@@ -102,14 +102,13 @@ class ConditionSpec extends Specification {
         "p1:v1"             | ["T3"]       | "p1:v1"
         "hasInstance.p7:v7" | ["T2"]       | "hasInstance.p7:v7"
         "instanceOf.p8:v8"  | ["T1"]       | "instanceOf.p8:v8"
-        "p5:x"              | []           | "meta.p5:x"
-        "meta.p5:x"         | []           | "meta.p5:x"
-        "bibliography:x"    | ["T1"]       | "instanceOf.meta.bibliography:x OR meta.bibliography:x"
-        "bibliography:x"    | ["T2"]       | "hasInstance.meta.bibliography:x OR meta.bibliography:x"
-        "bibliography:x"    | ["T3"]       | "meta.bibliography:x"
-        "t1MetaP1:x"        | ["T1"]       | "meta.p1:x"
-        "t1MetaP1:x"        | ["T2"]       | "hasInstance.meta.p1:x"
-        "t1MetaP1:x"        | ["T3"]       | "meta.p1:x"
+        "p3.p1:x"           | []           | "p3.p1:x"
+        "p3p1:x"            | ["T1"]       | "instanceOf.p3.p1:x OR p3.p1:x"
+        "p3p1:x"            | ["T2"]       | "hasInstance.p3.p1:x OR p3.p1:x"
+        "p3p1:x"            | ["T3"]       | "p3.p1:x"
+        "t1p3p1:x"          | ["T1"]       | "p3.p1:x"
+        "t1p3p1:x"          | ["T2"]       | "hasInstance.p3.p1:x"
+        "t1p3p1:x"          | ["T3"]       | "p3.p1:x"
     }
 
     def "To ES exists query"() {

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/QueryTreeSpec.groovy
@@ -10,7 +10,7 @@ class QueryTreeSpec extends Specification {
     static Disambiguate disambiguate = TestData.getDisambiguate()
     static JsonLd jsonLd = TestData.getJsonLd()
 
-    static var p1 = new Property("p1", jsonLd)
+    static var p1 = Property.getProperty("p1", jsonLd)
     static var p1v1 = new Condition(p1, Operator.EQUALS, new FreeText("v1"))
     static var p1v2 = new Condition(p1, Operator.EQUALS, new FreeText("v2"))
 

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -45,7 +45,9 @@ class TestData {
                 'identifycategory': ['librissearch:identifyCategory'] as Set,
                 'nonecategory'    : ['librissearch:noneCategory'] as Set,
                 'p3p1'            : ['p3p1'] as Set,
-                't1p3p1'          : ['t1p3p1'] as Set
+                't1p3p1'          : ['t1p3p1'] as Set,
+                'restrictedp_p1'  : ['restrictedP_p1'] as Set,
+                'restrictedp_p1_2': ['restrictedP_p1_2'] as Set
         ]
         def classMappings = [
                 't1' : ['T1'] as Set,
@@ -290,6 +292,54 @@ class TestData {
                                         'domain'       : [['@id': 'T1']],
                                         'subPropertyOf': [['@id': 'p3']]
                                 ],
+                                ['@id': 'p1']
+                        ]]]
+                ],
+                [
+                        '@id'               : 'restrictedP',
+                        'subPropertyOf'     : [['@id': 'p3']],
+                        "range"             : [
+                                [
+                                        "subClassOf": [
+                                                [
+                                                        "@type"     : "Restriction",
+                                                        "onProperty": ["@id": "p4"],
+                                                        "hasValue"  : ["@id": "https://id.kb.se/x"],
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                [
+                        '@id'               : 'restrictedP_p1',
+                        '@type'             : 'DatatypeProperty',
+                        'category'          : ['@id': "https://id.kb.se/vocab/shorthand"],
+                        'propertyChainAxiom': [['@list': [
+                                ['@id': 'restrictedP'],
+                                ['@id': 'p1']
+                        ]]]
+                ],
+                [
+                        '@id'               : '_:restrictedP',
+                        'subPropertyOf'     : [['@id': 'p3']],
+                        "range"             : [
+                                [
+                                        "subClassOf": [
+                                                [
+                                                        "@type"     : "Restriction",
+                                                        "onProperty": ["@id": "p4"],
+                                                        "hasValue"  : ["@id": "https://id.kb.se/x"],
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                [
+                        '@id'               : 'restrictedP_p1_2',
+                        '@type'             : 'DatatypeProperty',
+                        'category'          : ['@id': "https://id.kb.se/vocab/shorthand"],
+                        'propertyChainAxiom': [['@list': [
+                                ['@id': '_:restrictedP'],
                                 ['@id': 'p1']
                         ]]]
                 ]

--- a/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/querytree/TestData.groovy
@@ -45,9 +45,7 @@ class TestData {
                 'identifycategory': ['librissearch:identifyCategory'] as Set,
                 'nonecategory'    : ['librissearch:noneCategory'] as Set,
                 'p3p1'            : ['p3p1'] as Set,
-                'bibliography'    : ['bibliography'] as Set,
-                'meta'            : ['meta'] as Set,
-                't1metap1'        : ['t1MetaP1'] as Set
+                't1p3p1'          : ['t1p3p1'] as Set
         ]
         def classMappings = [
                 't1' : ['T1'] as Set,
@@ -93,7 +91,7 @@ class TestData {
                 ['@id': 'p2', '@type': 'ObjectProperty', 'librisQueryCode': 'P2'],
                 ['@id': 'p3', '@type': 'ObjectProperty'],
                 ['@id': 'p4', '@type': 'ObjectProperty'],
-                ['@id': 'p5', '@type': 'ObjectProperty', 'domain': ['@id': 'https://id.kb.se/vocab/AdminMetadata']],
+                ['@id': 'p5', '@type': 'ObjectProperty'],
                 [
                         '@id'               : 'p6',
                         '@type'             : 'ObjectProperty',
@@ -262,7 +260,6 @@ class TestData {
                 ],
                 ['@id': 'textQuery', '@type': 'DatatypeProperty'],
                 ['@id': 'rdf:type', '@type': 'ObjectProperty'],
-                ['@id': 'meta', '@type': 'ObjectProperty'],
                 ['@id': 'T1', '@type': 'Class'],
                 ['@id': 'T2', '@type': 'Class'],
                 ['@id': 'T3', '@type': 'Class'],
@@ -283,16 +280,15 @@ class TestData {
                                 ['@id': 'p1']
                         ]]]
                 ],
-                ['@id': 'bibliography', '@type': 'ObjectProperty', 'domain': ['@id': 'https://id.kb.se/vocab/AdminMetadata']],
                 [
-                        '@id'               : 't1MetaP1',
+                        '@id'               : 't1p3p1',
                         '@type'             : 'DatatypeProperty',
                         'category'          : ['@id': "https://id.kb.se/vocab/shorthand"],
                         'domain'            : ['@id': 'T1'],
                         'propertyChainAxiom': [['@list': [
                                 [
                                         'domain'       : [['@id': 'T1']],
-                                        'subPropertyOf': [['@id': 'meta']]
+                                        'subPropertyOf': [['@id': 'p3']]
                                 ],
                                 ['@id': 'p1']
                         ]]]


### PR DESCRIPTION
Complements https://github.com/libris/definitions/pull/600

- Remove the special handling of  `meta` in query expansion since it mostly just caused bugs. With shorthand properties now defined for the common use cases there is no need for it. When there is no shorthand available, queries can simply use the full qualified form, e.g. `meta.x:y`. 
- Support for identifiable restricted sub-properties, either as ID'd blank properties or named properties, e.g.:
```
# named property :x
:x :rdfs:subPropertyOf :y ;
    rdfs::range [ a owl:restriction ; owl:onProperty :p ; owl:hasValue :a ] . 
```
```
# blank property _:x
_:x :rdfs:subPropertyOf :y ;
    rdfs::range [ a owl:restriction ; owl:onProperty :p ; owl:hasValue :a ] . 
```
- Minor fixes/cleanups for things discovered when testing
- [02df0d9](https://github.com/libris/librisxl/pull/1780/commits/02df0d93ec6da210f4a0f537062d0fbd9920ca25) limits the set of fields searched when using e.g. the `title:` filter. While it removes a few superfluous fields from the expanded query, the handling of integral properties is still a bit too eager, causing `title:` to expand to more fields than necessary. This is not a big issue (better searching too many fields than too few) but we should fix it — either in the implementation or by tweaking the definitions. 