### PR TITLE
fix(xsearch): handle the case where agent is a list

### DIFF
--- a/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
+++ b/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
@@ -520,6 +520,7 @@ public class XSearchServlet extends WhelkHttpServlet {
                 .or(() -> contribution.stream().findFirst())
                 .filter(c -> c.containsKey("agent"))
                 .map(c -> c.get("agent"))
+                .map(agent -> agent instanceof List<?> l ? (l.isEmpty() ? null : l.getFirst()) : agent)
                 .map(format)
                 .ifPresent(t -> result.put("creator", t));
 


### PR DESCRIPTION
It can happen that contribution.agent is a list. https://libris-qa.kb.se/api/xsearch?query=onr:6nwssf4h4spbr3lw&format=json