### PR TITLE
Define freeOnline filter alias for XSearch/SRU

### DIFF
--- a/sru/src/main/java/whelk/sru/cql/Translation.java
+++ b/sru/src/main/java/whelk/sru/cql/Translation.java
@@ -45,12 +45,6 @@ public class Translation
         Object phase1Ast = Phase1.reduce(cst);
         String xlql = Phase2.flatten(phase1Ast);
 
-        // CQL searches only for instances
-        if (xlql.startsWith("(") && xlql.endsWith(")"))
-            xlql = xlql + " AND type=Instance";
-        else
-            xlql = "(" + xlql + ") AND type=Instance";
-
         /*
         System.err.println("CQL:  " + cqlQuery);
         System.err.println("AST:  " + phase1Ast);

--- a/sru/src/main/java/whelk/sru/servlet/SruServlet.java
+++ b/sru/src/main/java/whelk/sru/servlet/SruServlet.java
@@ -38,10 +38,13 @@ public class SruServlet extends WhelkHttpServlet {
 
     private static final List<String> SUPPORTED_VERSIONS = List.of("1.0", "1.1", "1.2");
 
+    private static final String appId = "https://libris.kb.se/sru/libris";
+
     JsonLD2MarcXMLConverter converter;
     XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
     ResourceLookup resourceLookup;
     ESSettings esSettings;
+    AppParams appParams;
 
     String explain = loadResource("explain.xml");
     ExportProfile marcExportProfile;
@@ -51,6 +54,7 @@ public class SruServlet extends WhelkHttpServlet {
         converter = new JsonLD2MarcXMLConverter(whelk.getMarcFrameConverter());
         resourceLookup = ResourceLookup.load(whelk);
         esSettings = new ESSettings(whelk);
+        appParams = new AppParams(appId, whelk);
 
         Properties marcProperties = new Properties();
         marcExportProfile = new ExportProfile(marcProperties);
@@ -126,21 +130,8 @@ public class SruServlet extends WhelkHttpServlet {
             paramsAsIfSearch.put("_offset", new String[] {"" + (startRecord-1)});
             paramsAsIfSearch.put("_limit", new String[] {"" + maximumRecords});
 
-            // FIXME: Get from configuration
-            String freeOnlineFilter = """
-                instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis
-                OR "associatedMedia.marc:publicNote":"fritt tillgänglig"
-                OR usageAndAccessPolicy:("https://id.kb.se/policy/freely-available"
-                OR "https://id.kb.se/policy/oa/gratis"))
-                """;
-            var filterAliases = List.of(
-                    Map.of("alias", "freeOnline",
-                            "filter", freeOnlineFilter)
-            );
-
             QueryParams qp = new QueryParams(paramsAsIfSearch);
-            AppParams ap = new AppParams(Map.of("filterAliases", filterAliases), whelk.getJsonld());
-            Query query = new Query(qp, ap, resourceLookup, esSettings, whelk);
+            Query query = new Query(qp, appParams, resourceLookup, esSettings, whelk);
             results = query.collectResults();
         } catch (InvalidQueryException | ParseCancellationException e) {
             logger.info("Bad query: \"" + parameters.get("query")[0] + "\" -> " + e.getMessage());

--- a/sru/src/main/java/whelk/sru/servlet/SruServlet.java
+++ b/sru/src/main/java/whelk/sru/servlet/SruServlet.java
@@ -126,8 +126,20 @@ public class SruServlet extends WhelkHttpServlet {
             paramsAsIfSearch.put("_offset", new String[] {"" + (startRecord-1)});
             paramsAsIfSearch.put("_limit", new String[] {"" + maximumRecords});
 
+            // FIXME: Get from configuration
+            String freeOnlineFilter = """
+                instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis
+                OR "associatedMedia.marc:publicNote":"fritt tillgänglig"
+                OR usageAndAccessPolicy:("https://id.kb.se/policy/freely-available"
+                OR "https://id.kb.se/policy/oa/gratis"))
+                """;
+            var filterAliases = List.of(
+                    Map.of("alias", "freeOnline",
+                            "filter", freeOnlineFilter)
+            );
+
             QueryParams qp = new QueryParams(paramsAsIfSearch);
-            AppParams ap = new AppParams(new HashMap<>(), whelk.getJsonld());
+            AppParams ap = new AppParams(Map.of("filterAliases", filterAliases), whelk.getJsonld());
             Query query = new Query(qp, ap, resourceLookup, esSettings, whelk);
             results = query.collectResults();
         } catch (InvalidQueryException | ParseCancellationException e) {

--- a/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
+++ b/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
@@ -94,6 +94,8 @@ public class XSearchServlet extends WhelkHttpServlet {
     private final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
     private final TransformerFactory transformerFactory = TransformerFactory.newInstance();
 
+    private static final String appId = "https://libris.kb.se/xsearch";
+
     private static final int DEFAULT_N = 10;
     private static final int MAX_N = 200;
     private static final int DEFAULT_START = 1;
@@ -158,6 +160,7 @@ public class XSearchServlet extends WhelkHttpServlet {
     XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
     ResourceLookup resourceLookup;
     ESSettings esSettings;
+    AppParams appParams;
     Map<Format, Templates> transformers;
 
     @Override
@@ -165,6 +168,7 @@ public class XSearchServlet extends WhelkHttpServlet {
         converter = new JsonLD2MarcXMLConverter(whelk.getMarcFrameConverter());
         resourceLookup = ResourceLookup.load(whelk);
         esSettings = new ESSettings(whelk);
+        appParams = new AppParams(appId, whelk);
 
         try {
             transformers = Map.of(
@@ -231,11 +235,9 @@ public class XSearchServlet extends WhelkHttpServlet {
         try {
             // TODO handle onr (record ID) here or in search2?
 
-            String instanceOnlyQueryString = "(" + query + ") AND type=Instance";
-
             // This part is a little weird
             HashMap<String, String[]> paramsAsIfSearch = new HashMap<>();
-            String[] q = new String[]{ instanceOnlyQueryString };
+            String[] q = new String[]{ query };
             paramsAsIfSearch.put("_q", q);
             paramsAsIfSearch.put("_stats", new String[]{"false"}); // don't need facets
             paramsAsIfSearch.put("_offset", new String[]{"" + (start - 1)});
@@ -244,21 +246,8 @@ public class XSearchServlet extends WhelkHttpServlet {
                 paramsAsIfSearch.put("_sort", new String[]{ sort });
             }
 
-            // FIXME: Get from configuration
-            String freeOnlineFilter = """
-                instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis
-                OR "associatedMedia.marc:publicNote":"fritt tillgänglig"
-                OR usageAndAccessPolicy:("https://id.kb.se/policy/freely-available"
-                OR "https://id.kb.se/policy/oa/gratis"))
-                """;
-            var filterAliases = List.of(
-                    Map.of("alias", "freeOnline",
-                            "filter", freeOnlineFilter)
-            );
-
             QueryParams qp = new QueryParams(paramsAsIfSearch);
-            AppParams ap = new AppParams(Map.of("filterAliases", filterAliases), whelk.getJsonld());
-            var results = new Query(qp, ap, resourceLookup, esSettings, whelk).collectResults();
+            var results = new Query(qp, appParams, resourceLookup, esSettings, whelk).collectResults();
 
             @SuppressWarnings("unchecked")
             List<Map<?,?>> items = (List<Map<?,?>>) results.get("items");

--- a/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
+++ b/sru/src/main/java/whelk/sru/servlet/XSearchServlet.java
@@ -244,8 +244,20 @@ public class XSearchServlet extends WhelkHttpServlet {
                 paramsAsIfSearch.put("_sort", new String[]{ sort });
             }
 
+            // FIXME: Get from configuration
+            String freeOnlineFilter = """
+                instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis
+                OR "associatedMedia.marc:publicNote":"fritt tillgänglig"
+                OR usageAndAccessPolicy:("https://id.kb.se/policy/freely-available"
+                OR "https://id.kb.se/policy/oa/gratis"))
+                """;
+            var filterAliases = List.of(
+                    Map.of("alias", "freeOnline",
+                            "filter", freeOnlineFilter)
+            );
+
             QueryParams qp = new QueryParams(paramsAsIfSearch);
-            AppParams ap = new AppParams(new HashMap<>(), whelk.getJsonld());
+            AppParams ap = new AppParams(Map.of("filterAliases", filterAliases), whelk.getJsonld());
             var results = new Query(qp, ap, resourceLookup, esSettings, whelk).collectResults();
 
             @SuppressWarnings("unchecked")

--- a/whelk-core/src/main/groovy/whelk/search2/AppParams.java
+++ b/whelk-core/src/main/groovy/whelk/search2/AppParams.java
@@ -1,6 +1,7 @@
 package whelk.search2;
 
 import whelk.JsonLd;
+import whelk.Whelk;
 import whelk.search2.querytree.FilterAlias;
 import whelk.search2.querytree.Property;
 
@@ -25,6 +26,10 @@ public class AppParams {
         this.sliceList = parseSliceList(appConfig, jsonLd);
         this.filterAliases = parseFilterAliases(appConfig);
         this.filters = parseFilters(appConfig);
+    }
+
+    public AppParams(String appId, Whelk whelk) {
+        this(loadConfig(appId, whelk), whelk.getJsonld());
     }
 
     public Map<String, FilterAlias> getFilterByAlias() {
@@ -207,5 +212,12 @@ public class AppParams {
 
     private static List<Map<String, Object>> getAsListOfMap(Map<String, Object> appConfig, String key) {
         return getAsList(appConfig, key).stream().map(QueryUtil::castToStringObjectMap).toList();
+    }
+
+    private static Map<String, Object> loadConfig(String appId, Whelk whelk) {
+        var data = whelk.loadData(appId);
+        return data != null
+                ? QueryUtil.castToStringObjectMap(JsonLd.findInData(data, appId))
+                : Map.of();
     }
 }


### PR DESCRIPTION
We previously added a hard-coded mapping `MAT:free` -> `freeOnline` for backward compatibility, however it turned out that the `freeOnline` filter wasn't configured in XSearch/SRU. ~This is just a quick-fix; the filter definition should not be hard-coded. Can we put this configuration in [apps.jsonld](https://github.com/libris/definitions/blob/develop/source/apps.jsonld)?~
See configuration in https://github.com/libris/definitions/pull/604