### PR TITLE
All CQL 'strings' must be quoted in the resulting XLQL query.

### DIFF
--- a/sru/src/main/java/whelk/sru/cql/Phase2.java
+++ b/sru/src/main/java/whelk/sru/cql/Phase2.java
@@ -14,21 +14,21 @@ public class Phase2 {
                 return flatten(bg);
             }
             case String s -> {
-
-                String str = s;
-                if (str.startsWith("\"") && str.endsWith("\"")) // Quoted strings come out here quoted, which causes issues.
-                    str = str.substring(1, str.length()-1);
-                // Turns for example "OCH" into "och" (the latter is not a xlql keyword). Case on search is irrelevant in xlql anyway.
-                str = str.toLowerCase();
-
-                str = str.replaceAll(":", "\\\\:");
-
-                return str;
+                return scrubXlQlString(s);
             }
             default -> {
                 return null;
             }
         }
+    }
+
+    /**
+     All 'strings' passed along as part of an XLQL query must be quoted and stripped of internal '\' and '"' chars (so there can be no escape from the quote).
+     */
+    private static String scrubXlQlString(String str) {
+        str = str.replace('\\', ' ');
+        str = str.replace('"', ' ');
+        return "\"" + str.toLowerCase().trim() + "\"";
     }
 
     private static String flatten(Phase1.AstScopedClause scopedClause) {
@@ -58,17 +58,10 @@ public class Phase2 {
     private static String flatten(Phase1.AstSearchClause searchClause) {
         // index, term, relation
 
-        String searchTerm = searchClause.term();
-        if (searchTerm.startsWith("\"") && searchTerm.endsWith("\"")) // Quoted strings come out here quoted, which causes issues.
-            searchTerm = searchTerm.substring(1, searchTerm.length()-1);
-
-        // Turns for example "OCH" into "och" (the latter is not a xlql keyword). Case on search is irrelevant in xlql anyway.
-        searchTerm = searchTerm.toLowerCase();
-
-        searchTerm = searchTerm.replaceAll(":", "\\\\:");
+        String searchTerm = scrubXlQlString(searchClause.term());
 
         if (searchClause.relation() == null) { // no relation also implies no index. It's just searchTerm alone.
-            return " " + searchTerm;
+            return " \"" + searchTerm + "\n";
         }
 
         Phase1.AstRelation relation = searchClause.relation();
@@ -77,12 +70,12 @@ public class Phase2 {
             // "any" means we're searching for any of the words in the searchTerm. So 'any "a b"' means (a or b)
             String[] parts = searchTerm.split("\\s+");
             if (parts.length > 1)
-                searchTerm = "(" + String.join(" OR ", parts) + ")";
+                searchTerm = "(" + String.join("\" OR \"", parts) + ")";
         } else if (relation.comparitor().equals("all")) {
             // "all" means we're searching for all of the words in the searchTerm. So 'all "a b"' means (a and b)
             String[] parts = searchTerm.split("\\s+");
             if (parts.length > 1)
-                searchTerm = "(" + String.join(" AND ", parts) + ")";
+                searchTerm = "(" + String.join("\" AND \"", parts) + ")";
         }
 
         String index = searchClause.index();

--- a/sru/src/main/java/whelk/sru/cql/Phase2.java
+++ b/sru/src/main/java/whelk/sru/cql/Phase2.java
@@ -1,5 +1,7 @@
 package whelk.sru.cql;
 
+import static whelk.search2.parse.Lex.reservedCharsInString;
+
 public class Phase2 {
     public static String flatten(Object ast) {
         switch (ast) {
@@ -22,13 +24,15 @@ public class Phase2 {
         }
     }
 
-    /**
-     All 'strings' passed along as part of an XLQL query must be quoted and stripped of internal '\' and '"' chars (so there can be no escape from the quote).
-     */
     private static String scrubXlQlString(String str) {
+        if (str.startsWith("\"") && str.endsWith("\"")) // Quoted strings come out here quoted, which causes issues.
+            str = str.substring(1, str.length()-1);
+
         str = str.replace('\\', ' ');
-        str = str.replace('"', ' ');
-        return "\"" + str.toLowerCase().trim() + "\"";
+        for (Character c : whelk.search2.parse.Lex.reservedCharsInString) {
+            str = str.replace(c, ' ');
+        }
+        return "(" + str.toLowerCase().trim() + ")";
     }
 
     private static String flatten(Phase1.AstScopedClause scopedClause) {
@@ -61,7 +65,7 @@ public class Phase2 {
         String searchTerm = scrubXlQlString(searchClause.term());
 
         if (searchClause.relation() == null) { // no relation also implies no index. It's just searchTerm alone.
-            return " \"" + searchTerm + "\n";
+            return " (" + searchTerm + ")";
         }
 
         Phase1.AstRelation relation = searchClause.relation();
@@ -70,12 +74,12 @@ public class Phase2 {
             // "any" means we're searching for any of the words in the searchTerm. So 'any "a b"' means (a or b)
             String[] parts = searchTerm.split("\\s+");
             if (parts.length > 1)
-                searchTerm = "(" + String.join("\" OR \"", parts) + ")";
+                searchTerm = "(" + String.join(") OR (", parts) + ")";
         } else if (relation.comparitor().equals("all")) {
             // "all" means we're searching for all of the words in the searchTerm. So 'all "a b"' means (a and b)
             String[] parts = searchTerm.split("\\s+");
             if (parts.length > 1)
-                searchTerm = "(" + String.join("\" AND \"", parts) + ")";
+                searchTerm = "(" + String.join(") AND (", parts) + ")";
         }
 
         String index = searchClause.index();

--- a/sru/src/test/groovy/whelk/sru/cql/CqlToXlSpec.groovy
+++ b/sru/src/test/groovy/whelk/sru/cql/CqlToXlSpec.groovy
@@ -12,7 +12,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"aaa"'
+        translatedXlQuery == '(aaa)'
     }
 
     def "CQL has left-to-right precedence"() {
@@ -22,7 +22,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '(("a" OR "b") AND "c")'
+        translatedXlQuery == '(((a) OR (b)) AND (c))'
     }
 
     def "CQL has left-to-right precedence2"() {
@@ -32,7 +32,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '(("a" AND "b") OR "c")'
+        translatedXlQuery == '(((a) AND (b)) OR (c))'
     }
 
     def "Group bonanza"() {
@@ -42,7 +42,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '(("a" AND ("b" OR "c")) AND "d")'
+        translatedXlQuery == '(((a) AND ((b) OR (c))) AND (d))'
     }
 
     def "any & all"() {
@@ -52,7 +52,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("field1"=("a" OR "b" OR "c") OR "field2"=("c" AND "d" AND "e"))'
+        translatedXlQuery == '("field1"=((a) OR (b) OR (c)) OR "field2"=((c) AND (d) AND (e)))'
     }
 
     def "example query 1"() {
@@ -62,7 +62,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("dc.title"="fish" OR ("dc.creator"="sanderson" AND "dc.identifier"="id:1234567"))'
+        translatedXlQuery == '("dc.title"=(fish) OR ("dc.creator"=(sanderson) AND "dc.identifier"=(id 1234567)))'
     }
 
     def "example query 2, ignore prefix assignments"() {
@@ -72,7 +72,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"dc.title"="fish"'
+        translatedXlQuery == '"dc.title"=(fish)'
     }
 
     def "example query 3, ignore relation modifiers"() {
@@ -82,7 +82,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"dc.title"="fish"'
+        translatedXlQuery == '"dc.title"=(fish)'
     }
 
     def "example query 4, prox is and"() {
@@ -92,7 +92,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("dc.title"="fish" AND "dc.title"="squirrel")'
+        translatedXlQuery == '("dc.title"=(fish) AND "dc.title"=(squirrel))'
     }
 
     def "example query 5, ignore sort"() {
@@ -102,7 +102,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"dinosaur"'
+        translatedXlQuery == '(dinosaur)'
     }
 
     def "hyphens"() {
@@ -112,7 +112,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"978-1-0732-3504-9"'
+        translatedXlQuery == '(978-1-0732-3504-9)'
     }
 
     def "special char"() {
@@ -122,7 +122,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"nånting:"'
+        translatedXlQuery == '(nånting)'
     }
 
     def "+"() {
@@ -132,7 +132,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("bath.isbn"="echo" AND "+main")'
+        translatedXlQuery == '("bath.isbn"=(echo) AND (+main))'
     }
 
     def "xlql keywords"() {
@@ -142,7 +142,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"a eller b och c"'
+        translatedXlQuery == '(a eller b och c)'
     }
 
     def "':' in qutoed string"() {
@@ -152,7 +152,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"title:subtitle"'
+        translatedXlQuery == '(title subtitle)'
     }
 
     def "':' in qutoed string"() {
@@ -162,7 +162,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '(("z3950.1003"="lidbeck, lasse" AND "z3950.7"="9129652634*") AND "z3950.4"="kungar och drottningar i sverige :")'
+        translatedXlQuery == '(("z3950.1003"=(lidbeck, lasse) AND "z3950.7"=(9129652634*)) AND "z3950.4"=(kungar och drottningar i sverige))'
     }
 
     //
@@ -174,7 +174,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("x.title"="dinosaur" AND "aVerySillyLongPrefix.author"="farlow")'
+        translatedXlQuery == '("x.title"=(dinosaur) AND "aVerySillyLongPrefix.author"=(farlow))'
     }
 
     def "failed parse"() {

--- a/sru/src/test/groovy/whelk/sru/cql/CqlToXlSpec.groovy
+++ b/sru/src/test/groovy/whelk/sru/cql/CqlToXlSpec.groovy
@@ -12,7 +12,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == 'aaa'
+        translatedXlQuery == '"aaa"'
     }
 
     def "CQL has left-to-right precedence"() {
@@ -22,7 +22,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '((a OR b) AND c)'
+        translatedXlQuery == '(("a" OR "b") AND "c")'
     }
 
     def "CQL has left-to-right precedence2"() {
@@ -32,7 +32,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '((a AND b) OR c)'
+        translatedXlQuery == '(("a" AND "b") OR "c")'
     }
 
     def "Group bonanza"() {
@@ -42,7 +42,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '((a AND (b OR c)) AND d)'
+        translatedXlQuery == '(("a" AND ("b" OR "c")) AND "d")'
     }
 
     def "any & all"() {
@@ -52,7 +52,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("field1"=(a OR b OR c) OR "field2"=(c AND d AND e))'
+        translatedXlQuery == '("field1"=("a" OR "b" OR "c") OR "field2"=("c" AND "d" AND "e"))'
     }
 
     def "example query 1"() {
@@ -62,7 +62,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("dc.title"=fish OR ("dc.creator"=sanderson AND "dc.identifier"=id\\:1234567))'
+        translatedXlQuery == '("dc.title"="fish" OR ("dc.creator"="sanderson" AND "dc.identifier"="id:1234567"))'
     }
 
     def "example query 2, ignore prefix assignments"() {
@@ -72,7 +72,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"dc.title"=fish'
+        translatedXlQuery == '"dc.title"="fish"'
     }
 
     def "example query 3, ignore relation modifiers"() {
@@ -82,7 +82,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '"dc.title"=fish'
+        translatedXlQuery == '"dc.title"="fish"'
     }
 
     def "example query 4, prox is and"() {
@@ -92,7 +92,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("dc.title"=fish AND "dc.title"=squirrel)'
+        translatedXlQuery == '("dc.title"="fish" AND "dc.title"="squirrel")'
     }
 
     def "example query 5, ignore sort"() {
@@ -102,7 +102,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == 'dinosaur'
+        translatedXlQuery == '"dinosaur"'
     }
 
     def "hyphens"() {
@@ -112,7 +112,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '978-1-0732-3504-9'
+        translatedXlQuery == '"978-1-0732-3504-9"'
     }
 
     def "special char"() {
@@ -122,7 +122,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == 'nånting\\:'
+        translatedXlQuery == '"nånting:"'
     }
 
     def "+"() {
@@ -132,7 +132,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("bath.isbn"=echo AND +main)'
+        translatedXlQuery == '("bath.isbn"="echo" AND "+main")'
     }
 
     def "xlql keywords"() {
@@ -142,7 +142,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == 'a eller b och c'
+        translatedXlQuery == '"a eller b och c"'
     }
 
     def "':' in qutoed string"() {
@@ -152,7 +152,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == 'title\\:subtitle'
+        translatedXlQuery == '"title:subtitle"'
     }
 
     def "':' in qutoed string"() {
@@ -162,7 +162,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '(("z3950.1003"=lidbeck, lasse AND "z3950.7"=9129652634*) AND "z3950.4"=kungar och drottningar i sverige \\:)'
+        translatedXlQuery == '(("z3950.1003"="lidbeck, lasse" AND "z3950.7"="9129652634*") AND "z3950.4"="kungar och drottningar i sverige :")'
     }
 
     //
@@ -174,7 +174,7 @@ class CqlToXlSpec extends Specification {
         String translatedXlQuery = Translation.translateCqlToXlQuery(cqlQuery)
 
         expect:
-        translatedXlQuery == '("x.title"=dinosaur AND "aVerySillyLongPrefix.author"=farlow)'
+        translatedXlQuery == '("x.title"="dinosaur" AND "aVerySillyLongPrefix.author"="farlow")'
     }
 
     def "failed parse"() {

--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -48,7 +48,7 @@ public class Lex {
         }
     }
 
-    private static final List<Character> reservedCharsInString = Arrays.asList('<', '>', '=', '(', ')', ':', '~');
+    public static final List<Character> reservedCharsInString = Arrays.asList('<', '>', '=', '(', ')', ':', '~');
 
     private static Symbol getNextSymbol(StringBuilder query, MutableInteger offset) throws InvalidQueryException {
         consumeWhiteSpace(query, offset);


### PR DESCRIPTION
This is to avoid collisions with XLQL special characters. This replaces a prior temporary solution for ':' alone.