### PR TITLE
Handle revert on non-string values

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -3112,7 +3112,7 @@ class MatchRule {
 
     String matchDomain
 
-    boolean matchValue(String code, String value) {
+    boolean matchValue(String code, Object value) {
         Closure pattern = codePatterns[code]
         if (!pattern)
             return true
@@ -3179,7 +3179,7 @@ class MatchRule {
                     Closure check = null
                     if (comparator == '=~') {
                         def pattern = Pattern.compile(matchValue)
-                        check = codePatterns[code] = { pattern.matcher(it).matches() }
+                        check = codePatterns[code] = { pattern.matcher(it.toString()).matches() }
                     } else {
                         check = codePatterns[code] = { it == matchValue }
                     }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -3179,7 +3179,7 @@ class MatchRule {
                     Closure check = null
                     if (comparator == '=~') {
                         def pattern = Pattern.compile(matchValue)
-                        check = codePatterns[code] = { pattern.matcher(it.toString()).matches() }
+                        check = codePatterns[code] = { it != null && pattern.matcher(it.toString()).matches() }
                     } else {
                         check = codePatterns[code] = { it == matchValue }
                     }


### PR DESCRIPTION
Error cropped up on revert of e.g. https://libris.kb.se/rd4gslvdp3283glj which for some reason contains:
```json5
    {
     // ...
      "publication": [
        {
          // ...
          "year": 1961
        }
      ]
    }
```