### PR TITLE
fix(rest): preserve query string on redirect

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/Crud.java
+++ b/rest/src/main/groovy/whelk/rest/api/Crud.java
@@ -205,7 +205,13 @@ public class Crud extends WhelkHttpServlet {
             sendNotFound(request.getHttpServletRequest(), response);
         } else if (doc == null && loc != null) {
             if (request.getView() == CrudGetRequest.View.DATA) {
-                loc = getDataURI(loc, request);
+                loc = getDataURI(loc, request.getContentType(), null, null);
+            }
+            // Preserve representation parameters (embellished, framed, lens,
+            // computedLabel, _findBlank, ...) so they survive the redirect.
+            String queryString = request.getHttpServletRequest().getQueryString();
+            if (queryString != null && !queryString.isEmpty()) {
+                loc += "?" + queryString;
             }
             sendRedirect(request.getHttpServletRequest(), response, loc);
         } else if (doc != null && doc.getDeleted()) {

--- a/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
+++ b/rest/src/test/groovy/whelk/rest/api/CrudSpec.groovy
@@ -221,6 +221,85 @@ class CrudSpec extends Specification {
         response.getStatus() == HttpServletResponse.SC_FOUND
     }
 
+    def "GET /<sameAs ID> 302 redirect should preserve query parameters"() {
+        given:
+        def id = BASE_URI.resolve("/1234").toString()
+        def altId = BASE_URI.resolve("/alt_1234").toString()
+        request.pathInfo >> {
+            '/' + id
+        }
+        request.getPathInfo() >> {
+            "/${id}".toString()
+        }
+        request.getQueryString() >> {
+            "framed=true&_findBlank=true"
+        }
+        request.getHeader("Accept") >> {
+            "*/*"
+        }
+        storage.load(_, _) >> {
+            return null
+        }
+        storage.loadDocumentByMainId(altId) >> {
+            return null
+        }
+        storage.loadDocumentByMainId(id) >> {
+            new Document(['@graph': [['@id': id, 'sameAs': [['@id': altId]]]]])
+        }
+        storage.getMainId(_) >> {
+            return id
+        }
+        storage.getIdType(_) >> {
+            return IdType.RecordSameAsId
+        }
+        when:
+        crud.doGet(request, response)
+        then:
+        response.getStatus() == HttpServletResponse.SC_FOUND
+        response.getHeader("Location") == id + "?framed=true&_findBlank=true"
+    }
+
+    def "GET /<sameAs ID>/data.jsonld 302 redirect should preserve query parameters without duplicating lens"() {
+        given:
+        def id = BASE_URI.resolve("/1234").toString()
+        def altId = BASE_URI.resolve("/alt_1234").toString()
+        request.pathInfo >> {
+            '/' + id + '/data.jsonld'
+        }
+        request.getPathInfo() >> {
+            "/${id}/data.jsonld".toString()
+        }
+        request.getQueryString() >> {
+            "lens=chip"
+        }
+        request.getParameter("lens") >> {
+            "chip"
+        }
+        request.getHeader("Accept") >> {
+            "*/*"
+        }
+        storage.load(_, _) >> {
+            return null
+        }
+        storage.loadDocumentByMainId(altId) >> {
+            return null
+        }
+        storage.loadDocumentByMainId(id) >> {
+            new Document(['@graph': [['@id': id, 'sameAs': [['@id': altId]]]]])
+        }
+        storage.getMainId(_) >> {
+            return id
+        }
+        storage.getIdType(_) >> {
+            return IdType.RecordSameAsId
+        }
+        when:
+        crud.doGet(request, response)
+        then:
+        response.getStatus() == HttpServletResponse.SC_FOUND
+        response.getHeader("Location") == id + "/data.jsonld?lens=chip"
+    }
+
     def "GET /<id> should return 404 Not Found if document can't be found"() {
         given:
         def id = BASE_URI.resolve("/1234").toString()


### PR DESCRIPTION
Some representational query parameters are dropped on redirect, e.g.
```
~ curl -I "https://libris.kb.se/dqzlcswjbtc76h9v/data.jsonld?framed=true&_findBlank=true"
HTTP/2 302
...
location: https://libris.kb.se/2dlhkd9202xxhjv0/data.jsonld
```
Which causes problems in lxl-web for some records.

So let's preserve all query params when doing redirects and not just chip and profile. (At the point where the redirection happens `CrudGetRequest.parse(request)` has already run `parseLens()` and `parseProfile()` so no need to do it again.)