### PR TITLE
feat(oaipmh): add support for resumptionToken

### DIFF
--- a/oaipmh/src/main/java/whelk/export/servlet/GetRecord.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/GetRecord.java
@@ -78,7 +78,7 @@ public class GetRecord
         try (Connection dbconn = OaiPmh.s_whelk.getStorage().getOuterConnection())
         {
             dbconn.setAutoCommit(false);
-            try (Helpers.ResultIterator it = Helpers.getMatchingDocuments(dbconn, null, null, null, id, false, false))
+            try (Helpers.ResultIterator it = Helpers.getMatchingDocuments(dbconn, null, null, null, id, false, false, null, null, 1))
             {
                 if (!it.hasNext())
                 {

--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -34,11 +34,19 @@ public class Helpers
         private final String mustBeHeldBy;
         private final String explicitSet;
         private final boolean includeDependenciesInTimeInterval;
+        private final int pageSize;
         private final Stack<Document> resultingDocuments = new Stack<>();
         private boolean firstAccess = true;
 
+        // For resumption tokens, to keep track of the last source row consumed. A source row is simply a
+        // row read from lddb. One source row might or might not emit a record (or several), depending on
+        // filtering and dependencies
+        private String lastSourceModified = null;
+        private String lastSourceId = null;
+        private int sourceRowsRead = 0;
+
         public ResultIterator(PreparedStatement statement, String requestedCollection, String mustBeHeldBy,
-                              boolean includeDependenciesInTimeInterval, String explicitSet)
+                              boolean includeDependenciesInTimeInterval, String explicitSet, int pageSize)
                 throws SQLException {
             this.statement = statement;
             this.resultSet = statement.executeQuery();
@@ -46,7 +54,14 @@ public class Helpers
             this.mustBeHeldBy = mustBeHeldBy;
             this.includeDependenciesInTimeInterval = includeDependenciesInTimeInterval;
             this.explicitSet = explicitSet;
+            this.pageSize = pageSize;
         }
+
+        public String getLastSourceModified() { return lastSourceModified; }
+
+        public String getLastSourceId() { return lastSourceId; }
+
+        public boolean isExhausted() { return sourceRowsRead < pageSize; }
 
         private boolean isHeld(Document doc, String bySigel)
         {
@@ -181,7 +196,15 @@ public class Helpers
                     firstAccess = false;
                     while (resultSet.next())
                     {
+                        sourceRowsRead++;
                         String data = resultSet.getString("data");
+
+                        lastSourceId = resultSet.getString("id");
+                        // effective_modified is the value the scan is ordered by (see getIntervalStatement):
+                        // plain 'modified', or GREATEST(modified, generationDate) in the silent-changes path.
+                        Timestamp modified = resultSet.getTimestamp("effective_modified");
+                        lastSourceModified = modified != null
+                                ? modified.toInstant().toString() : null;
 
                         Document updated = new Document(mapper.readValue(data, HashMap.class));
                         emitAffected(updated);
@@ -260,103 +283,85 @@ public class Helpers
         return preparedStatement;
     }
 
-    private static PreparedStatement getOpenIntervalStatement(Connection connection, ZonedDateTime fromDateTime,
-                                                                ZonedDateTime untilDateTime, boolean includeSilentChanges)
+    /**
+     * Builds a keyset-paginated interval scan over lddb.
+     */
+    private static PreparedStatement getIntervalStatement(Connection connection, ZonedDateTime fromDateTime,
+                                                          ZonedDateTime untilDateTime, boolean includeSilentChanges,
+                                                          Timestamp afterModified, String afterId,
+                                                          String explicitSet, int limit)
             throws SQLException
     {
-        PreparedStatement preparedStatement;
-        String sql = "SELECT data FROM lddb WHERE collection in ('bib', 'auth', 'hold')";
+        // By default we go by the modified date, but we support to option to include silent changes.
+        // NOTE/TODO?: No index on GREATEST(modified, totstz(...) so it'll be slow. Unsure if anyone's actually
+        // using this still. If someone is, we might want to add an index.
+        String effectiveModified = includeSilentChanges
+                ? "GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}'))"
+                : "modified";
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT id, " + effectiveModified + " AS effective_modified, data" +
+                " FROM lddb WHERE collection in ('bib', 'auth', 'hold')");
+
+        String explicitSetColumn = explicitSetColumn(explicitSet);
+        if (explicitSetColumn != null)
+            sql.append(" AND ").append(explicitSetColumn).append(" = ? ");
 
         if (fromDateTime != null)
-        {
-            if (includeSilentChanges)
-                sql += " AND ( modified >= ? OR totstz(data#>>'{@graph,0,generationDate}') >= ? ) ";
-            else
-                sql += " AND modified >= ? ";
-        }
+            sql.append(" AND ").append(effectiveModified).append(" >= ? ");
         if (untilDateTime != null)
-        {
-            if (includeSilentChanges)
-                sql += " AND ( modified <= ? OR totstz(data#>>'{@graph,0,generationDate}') <= ? ) ";
-            else
-                sql += " AND modified <= ? ";
-        }
+            sql.append(" AND ").append(effectiveModified).append(" <= ? ");
 
-        preparedStatement = connection.prepareStatement(sql);
+        if (afterModified != null)
+            sql.append(" AND (").append(effectiveModified).append(", id) > (?, ?) ");
+
+        sql.append(" ORDER BY ").append(effectiveModified).append(", id ");
+        sql.append(" LIMIT ").append(limit);
+
+        PreparedStatement preparedStatement = connection.prepareStatement(sql.toString());
         preparedStatement.setFetchSize(512);
+
         int parameterIndex = 1;
+        if (explicitSetColumn != null)
+            preparedStatement.setString(parameterIndex++, explicitSetValue(explicitSet));
         if (fromDateTime != null)
-        {
-            Timestamp fromTimeStamp = new Timestamp(fromDateTime.toInstant().getEpochSecond() * 1000L);
-            preparedStatement.setTimestamp(parameterIndex++, fromTimeStamp);
-            if (includeSilentChanges)
-                preparedStatement.setTimestamp(parameterIndex++, fromTimeStamp);
-        }
+            preparedStatement.setTimestamp(parameterIndex++, new Timestamp(fromDateTime.toInstant().toEpochMilli()));
         if (untilDateTime != null)
+            preparedStatement.setTimestamp(parameterIndex++, new Timestamp(untilDateTime.toInstant().toEpochMilli()));
+        if (afterModified != null)
         {
-            Timestamp untilTimeStamp = new Timestamp(untilDateTime.toInstant().getEpochSecond() * 1000L);
-            preparedStatement.setTimestamp(parameterIndex++, untilTimeStamp);
-            if (includeSilentChanges)
-                preparedStatement.setTimestamp(parameterIndex++, untilTimeStamp);
+            preparedStatement.setTimestamp(parameterIndex++, afterModified);
+            preparedStatement.setString(parameterIndex++, afterId);
         }
 
         return preparedStatement;
     }
 
-    private static PreparedStatement getClosedIntervalStatement(Connection connection, ZonedDateTime fromDateTime,
-                                                      ZonedDateTime untilDateTime, boolean includeSilentChanges)
-            throws SQLException
+    private static String explicitSetColumn(String explicitSet)
     {
-        PreparedStatement preparedStatement;
-        String sql = "SELECT data FROM lddb WHERE collection in ('bib', 'auth', 'hold')";
+        if ("nb".equals(explicitSet))
+            return "data#>>'{@graph,0,encodingLevel}'";
+        if ("sao".equals(explicitSet))
+            return "data#>>'{@graph,1,inScheme,@id}'";
+        return null;
+    }
 
-        if (includeSilentChanges)
-        {
-            sql += " AND ( modified BETWEEN ? AND ? OR totstz(data#>>'{@graph,0,generationDate}') BETWEEN ? AND ? ) ";
-        }
-        else
-        {
-            sql += " AND ( modified BETWEEN ? AND ? ) ";
-        }
-
-        preparedStatement = connection.prepareStatement(sql);
-        preparedStatement.setFetchSize(512);
-
-        Timestamp fromTimeStamp = new Timestamp(fromDateTime.toInstant().getEpochSecond() * 1000L);
-        Timestamp untilTimeStamp = new Timestamp(untilDateTime.toInstant().getEpochSecond() * 1000L);
-        int parameterIndex = 1;
-        preparedStatement.setTimestamp(parameterIndex++, fromTimeStamp);
-        preparedStatement.setTimestamp(parameterIndex++, untilTimeStamp);
-        if (includeSilentChanges)
-        {
-            preparedStatement.setTimestamp(parameterIndex++, fromTimeStamp);
-            preparedStatement.setTimestamp(parameterIndex++, untilTimeStamp);
-        }
-
-        return preparedStatement;
+    private static String explicitSetValue(String explicitSet)
+    {
+        if ("nb".equals(explicitSet))
+            return "marc:FullLevel";
+        if ("sao".equals(explicitSet))
+            return "https://id.kb.se/term/sao";
+        return null;
     }
 
     public static ResultIterator getMatchingDocuments(Connection connection, ZonedDateTime fromDateTime,
                                                       ZonedDateTime untilDateTime, SetSpec setSpec, String id,
                                                       boolean includeDependenciesInTimeInterval,
-                                                      boolean includeSilentChanges)
+                                                      boolean includeSilentChanges,
+                                                      Timestamp afterModified, String afterId, int limit)
             throws SQLException
     {
-        PreparedStatement preparedStatement;
-        if (id == null)
-        {
-            if (fromDateTime == null || untilDateTime == null)
-                preparedStatement = getOpenIntervalStatement(connection, fromDateTime, untilDateTime, includeSilentChanges);
-            else
-                preparedStatement = getClosedIntervalStatement(connection, fromDateTime, untilDateTime, includeSilentChanges);
-        }
-        else
-        {
-            String sql = "SELECT data FROM lddb WHERE id = ?";
-            preparedStatement = connection.prepareStatement(sql);
-            preparedStatement.setString(1, id);
-        }
-
         // Extract requested marc:collection and explicit set, if any, from setSpec
         String requestedCollection = null;
         String mustBeHeldBy = null;
@@ -382,7 +387,20 @@ public class Helpers
             }
         }
 
+        PreparedStatement preparedStatement;
+        if (id == null)
+        {
+            preparedStatement = getIntervalStatement(connection, fromDateTime, untilDateTime,
+                    includeSilentChanges, afterModified, afterId, explicitSet, limit);
+        }
+        else
+        {
+            String sql = "SELECT id, modified AS effective_modified, data FROM lddb WHERE id = ?";
+            preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setString(1, id);
+        }
+
         return new ResultIterator(preparedStatement, requestedCollection, mustBeHeldBy,
-                includeDependenciesInTimeInterval, explicitSet);
+                includeDependenciesInTimeInterval, explicitSet, limit);
     }
 }

--- a/oaipmh/src/main/java/whelk/export/servlet/ListRecords.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ListRecords.java
@@ -7,6 +7,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.sql.*;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
@@ -24,6 +25,10 @@ public class ListRecords
     private final static String DELETED_DATA_PARAM = "x-withDeletedData";
     private final static String INCLUDE_SILENT_PARAM = "x-withSilentUpdates";
 
+    // Number of source rows from lddb to scan per page. One page = one HTTP response,
+    // possibly with a resumptionToken for the next page.
+    private final static int PAGE_SIZE = 1000;
+
     private static final Counter failedRequests = Counter.build()
             .name("oaipmh_failed_listrecords_requests_total").help("Total failed ListRecords requests.")
             .labelNames("error").register();
@@ -40,36 +45,65 @@ public class ListRecords
                                                 boolean onlyIdentifiers)
             throws IOException, XMLStreamException, SQLException
     {
-        // Parse and verify the parameters allowed for this request
-        String from = request.getParameter(FROM_PARAM); // optional
-        String until = request.getParameter(UNTIL_PARAM); // optional
-        String set = request.getParameter(SET_PARAM); // optional
-        String resumptionToken = request.getParameter(RESUMPTION_PARAM); // exclusive, not supported/used
-        String metadataPrefix = request.getParameter(FORMAT_PARAM); // required
+        String resumptionTokenParam = request.getParameter(RESUMPTION_PARAM);
+        String from, until, set, metadataPrefix;
+        boolean withDeletedData, withSilentChanges;
+        Timestamp afterModified = null;
+        String afterId = null;
 
-        // optional and not technically legal OAI-PMH
-        boolean withDeletedData = Boolean.parseBoolean(request.getParameter(DELETED_DATA_PARAM));
-        boolean withSilentChanges = Boolean.parseBoolean(request.getParameter(INCLUDE_SILENT_PARAM));
-
-        if (ResponseCommon.errorOnExtraParameters(request, response,
-                FROM_PARAM, UNTIL_PARAM, SET_PARAM, RESUMPTION_PARAM, FORMAT_PARAM, DELETED_DATA_PARAM, INCLUDE_SILENT_PARAM))
-            return;
-
-        // We do not use resumption tokens.
-        if (resumptionToken != null)
+        if (resumptionTokenParam != null)
         {
-            failedRequests.labels(OaiPmh.OAIPMH_ERROR_BAD_RESUMPTION_TOKEN).inc();
-            ResponseCommon.sendOaiPmhError(OaiPmh.OAIPMH_ERROR_BAD_RESUMPTION_TOKEN,
-                    "No such resumption token was issued", request, response);
-            return;
+            if (ResponseCommon.errorOnExtraParameters(request, response, RESUMPTION_PARAM))
+                return;
+
+            ResumptionToken token = ResumptionToken.parse(resumptionTokenParam);
+            if (token == null)
+            {
+                failedRequests.labels(OaiPmh.OAIPMH_ERROR_BAD_RESUMPTION_TOKEN).inc();
+                ResponseCommon.sendOaiPmhError(OaiPmh.OAIPMH_ERROR_BAD_RESUMPTION_TOKEN,
+                        "The resumptionToken is invalid or has expired.", request, response);
+                return;
+            }
+
+            from = token.from;
+            until = token.until;
+            set = token.set;
+            metadataPrefix = token.metadataPrefix;
+            withDeletedData = token.withDeletedData;
+            withSilentChanges = token.withSilentChanges;
+            if (token.afterModified != null)
+            {
+                afterModified = Timestamp.from(ZonedDateTime.parse(token.afterModified).toInstant());
+                afterId = token.afterId;
+            }
         }
-
-        if (metadataPrefix == null)
+        else
         {
-            failedRequests.labels(OaiPmh.OAIPMH_ERROR_BAD_ARGUMENT).inc();
-            ResponseCommon.sendOaiPmhError(OaiPmh.OAIPMH_ERROR_BAD_ARGUMENT,
-                    "metadataPrefix argument required.", request, response);
-            return;
+            from = request.getParameter(FROM_PARAM); // optional
+            until = request.getParameter(UNTIL_PARAM); // optional
+            set = request.getParameter(SET_PARAM); // optional
+            metadataPrefix = request.getParameter(FORMAT_PARAM); // required
+
+            // optional and not technically legal OAI-PMH
+            withDeletedData = Boolean.parseBoolean(request.getParameter(DELETED_DATA_PARAM));
+            withSilentChanges = Boolean.parseBoolean(request.getParameter(INCLUDE_SILENT_PARAM));
+
+            if (ResponseCommon.errorOnExtraParameters(request, response,
+                    FROM_PARAM, UNTIL_PARAM, SET_PARAM, FORMAT_PARAM, DELETED_DATA_PARAM, INCLUDE_SILENT_PARAM))
+                return;
+
+            if (metadataPrefix == null)
+            {
+                failedRequests.labels(OaiPmh.OAIPMH_ERROR_BAD_ARGUMENT).inc();
+                ResponseCommon.sendOaiPmhError(OaiPmh.OAIPMH_ERROR_BAD_ARGUMENT,
+                        "metadataPrefix argument required.", request, response);
+                return;
+            }
+
+            // If client doesn't supply an "until" parameter, make one and put it in the resumptionToken,
+            // so we can guarantee that the harvest terminates.
+            if (until == null)
+                until = ZonedDateTime.now(ZoneOffset.UTC).toString();
         }
 
         // Was the set selection valid?
@@ -112,11 +146,16 @@ public class ListRecords
             boolean includeDependencies = metadataPrefix.contains(OaiPmh.FORMAT_EXPANDED_POSTFIX) ||
                     metadataPrefix.contains("marcxml");
 
+            ResumptionToken baseToken = new ResumptionToken(from, until, set, metadataPrefix,
+                    withDeletedData, withSilentChanges, null, null);
+
             try (Helpers.ResultIterator resultIterator = Helpers.getMatchingDocuments(dbconn, fromDateTime,
-                    untilDateTime, setSpec, null, includeDependencies, withSilentChanges))
+                    untilDateTime, setSpec, null, includeDependencies, withSilentChanges,
+                    afterModified, afterId, PAGE_SIZE))
             {
                 respond(request, response, metadataPrefix, onlyIdentifiers,
-                        includeDependencies, withDeletedData, resultIterator);
+                        includeDependencies, withDeletedData, resultIterator, baseToken,
+                        resumptionTokenParam != null);
             } finally {
                 dbconn.commit();
             }
@@ -125,11 +164,11 @@ public class ListRecords
 
     private static void respond(HttpServletRequest request, HttpServletResponse response,
                                 String requestedFormat, boolean onlyIdentifiers, boolean embellish,
-                                boolean withDeletedData, Helpers.ResultIterator resultIterator)
+                                boolean withDeletedData, Helpers.ResultIterator resultIterator,
+                                ResumptionToken baseToken, boolean resuming)
             throws IOException, XMLStreamException, SQLException
     {
-        // Is the resultset empty?
-        if (!resultIterator.hasNext())
+        if (!resultIterator.hasNext() && !resuming && resultIterator.isExhausted())
         {
             failedRequests.labels(OaiPmh.OAIPMH_ERROR_NO_RECORDS_MATCH).inc();
             ResponseCommon.sendOaiPmhError(OaiPmh.OAIPMH_ERROR_NO_RECORDS_MATCH, "", request, response);
@@ -153,7 +192,32 @@ public class ListRecords
                     onlyIdentifiers, embellish, withDeletedData);
         }
 
+        writeResumptionToken(writer, resultIterator, baseToken, resuming);
+
         writer.writeEndElement(); // ListIdentifiers/ListRecords
         ResponseCommon.writeOaiPmhClose(writer, request);
+    }
+
+    private static void writeResumptionToken(XMLStreamWriter writer, Helpers.ResultIterator resultIterator,
+                                             ResumptionToken baseToken, boolean resuming)
+            throws XMLStreamException
+    {
+        // If we've previously emitted a non-empty resumptionToken and there are no more records,
+        // then per the spec we have to end with an empty resumptionToken.
+        if (resultIterator.isExhausted())
+        {
+            if (resuming)
+            {
+                writer.writeStartElement("resumptionToken");
+                writer.writeEndElement();
+            }
+            return;
+        }
+
+        ResumptionToken next = baseToken.withCursor(
+                resultIterator.getLastSourceModified(), resultIterator.getLastSourceId());
+        writer.writeStartElement("resumptionToken");
+        writer.writeCharacters(next.toToken());
+        writer.writeEndElement();
     }
 }

--- a/oaipmh/src/main/java/whelk/export/servlet/ResumptionToken.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ResumptionToken.java
@@ -1,0 +1,91 @@
+package whelk.export.servlet;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static whelk.util.Jackson.mapper;
+
+/**
+ * Stateless OAI-PMH resumptionToken.
+ *
+ * All state needed to resume a ListRecords/ListIdentifiers harvest is encoded into the Base64-encoded
+ * token itself.
+ */
+public class ResumptionToken
+{
+    // Original request parameters
+    public final String from;            // ISO8601 or null
+    public final String until;           // ISO8601, never null (frozen to now() on the first request)
+    public final String set;             // setSpec or null
+    public final String metadataPrefix;  // never null
+    public final boolean withDeletedData;
+    public final boolean withSilentChanges;
+
+    // Keyset cursor: (modified, id) of the last source row consumed from lddb
+    public final String afterModified;   // ISO8601 timestamp string, or null before the first row
+    public final String afterId;         // lddb.id, or null before the first row
+
+    public ResumptionToken(String from, String until, String set, String metadataPrefix,
+                           boolean withDeletedData, boolean withSilentChanges,
+                           String afterModified, String afterId) {
+        this.from = from;
+        this.until = until;
+        this.set = set;
+        this.metadataPrefix = metadataPrefix;
+        this.withDeletedData = withDeletedData;
+        this.withSilentChanges = withSilentChanges;
+        this.afterModified = afterModified;
+        this.afterId = afterId;
+    }
+
+    public static ResumptionToken parse(String token) {
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(token);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> m = mapper.readValue(new String(decoded, StandardCharsets.UTF_8), HashMap.class);
+
+            // until and metadataPrefix are mandatory in any valid token.
+            if (m.get("u") == null || m.get("p") == null)
+                return null;
+
+            return new ResumptionToken(
+                    (String) m.get("f"),
+                    (String) m.get("u"),
+                    (String) m.get("s"),
+                    (String) m.get("p"),
+                    Boolean.TRUE.equals(m.get("d")),
+                    Boolean.TRUE.equals(m.get("c")),
+                    (String) m.get("am"),
+                    (String) m.get("ai"));
+        } catch (IllegalArgumentException | IOException e) {
+            return null;
+        }
+    }
+
+    public String toToken() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("u", until);
+        m.put("p", metadataPrefix);
+        if (from != null) m.put("f", from);
+        if (set != null) m.put("s", set);
+        if (withDeletedData) m.put("d", true);
+        if (withSilentChanges) m.put("c", true);
+        if (afterModified != null) m.put("am", afterModified);
+        if (afterId != null) m.put("ai", afterId);
+
+        try {
+            byte[] json = mapper.writeValueAsBytes(m);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public ResumptionToken withCursor(String newAfterModified, String newAfterId) {
+        return new ResumptionToken(from, until, set, metadataPrefix, withDeletedData, withSilentChanges,
+                newAfterModified, newAfterId);
+    }
+}

--- a/oaipmh/src/test/java/whelk/export/servlet/ResumptionTokenTest.java
+++ b/oaipmh/src/test/java/whelk/export/servlet/ResumptionTokenTest.java
@@ -1,0 +1,106 @@
+package whelk.export.servlet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ResumptionTokenTest
+{
+    @Test
+    public void roundTripsAllFields()
+    {
+        ResumptionToken token = new ResumptionToken(
+                "2020-01-01T00:00:00Z", "2026-06-16T10:00:00Z", "bib:S", "marcxml",
+                true, true, "2021-03-04T08:00:00.123Z", "abcd1234");
+
+        ResumptionToken parsed = ResumptionToken.parse(token.toToken());
+
+        assertNotNull(parsed);
+        assertEquals("2020-01-01T00:00:00Z", parsed.from);
+        assertEquals("2026-06-16T10:00:00Z", parsed.until);
+        assertEquals("bib:S", parsed.set);
+        assertEquals("marcxml", parsed.metadataPrefix);
+        assertTrue(parsed.withDeletedData);
+        assertTrue(parsed.withSilentChanges);
+        assertEquals("2021-03-04T08:00:00.123Z", parsed.afterModified);
+        assertEquals("abcd1234", parsed.afterId);
+    }
+
+    @Test
+    public void roundTripsMinimalFields()
+    {
+        // No from/set/flags, no cursor yet (as on the very first page).
+        ResumptionToken token = new ResumptionToken(
+                null, "2026-06-16T10:00:00Z", null, "oai_dc", false, false, null, null);
+
+        ResumptionToken parsed = ResumptionToken.parse(token.toToken());
+
+        assertNotNull(parsed);
+        assertNull(parsed.from);
+        assertEquals("2026-06-16T10:00:00Z", parsed.until);
+        assertNull(parsed.set);
+        assertEquals("oai_dc", parsed.metadataPrefix);
+        assertFalse(parsed.withDeletedData);
+        assertFalse(parsed.withSilentChanges);
+        assertNull(parsed.afterModified);
+        assertNull(parsed.afterId);
+    }
+
+    @Test
+    public void withCursorPreservesRequestAndAdvancesPosition()
+    {
+        ResumptionToken base = new ResumptionToken(
+                "2020-01-01T00:00:00Z", "2026-06-16T10:00:00Z", "auth", "rdfxml", false, false, null, null);
+
+        ResumptionToken advanced = base.withCursor("2022-05-05T00:00:00Z", "xyz");
+
+        assertEquals(base.from, advanced.from);
+        assertEquals(base.until, advanced.until);
+        assertEquals(base.set, advanced.set);
+        assertEquals(base.metadataPrefix, advanced.metadataPrefix);
+        assertEquals("2022-05-05T00:00:00Z", advanced.afterModified);
+        assertEquals("xyz", advanced.afterId);
+    }
+
+    @Test
+    public void parseRejectsGarbage()
+    {
+        assertNull(ResumptionToken.parse("not-a-valid-token!!!"));
+        assertNull(ResumptionToken.parse(""));
+    }
+
+    @Test
+    public void parseRejectsTokenMissingMandatoryFields()
+    {
+        // Valid Base64URL JSON, but missing the mandatory 'until' (u) and 'metadataPrefix' (p).
+        String json = "{\"f\":\"2020-01-01T00:00:00Z\"}";
+        String encoded = java.util.Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        assertNull(ResumptionToken.parse(encoded));
+    }
+
+    @Test
+    public void tokenIsUrlSafe()
+    {
+        // A token is handed back to harvesters verbatim in a URL; it must not contain characters
+        // that would need further escaping.
+        ResumptionToken token = new ResumptionToken(
+                null, "2026-06-16T10:00:00Z", "hold:Some/Sigel+Weird", "marcxml_expanded",
+                false, false, "2021-03-04T08:00:00.123Z", "id/with+chars");
+
+        String encoded = token.toToken();
+        assertFalse(encoded.contains("+"));
+        assertFalse(encoded.contains("/"));
+        assertFalse(encoded.contains("="));
+
+        ResumptionToken parsed = ResumptionToken.parse(encoded);
+        assertNotNull(parsed);
+        assertEquals("hold:Some/Sigel+Weird", parsed.set);
+        assertEquals("id/with+chars", parsed.afterId);
+    }
+}


### PR DESCRIPTION
Most OAI-PMH server implementations limit the number of records per HTTP response to something like 100 or 1000 and use [resumptionToken](https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl) for pagination. We haven't had support for this, which has caused problems for some users doing heavy requests that never finish properly. So let's add it. This implementation is stateless and encodes all the necessary stuff in the resumptionToken sent to the client.

I've done some local testing but will also add some tests to https://github.com/libris/lxl_api_tests.

Not sure if `x-withSilentUpdates` is still necessary (it's not publicly documented) but I kept it around for now. `x-withSilentUpdates` is probably a little slower now, but we can add an index if it's an issue.

https://kbse.atlassian.net/browse/LXL-4808