### PR TITLE
fix(remotesearchapi): don't try to serialize empty GPathResult; warning instead of error on exception

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.java
+++ b/rest/src/main/groovy/whelk/rest/api/RemoteSearchAPI.java
@@ -491,13 +491,13 @@ public class RemoteSearchAPI extends WhelkHttpServlet {
                 }
             }
         } catch (Exception e) {
-            log.error("Error extracting XML record strings", e);
+            log.warn("Error extracting XML record strings", e);
         }
         return xmlRecs;
     }
 
     String createString(GPathResult root) {
-        if (root == null) {
+        if (root == null || root.size() == 0) {
             return "";
         }
         return XmlUtil.serialize(root);


### PR DESCRIPTION
(because tired of seeing "ERROR whelk.rest.api.RemoteSearchAPI - Error extracting XML record strings" which happens when we run `XmlUtil.serialize()` on empty XML which causes an exception)