### PR TITLE
Handle cyclic categories in BibTypeNormalizationStep

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -225,12 +225,21 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     // TODO: optimize by returning result *Map* (check only id in keys unless more is needed)
     Collection<Map<String, Object>> getCategoryOfType(List<Map<String, Object>> categories, String type, boolean keepImplied=false) {
         var result = new LinkedHashMap()
-        collectCategoryOfType(categories, type, keepImplied, result)
+        var seen = new HashSet<String>()
+        aggregateCategoryOfType(categories, seen, type, keepImplied, result)
         return result.values().toList()
     }
 
-    private void collectCategoryOfType(List<Map<String, Object>> categories, String type, boolean keepImplied, Map<String, Map<String, Object>> result) {
+    private void aggregateCategoryOfType(List<Map<String, Object>> categories, Set<String> seen, String type, boolean keepImplied, Map<String, Map<String, Object>> result) {
         for (Map<String, Object> ctg : categories) {
+            if (ID in ctg) {
+              var id = ctg[ID]
+              if (id in seen) {
+                continue
+              }
+              seen << id
+            }
+
             if (
                 asList(ctg[TYPE]).any { t -> isSubClassOf(t, type) }
                 || isComplexSubjectWithFirstTermOfType(ctg, type)
@@ -238,6 +247,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
                 def key = ctg[ID] ?: '_:b' + result.size().toString() // id or throwaway fake blank id
                 result[key] = ctg
             }
+
             for (rel in matchRelations) {
                 var implied = getDescriptions(ctg[rel], true)
                 if (!keepImplied) {
@@ -251,18 +261,20 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
                         }
                     }
                 }
-                collectCategoryOfType(implied, type, keepImplied, result)
+                aggregateCategoryOfType(implied, seen, type, keepImplied, result)
             }
         }
     }
 
     Set<String> collectImpliedTypesFromCategory(List<Map<String, Object>> categories) {
       var result = new HashSet<String>()
-      collectImpliedTypesFromCategory(categories, result)
+      var seen = new HashSet<String>()
+      aggregateImpliedTypesFromCategory(categories, seen, result)
       return result
     }
-    void collectImpliedTypesFromCategory(List<Map<String, Object>> categories, Set<String> result) {
-        // TODO: if multiple types, select one (e.g. prefer Text over StillImage?)
+
+    private void aggregateImpliedTypesFromCategory(List<Map<String, Object>> categories, Set<String> seen, Set<String> result) {
+        // TODO: break on preferred type? (e.g. prioritizedWorkLegacyTypes)
         for (ctg in categories) {
           var type = categoryTypeMap[ctg[ID]]
           if (type) {
@@ -273,7 +285,13 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         // (but less optimal for lots of categories)
         for (rel in matchRelations) {
             for (category in categories) {
-                collectImpliedTypesFromCategory(getDescriptions(category[rel]), result)
+                var id = category[ID]
+                var key = rel + ':' + id
+                if (key in seen) {
+                  continue
+                }
+                seen << key
+                aggregateImpliedTypesFromCategory(getDescriptions(category[rel]), seen, result)
             }
         }
     }

--- a/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
@@ -1,0 +1,46 @@
+package whelk.converter.marc
+
+import spock.lang.Specification
+
+class BibTypeNormalizationStepSpec extends Specification {
+
+  static Map testCategories = [
+    '_:gf1': ['@id': '_:gf1', '@type': 'GenreForm'],
+    '_:gf2': ['@id': '_:gf2', '@type': 'GenreForm', 'broader': [['@id': '_:gf1']]],
+    '_:gf3': ['@id': '_:gf3', '@type': 'GenreForm', 'closeMatch': [['@id': '_:gf4']]],
+    '_:gf4': ['@id': '_:gf4', '@type': 'GenreForm', 'closeMatch': [['@id': '_:gf3']]],  // cycle!
+    '_:gf5': ['@id': '_:gf5', '@type': 'GenreForm'],
+  ]
+
+  // subclass to overcome too coupled components (JsonLd and ResourceCache)
+  static var bibTypeNormalizationStep = new BibTypeNormalizationStep() {
+    boolean isSubClassOf(Object givenType, String baseType) {
+        return givenType == baseType
+    }
+    List<Map<String, Object>> getDescriptions(Object refs, boolean onlyLinked=false) {
+        return refs.collect { testCategories[it['@id']] }
+    }
+  }
+
+  static {
+    bibTypeNormalizationStep.matchRelations = ['broader', 'closeMatch']
+    bibTypeNormalizationStep.prioritizedWorkLegacyTypes = ['Multimedia', 'Text']
+    bibTypeNormalizationStep.marcTypeMappings = [:]
+    bibTypeNormalizationStep.categoryTypeMap = [
+        '_:gf3': 'Text',
+        '_:gf5': 'Image',
+    ]
+  }
+
+  def "should collect categories by type"() {
+      given:
+      def workCategories = testCategories.values() as List
+      when:
+      def categories = bibTypeNormalizationStep.getCategoryOfType(workCategories, 'GenreForm', true)
+      def impliedTypes = bibTypeNormalizationStep.collectImpliedTypesFromCategory(categories)
+      then:
+      impliedTypes == ['Text', 'Image'] as Set
+      and:
+      bibTypeNormalizationStep.getWorkType(workCategories) == 'Text'
+  }
+}


### PR DESCRIPTION
This should work, and avoids introducing a bug that would fail to get all candidates and therefore not honor `prioritizedWorkLegacyTypes`.

Also includes a basic unit test.