### PR TITLE
Static-compile all major runtime MarcFrameConverter logic

### DIFF
--- a/whelk-core/src/main/groovy/whelk/ResourceCache.groovy
+++ b/whelk-core/src/main/groovy/whelk/ResourceCache.groovy
@@ -27,6 +27,10 @@ class ResourceCache {
       this.jsonld = jsonld
     }
 
+    JsonLd getJsonld() {
+      return jsonld
+    }
+
     ResourceCache(Whelk whelk, LanguageLinker languageLinker, BlankNodeLinker relatorLinker) {
         this.whelk = whelk
         this.jsonld = whelk.jsonld

--- a/whelk-core/src/main/groovy/whelk/TypeCategoryNormalizer.groovy
+++ b/whelk-core/src/main/groovy/whelk/TypeCategoryNormalizer.groovy
@@ -1,14 +1,17 @@
 package whelk
 
+import groovy.transform.CompileStatic
+
 import java.util.stream.Collectors
 
 import static whelk.JsonLd.ID_KEY as ID
 import static whelk.JsonLd.TYPE_KEY as TYPE
 import static whelk.JsonLd.asList
 
+@CompileStatic
 class TypeCategoryNormalizer {
 
-    static Map SCHEMES = [
+    static Map<String, String> SCHEMES = [
       saogf: 'https://id.kb.se/term/saogf',
       barngf: 'https://id.kb.se/term/barngf',
       tgm: 'https://id.kb.se/term/gmgpc/swe',
@@ -31,7 +34,7 @@ class TypeCategoryNormalizer {
     List<String> newWorkTypes = ["Monograph", "Serial", "Collection", "Integrating"]
     List<String> newInstanceTypes = ['PhysicalResource', 'DigitalResource']
 
-    Map remappedLegacyInstanceTypes = [
+    Map<String, Map<String, String>> remappedLegacyInstanceTypes = [
       'SoundRecording': [category: 'https://id.kb.se/term/saobf/SoundStorageMedium', workCategory: 'https://id.kb.se/term/ktg/Audio'],  // 170467
       'VideoRecording': [category: 'https://id.kb.se/term/saobf/VideoStorageMedium', workCategory: 'https://id.kb.se/term/ktg/MovingImage'],  // 20515
       'Map': [workCategory: 'https://id.kb.se/term/rda/CartographicImage'],  // 12686
@@ -61,11 +64,12 @@ class TypeCategoryNormalizer {
 
             type = jsonld.toTermKey(term[ID])
 
-            if (term.intersectionOf) {
+            def intersectionOf = term.intersectionOf
+            if (intersectionOf instanceof List) {
                 if (!isWorkOrInstanceClass(type)) {
                     var expectedbase = false
-                    for (item in term.intersectionOf) {
-                        if (ID in item && isWorkOrInstanceClass(jsonld.toTermKey(item[ID]))) {
+                    for (def item : intersectionOf) {
+                        if (item instanceof Map && ID in item && isWorkOrInstanceClass(jsonld.toTermKey(item[ID]))) {
                             expectedbase = true
                         }
                     }
@@ -73,7 +77,7 @@ class TypeCategoryNormalizer {
                         continue
                     }
                 }
-                catRestriction = term.intersectionOf.find { isCategoryRestriction(it) }
+                catRestriction = intersectionOf.find { isCategoryRestriction(it) }
             } else if (term.equivalentClass || term.isSubClassOf) {
                 if (!isWorkOrInstanceClass(type)) {
                   continue
@@ -105,8 +109,12 @@ class TypeCategoryNormalizer {
         return false
     }
 
-    boolean isCategoryRestriction(Map term) {
-        return term?.onProperty && term?.onProperty[ID] == categoryPropertyId
+    boolean isCategoryRestriction(Object term) {
+        if (term !instanceof Map) {
+          return false
+        }
+        var onProperty = term.onProperty
+        return onProperty instanceof Map && onProperty[ID] == categoryPropertyId
     }
 
     void loadCategories() {
@@ -127,10 +135,12 @@ class TypeCategoryNormalizer {
 
         for (ctg in categories.values()) {
 
-            String id = ctg[ID]
+            var id = (String) ctg[ID]
 
             for (same in asList(ctg['sameAs'])) {
-                sameAsMap[same[ID]] = id
+                if (same instanceof Map) {
+                  sameAsMap[(String) same[ID]] = id
+                }
             }
 
             String scheme = ctg.inScheme?[ID]
@@ -138,10 +148,12 @@ class TypeCategoryNormalizer {
                 scheme = id.split('/[^/]+$')[0]
             }
 
-            def closeMatch = asList(ctg.closeMatch).findResults { if (ID in it) categories[it[ID]] }
-            def exactMatch = asList(ctg.exactMatch).findResults { if (ID in it) categories[it[ID]] }
-            def broadMatch = asList(ctg.broadMatch).findResults { if (ID in it) categories[it[ID]] }
-            def broader = asList(ctg.broader).findResults { if (ID in it) categories[it[ID]] }
+            var getCategory =  { if (it instanceof Map && ID in it) categories[it[ID]] }
+
+            def closeMatch = asList(ctg.closeMatch).findResults(getCategory)
+            def exactMatch = asList(ctg.exactMatch).findResults(getCategory)
+            def broadMatch = asList(ctg.broadMatch).findResults(getCategory)
+            def broader = asList(ctg.broader).findResults(getCategory)
 
             for (match in closeMatch + exactMatch) {
                 String matchId = match[ID]
@@ -165,18 +177,22 @@ class TypeCategoryNormalizer {
             for (broadTerm in exactMatch + closeMatch + broadMatch + broader) {
                 String broadTermScheme = broadTerm.inScheme?[ID]
                 if (!broadTermScheme) {
-                    broadTermScheme = broadTerm[ID].split('/[^/]+$')[0]
+                    var broadId = (String) broadTerm[ID]
+                    broadTermScheme = broadId.split('/[^/]+$')[0]
                 }
 
                 if (broadTermScheme in broaderSchemes) {
                     categoryMatches.get(id, []) << broadTerm[ID]
-                    categoryMatches.get(id).sort().unique()
+                    var matches = categoryMatches.get(id)
+                    if (matches instanceof List) {
+                      categoryMatches[id] = matches.sort().unique()
+                    }
                 }
             }
         }
     }
 
-    List reduceSymbols(List symbols) {
+    List reduceSymbols(List<Map> symbols) {
         symbols = symbols.stream()
                 .map(x -> x.containsKey(ID)
                         ? [(ID): sameAsMap.getOrDefault(x[ID], x[ID])]
@@ -189,14 +205,14 @@ class TypeCategoryNormalizer {
 
         var mostSpecific = [:]
         var blanks = []
-        for (Map x : symbols) {
+        for (var x : symbols) {
             if (ID !in x) {
                 blanks << x
                 continue
             }
             String xId = x[ID]
             var implied = false
-            for (Map y : symbols) {
+            for (var y : symbols) {
                 if (ID !in y) continue
                 String yId = y[ID]
                 if (xId != yId && isImpliedBy(xId, yId)) {
@@ -236,7 +252,7 @@ class TypeCategoryNormalizer {
 
         List bases = categoryMatches[yId]
         for (var base in bases) {
-            if (base !in visited) {
+            if (base instanceof String && base !in visited) {
               if (isImpliedByRecursive(xId, base, visited + new HashSet())) {
                   return true
               }

--- a/whelk-core/src/main/groovy/whelk/converter/BibTypeNormalizer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/BibTypeNormalizer.groovy
@@ -1,5 +1,7 @@
 package whelk.converter
 
+import groovy.transform.CompileStatic
+
 import java.util.regex.Pattern
 
 import whelk.ResourceCache
@@ -11,6 +13,7 @@ import static whelk.JsonLd.TYPE_KEY as TYPE
 import static whelk.JsonLd.asList
 import static whelk.JsonLd.isLink
 
+@CompileStatic
 class BibTypeNormalizer {
 
     static final var ANNOTATION = '@annotation'
@@ -70,7 +73,7 @@ class BibTypeNormalizer {
                     // Always keep old instance type
                     value.put(TYPE, "Instance")
                     // Since we typically can't tell if Electronic ones are digital or not, don't assume
-                    if (value.category) {
+                    if (value.category instanceof List) {
                         if (value.category.removeAll { it['@id'] == "https://id.kb.se/term/saobf/ElectronicStorageMedium" }) {
                             value.get('category', []) << [(ID): SAOBF + 'AbstractElectronic']
                         }
@@ -101,10 +104,11 @@ class BibTypeNormalizer {
         } else {
             var mappedTypes = normalizer.remappedLegacyInstanceTypes[itype]
             if (mappedTypes) {
-                if (mappedTypes.workCategory.contains('/rda/')) {
-                    work.get('contentType', []) << [(ID): mappedTypes.workCategory]
+                var workCategory = mappedTypes.workCategory
+                if (workCategory.contains('/rda/')) {
+                    work.get('contentType', []) << [(ID): workCategory]
                 } else {
-                    work.get('genreForm', []) << [(ID): mappedTypes.workCategory]
+                    work.get('genreForm', []) << [(ID): workCategory]
                 }
                 if (mappedTypes?.category) {
                     instance.get('carrierType', []) << [(ID): mappedTypes.category]
@@ -195,7 +199,7 @@ class BibTypeNormalizer {
             work.get('genreForm', []) << [(ID): SAOGF + 'Handskrifter']
             work.get('contentType', []) << [(ID): KBRDA + 'NotatedMusic']
         } else if (wtype == 'Cartography') {
-            if (!work['contentType'].any { it[ID]?.startsWith(KBRDA + 'Cartographic') }) {
+            if (!work['contentType'].any { it instanceof Map && ((String) it[ID])?.startsWith(KBRDA + 'Cartographic') }) {
                 work.get('contentType', []) << [(ID): KBRDA + 'CartographicImage'] // TODO: good enough guess?
             }
         } else {
@@ -211,7 +215,7 @@ class BibTypeNormalizer {
         var workGenreForms = normalizer.reduceSymbols(asList(work.get("genreForm")))
 
         // Replace genreForm and contentType properties with category
-        List<String> categories = []
+        List<Map> categories = []
         categories += workGenreForms + contentTypes
         work.remove("genreForm")
         work.remove("contentType")
@@ -244,7 +248,7 @@ class BibTypeNormalizer {
         categories += carrierTypes
 
         // Remove the ambiguous NARC term Other
-        categories.removeAll { it['@id'] == "https://id.kb.se/marc/Other" }
+        categories.removeAll { it[ID] == "https://id.kb.se/marc/Other" }
 
         instance.remove("carrierType")
         instance.remove("mediaType")
@@ -297,7 +301,7 @@ class BibTypeNormalizer {
 
         // resourceCache.get("https://id.kb.se/term/saobf/Braille").closeMatch.findResults { it[ID] } ==
         var legacyBrailleCategories = [MARC + "Braille", MARC + "TacMaterialType-b", MARC + "TextMaterialType-c"] as Set
-        var nonBrailleCarrierTypes = carrierTypes.findAll { !legacyBrailleCategories.contains(it.get(ID)) }
+        var nonBrailleCarrierTypes = carrierTypes.findAll { it instanceof Map && !legacyBrailleCategories.contains(it.get(ID)) }
         if (nonBrailleCarrierTypes.size() < carrierTypes.size()) {
             isBraille = true
             //carrierTypes = nonBrailleCarrierTypes
@@ -351,10 +355,14 @@ class BibTypeNormalizer {
     boolean moveInstanceGenreFormsToWork(Map instance, Map work) {
         var changed = false
 
-        var instanceGenreForms = asList(instance.get("genreForm"))
+        var instanceGenreForms = (List<Map>) asList(instance.get("genreForm"))
 
         var instanceGenreFormsToMove = instanceGenreForms.findAll {
-            isLink(it) && (it.'@id'?.startsWith('https://id.kb.se/term/barngf') || it.'@id'?.startsWith('https://id.kb.se/term/saogf'))
+            if (it !instanceof Map || !isLink(it)) {
+              return false
+            }
+            var id = (String) it[ID]
+            return id.startsWith('https://id.kb.se/term/barngf') || id.startsWith('https://id.kb.se/term/saogf')
         }
 
         var instanceGenreFormsToKeep  = instanceGenreForms - instanceGenreFormsToMove
@@ -384,7 +392,7 @@ class BibTypeNormalizer {
     }
 
     boolean looksLikeVolume(Map instance) {
-        for (extent in asList(instance.get("extent"))) {
+        for (extent in (List<Map>) asList(instance.get("extent"))) {
             for (label in asList(extent.get("label"))) {
                 if (label instanceof String && label.matches(/(?i).*\s(s|p|sidor|pages|vol(ym(er)?)?)\b\.?/)) {
                     return true
@@ -418,7 +426,7 @@ class BibTypeNormalizer {
     }
 
     protected static void reorderForReadability(Map thing) {
-        var copy = thing.clone()
+        var copy = new HashMap(thing)
         thing.clear()
         for (var key : [ID, TYPE, 'sameAs', 'category']) {
             if (key in copy) thing[key] = copy[key]

--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -1,6 +1,6 @@
 package whelk.converter.marc
 
-//import groovy.transform.CompileStatic
+import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2 as Log
 
 import whelk.TypeCategoryNormalizer
@@ -10,13 +10,14 @@ import whelk.util.DocumentUtil
 
 import static whelk.JsonLd.asList
 
-//@CompileStatic
 @Log
+@CompileStatic
 class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     boolean requiresResources = true
 
     BibTypeNormalizer bibTypeNormaliser
+    TypeCategoryNormalizer typeCategoryNormalizer
 
     // Injected configuration
     List<String> matchRelations = Collections.emptyList()
@@ -39,6 +40,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
 
         bibTypeNormaliser = new BibTypeNormalizer(resourceCache)
+        typeCategoryNormalizer = bibTypeNormaliser.normalizer
 
         issuanceTypeSet.addAll(newWorkTypes)
 
@@ -47,10 +49,6 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
 
         keepMatchingWithCategoriesSet.addAll(keepMatchingWithCategories)
-    }
-
-    TypeCategoryNormalizer getTypeCategoryNormalizer() {
-        return bibTypeNormaliser.normalizer
     }
 
     boolean checkRequired() {
@@ -67,7 +65,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
             return
         }
 
-        bibTypeNormaliser.normalize(thing, thing.instanceOf)
+        bibTypeNormaliser.normalize(thing, (Map) thing.instanceOf)
     }
 
     void unmodify(Map record, Map instance) {
@@ -101,7 +99,9 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         instance.remove('category')
 
         // Mutate into legacy form:
-        def issuanceType = getIssuanceType(work[TYPE], instance[TYPE], workCategories, instanceCategories)
+        var wtype = (String) work[TYPE]
+        var itype = (String) instance[TYPE]
+        def issuanceType = getIssuanceType(wtype, itype, workCategories, instanceCategories)
         reshapeToLegacyWork(work, workCategories)
         reshapeToLegacyInstance(instance, workCategories, instanceCategories)
         instance.issuanceType = issuanceType ?: 'Monograph'
@@ -154,8 +154,8 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
         if (itype == null) {
             typeCategoryNormalizer.remappedLegacyInstanceTypes.each { ruletype, rule ->
-                if (typeCategoryNormalizer.anyImplies(instanceCategories, rule.category)) {
-                    if (typeCategoryNormalizer.anyImplies(workCategories, rule.workCategory)) {
+                if (typeCategoryNormalizer.anyImplies(instanceCategories, (String) rule.category)) {
+                    if (typeCategoryNormalizer.anyImplies(workCategories, (String) rule.workCategory)) {
                         itype = ruletype
                     }
                 }
@@ -171,14 +171,15 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     }
 
     List<Map<String, Object>> getDescriptions(Object refs, boolean onlyLinked=false) {
-        return (List<Map<String, Object>>) asList(refs).findResults {
+        var refList = (List<Map>) asList(refs)
+        return (List<Map<String, Object>>) refList.findResults {
             ID in it && it[ID] in typeCategoryNormalizer.categories
                 ? new HashMap(typeCategoryNormalizer.categories[it[ID]])
                 : onlyLinked ? null : it
         }
     }
 
-    String getIssuanceType(String workType, String instanceType, List workCategories, List instanceCategories) {
+    String getIssuanceType(String workType, String instanceType, List<Map> workCategories, List<Map> instanceCategories) {
         if (instanceCategories.any { it[ID] == componentPartCategory}) {
           return 'ComponentPart'
         }
@@ -214,7 +215,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     boolean isComplexSubjectWithFirstTermOfType(Map term, String baseType) {
         if (term[TYPE] == 'ComplexSubject') {
-            def termComponentList = asList(term['termComponentList'])
+            var termComponentList = (List<Map>) asList(term['termComponentList'])
             if (termComponentList.size() > 0) {
                 return isSubClassOf(termComponentList[0][TYPE], type)
             }
@@ -224,7 +225,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
 
     // TODO: optimize by returning result *Map* (check only id in keys unless more is needed)
     Collection<Map<String, Object>> getCategoryOfType(List<Map<String, Object>> categories, String type, boolean keepImplied=false) {
-        var result = new LinkedHashMap()
+        var result = new LinkedHashMap<String, Map>()
         var seen = new HashSet<String>()
         aggregateCategoryOfType(categories, seen, type, keepImplied, result)
         return result.values().toList()
@@ -233,7 +234,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     private void aggregateCategoryOfType(List<Map<String, Object>> categories, Set<String> seen, String type, boolean keepImplied, Map<String, Map<String, Object>> result) {
         for (Map<String, Object> ctg : categories) {
             if (ID in ctg) {
-              var id = ctg[ID]
+              var id = (String) ctg[ID]
               if (id in seen) {
                 continue
               }
@@ -244,7 +245,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
                 asList(ctg[TYPE]).any { t -> isSubClassOf(t, type) }
                 || isComplexSubjectWithFirstTermOfType(ctg, type)
             ) {
-                def key = ctg[ID] ?: '_:b' + result.size().toString() // id or throwaway fake blank id
+                var key = (String) ctg[ID] ?: '_:b' + result.size().toString() // id or throwaway fake blank id
                 result[key] = ctg
             }
 
@@ -254,7 +255,9 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
                     implied.each {
                         var keep = ID in it
                             && keepMatchingWithCategoriesSet
-                            && asList(it['inCollection']).any { it[ID] in keepMatchingWithCategoriesSet }
+                            && asList(it['inCollection']).any {
+                              it instanceof Map && it[ID] in keepMatchingWithCategoriesSet
+                            }
                         if (!keep) {
                             // Make MarcFrameConverter skip these for regular fields
                             it['_revertedBy'] = 'BibTypeNormalizationStep'

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -470,8 +470,10 @@ class MarcConversion {
             if (tag == "000") {
                 marc.leader = value
             } else {
-                if (value == null)
+                if (value == null) {
                     return
+                }
+
                 if (value instanceof List) {
                     value.each {
                         if (it) {
@@ -1195,7 +1197,7 @@ class ConversionPart {
 
         // The about map is the whole embellished record N times, framed around the "pending keys", typically:
         // ?record, ?thing, ?work, _:provision
-        return new Tuple2<Boolean, Map<String, List>>(requiredOk, aboutMap)
+        return new Tuple2(requiredOk, aboutMap)
     }
 
     static String findTokenFromId(Object node, String uriTemplate,
@@ -1437,15 +1439,14 @@ class MarcFixedFieldHandler {
         return new ConvertResult(success)
     }
 
-    @CompileStatic(SKIP)
     def revert(Map state, Map data, Map result, boolean keepEmpty = false) {
-        def value = new StringBuilder(FIXED_NONE * fieldSize)
-        def actualValue = false
-        for (col in columns) {
+        var value = new StringBuilder(FIXED_NONE * fieldSize)
+        var actualValue = false
+        for (var col : columns) {
             assert value.size() > col.start // columns must fit within value
             String obj = (String) col.revert(state, data)
             if (obj && col.width >= obj.size()) {
-                def end = col.start + obj.size() - 1
+                var end = col.start + obj.size() - 1
                 value[col.start..end] = obj
                 if (col.isActualValue(obj)) {
                     actualValue = true
@@ -1513,7 +1514,6 @@ class MarcFixedFieldHandler {
             return super.convert(state, token)
         }
 
-        @CompileStatic(SKIP)
         def revert(Map state, Map data) {
             def v = super.revert(state, data, null)
             if (ignoreOnRevert && fixedDefault)
@@ -1523,7 +1523,9 @@ class MarcFixedFieldHandler {
                 return fixedDefault
 
             if (v instanceof List) {
-                v = v.findAll { it && width >= it.size() }
+                v = v.findAll {
+                  it instanceof String && width >= it.length()
+                }
                 if (v.size() > 1 && tokensInOrder != null) {
                   var vset = v as Set
                   v = []
@@ -1858,9 +1860,8 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
         return OK
     }
 
-    @CompileStatic(SKIP)
     def revert(Map state, Map data, Map result) {
-        def entity = getEntity(state, data)
+        var entity = getEntity(state, data)
         if (link) {
             entity = entity[link]
         }
@@ -1869,12 +1870,16 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
             if (v) {
                 if (dateTimeFormat) {
                     try {
-                        if (v instanceof List)
+                        if (v instanceof List) {
                             v = v[0]
-                        if (!(v instanceof String))
+                        }
+
+                        if (v !instanceof String) {
                             return null
-                        def zonedDateTime = parseDate(v)
-                        def value = zonedDateTime.format(dateTimeFormat)
+                        }
+
+                        var zonedDateTime = parseDate(v)
+                        var value = zonedDateTime.format(dateTimeFormat)
                         if (missingCentury) {
                             value = value.substring(2)
                         }
@@ -1893,8 +1898,8 @@ class MarcSimpleFieldHandler extends BaseMarcFieldHandler {
             return revertObject(v)
         } else {
             return (entity instanceof List ? entity : [entity]).collect {
-                if (uriTemplate) {
-                    String token = findTokenFromId(it, uriTemplate, matchUriToken)
+                if (uriTemplate && it instanceof Map) {
+                    var token = findTokenFromId(it, uriTemplate, matchUriToken)
                     if (token) {
                         return revertToken(it, token)
                     }
@@ -1953,7 +1958,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
     Set<String> sharesGroupIdWith = new HashSet<String>()
     boolean silentRevert
 
-    static GENERIC_REL_URI_TEMPLATE = "generic:{_}"
+    static String GENERIC_REL_URI_TEMPLATE = "generic:{_}"
 
     MarcFieldHandler(MarcRuleSet ruleSet, String tag, Map fieldDfn,
             String baseTag = tag) {
@@ -2027,11 +2032,11 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         if (!order['...']) {
             order['...'] = order.size()
         }
-        
+
         if (!order['6']) {
             order['6'] = -1 // MARC 21, Appendix A: "Subfield $6 is always the first subfield in the field."
         }
-        
+
         Closure getOrder = {
             [order.get(it.code, order['...']), !it.code.isNumber(), it.code]
         }
@@ -2048,15 +2053,14 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         }
     }
 
-    @CompileStatic(SKIP)
-    static void completePunctuationRules(Collection subfields) {
-        def charSet = new HashSet<Character>()
+    static void completePunctuationRules(Collection<MarcSubFieldHandler> subfields) {
+        var charSet = new HashSet<char>()
         // This adds all possible leading to be stripped from all other subfields.
         // IMPROVE: just add seen leading to all subfields preceding current?
         // (Pro: might remove chars too aggressively. Con: might miss some
         // punctuation in weirdly ordered subfields.)
         subfields.each {
-            def lead = it.leadingPunctuation
+            var lead = it.leadingPunctuation
             if (lead) charSet.addAll(lead.toCharArray())
         }
         subfields.each {
@@ -2252,34 +2256,38 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         }
     }
 
-    @CompileStatic(SKIP)
     Map computeLinkage(Map state, Map entity, Map value, Set handled) {
-        def linkRule = getLinkRule(state, value)
-        def newEnt = null
+        var linkRule = getLinkRule(state, value)
+        Map newEnt = null
         if (linkRule.link || linkRule.resourceType) {
-            def useLinks = Collections.emptyList()
+            List<String> useLinks = Collections.emptyList()
             if (computeLinks) {
                 def use = computeLinks.use
+
                 Map resourceMap = (Map) ((computeLinks.mapping instanceof Map) ?
                         computeLinks.mapping : tokenMaps[computeLinks.mapping])
-                def linkTokens = value.subfields.findAll { Map it ->
+
+                var linkTokens = (List<String>) value.subfields.findAll { Map it ->
                     use in it.keySet()
                 }.collect { ((Map.Entry) it.iterator().next()).value }
+
                 useLinks = linkTokens.collect {
                     def linkDfn = resourceMap[it]
                     if (linkDfn == null) {
                         linkDfn = resourceMap[it.toLowerCase().replaceAll(/[^a-z0-9_-]/, '')]
                     }
-                    if (linkDfn instanceof String)
+                    if (linkDfn instanceof String) {
                         return linkDfn
-                    else
+                    } else {
                         return fromTemplate(GENERIC_REL_URI_TEMPLATE).expand(["_": it])
+                    }
                 }
+
                 if (useLinks.size() > 0) {
                     handled << use
                 } else {
                     def link = resourceMap['*']
-                    if (link) {
+                    if (link instanceof String) {
                         useLinks = [link]
                     }
                 }
@@ -2289,20 +2297,20 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                 linkRule.repeatable = true
             }
 
-            newEnt = newEntity(state, linkRule.resourceType, linkRule.groupId, linkRule.embedded)
+            newEnt = newEntity(state, (String) linkRule.resourceType, (String) linkRule.groupId, (boolean) linkRule.embedded)
 
             // TODO: use @id (existing or added bnode-id) instead of duplicating newEnt
-            def entRef = newEnt
+            var entRef = newEnt
             if (useLinks && linkRule.link) {
                 if (!newEnt['@id'])
-                    newEnt['@id'] = "_:b-${state.bnodeCounter++}" as String
+                    newEnt['@id'] = "_:b-${((int) state.bnodeCounter)++}" as String
                 entRef = ['@id': newEnt['@id']]
             }
             if (linkRule.link) {
-                addValue(entity, linkRule.link, newEnt, linkRule.repeatable)
+                addValue(entity, (String) linkRule.link, newEnt, (boolean) linkRule.repeatable)
             }
             useLinks.each {
-                addValue(entity, it, entRef, linkRule.repeatable)
+                addValue(entity, it, entRef, (boolean) linkRule.repeatable)
             }
         }
         return [ // TODO: just returning the entity would be enough
@@ -2333,7 +2341,6 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         return entity
     }
 
-    @CompileStatic(SKIP)
     def revert(Map state, Map data, Map result, List<MatchRule> usedMatchRules = []) {
 
         def matchedResults = []
@@ -2347,7 +2354,16 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
             }
 
             if (matchres) {
-                matchedResults += matchres
+                // TODO: Why did dynamic `matchedResults += matchres` work the same (no implicit flatten)?
+                matchres.each {
+                    if (it instanceof List) {
+                        matchedResults.addAll(it)
+                    }
+                    else {
+                        matchedResults.add(it)
+                    }
+
+                }
             }
         }
 
@@ -2359,7 +2375,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
 
         def results = []
 
-        def useLinks = []
+        List<Map> useLinks = []
 
         allowLinkOnRevert.each {
             useLinks << [link: it, resourceType: resourceType]
@@ -2403,39 +2419,47 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                         if (!it) return false
                         assert it instanceof Map, "Error reverting ${fieldId} - expected object, got: ${it}"
                         if (uriTemplateBase) {
-                            if (!it['@id'] || !it['@id'].startsWith(uriTemplateBase)) {
+                            String id = '@id' in it ? (String) it['@id'] : null
+                            if (!id || !id.startsWith(uriTemplateBase)) {
                                 boolean aliasMatchesBase = Util.asList(it['sameAs']).any {
-                                    it.get('@id')?.startsWith(uriTemplateBase)
+                                    if (it instanceof Map && '@id' in it) {
+                                        String sameId = (String) it['@id']
+                                        return sameId.startsWith(uriTemplateBase)
+                                    } else {
+                                        return false
+                                    }
                                 }
                                 if (!aliasMatchesBase) {
                                     return false
                                 }
                             }
                         }
-                        return isInstanceOf(it, useLink.resourceType)
+                        return isInstanceOf(it, (String) useLink.resourceType)
                     }
                 }
             }
 
             useEntities.each {
-                def (boolean requiredOk, Map aboutMap) = buildAboutMap(pendingResources, pendingKeys, it, aboutAlias)
+                def (Boolean requiredOk, Map aboutMap) = buildAboutMap(pendingResources, pendingKeys, it, aboutAlias)
                 if (requiredOk) {
-                    def field = revertOne(state, data, topEntity, it, aboutMap, usedMatchRules, useLink.groupId ?: this.groupId)
+                    var field = revertOne(state, data, topEntity, it, aboutMap, usedMatchRules, (String) useLink.groupId ?: this.groupId)
                     if (field) {
-                        if (useLink.subfield) {
-                            field.subfields.add(0, useLink.subfield)
+                        def subfields = field.subfields
+                        if (useLink.subfield && subfields instanceof List) {
+                            subfields.add(0, useLink.subfield)
                         }
-                        results << field
+                        results.add(field)
                     }
                 }
             }
         }
 
-        return results + matchedResults
+        results.addAll(matchedResults)
+
+        return results
     }
 
-    @CompileStatic(SKIP)
-    def revertOne(Map state, Map data, Map topEntity, Map currentEntity, Map<String, List> aboutMap = null,
+    Map revertOne(Map state, Map data, Map topEntity, Map currentEntity, Map<String, List> aboutMap = null,
                     List<MatchRule> usedMatchRules, String groupId) {
         if (usedMatchRules.any { !it.acceptRevert(currentEntity) }) {
             return null
@@ -2445,12 +2469,12 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         String i2 = usedMatchRules.findResult { it.ind2 } ?: revertIndicator(ind2, state, data, currentEntity, aboutMap)
 
         def subs = []
-        def failedRequired = false
-        def onlySupplementary = true
+        var failedRequired = false
+        var onlySupplementary = true
 
-        def usedEntities = new HashSet()
+        var usedEntities = new HashSet<Map>()
 
-        def prevAdded = null
+        Tuple2<String, Map> prevAdded = null
 
         // NOTE: Within a field, only *one* positioned term is supported.
         Map firstRelPosSubfield = null
@@ -2459,25 +2483,28 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
         Set requiredCodes = new HashSet()
         Set succeededCodes = new HashSet()
 
-        orderedAndGroupedSubfields.each { subhandlers ->
+        for (var subhandlers : orderedAndGroupedSubfields) {
 
             def about = subhandlers[0].about ?: aboutAlias
 
-            def subhandlersByEntity
+            List<Tuple2<MarcSubFieldHandler, Map>> subhandlersByEntity = null
             if (about == null) {
-                subhandlersByEntity = subhandlers.collect { [it, currentEntity ] }
+                subhandlersByEntity = subhandlers.collect { new Tuple2(it, currentEntity ) }
             } else {
-                def selectedEntities = aboutMap[about]
+                var selectedEntities = (List<Map>) aboutMap[about]
                 subhandlersByEntity = []
-                selectedEntities.each { entity ->
-                    subhandlers.each { subhandlersByEntity << [it, entity ] }
+                selectedEntities?.each { entity ->
+                    subhandlers.each { subhandlersByEntity << new Tuple2(it, entity ) }
                 }
             }
 
-            subhandlersByEntity.each { MarcSubFieldHandler subhandler, Map selectedEntity ->
-                def code = subhandler.code
+            for (Tuple2<MarcSubFieldHandler, Map> pair : subhandlersByEntity) {
+                var (subhandler, selectedEntity) = pair
+
+                var code = subhandler.code
+
                 if (failedRequired)
-                    return
+                    continue
 
                 if (subhandler.required) {
                     requiredCodes << code
@@ -2487,20 +2514,20 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                     if (i1 == null) {
                         i1 = subhandler.requiresI1
                     } else if (i1 != subhandler.requiresI1) {
-                        return
+                        continue
                     }
                 }
                 if (subhandler.requiresI2) {
                     if (i2 == null) {
                         i2 = subhandler.requiresI2
                     } else if (i2 != subhandler.requiresI2) {
-                        return
+                        continue
                     }
                 }
 
                 if (!selectedEntity) {
                     failedRequired = true
-                    return
+                    continue
                 }
 
                 // TODO: This check is rather crude for determining if an
@@ -2512,21 +2539,25 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                          selectedEntity._revertedBy && (!groupId || selectedEntity._groupId != groupId)) ||
                         selectedEntity._revertedBy == baseTag ||
                         selectedEntity._revertedBy in sharesGroupIdWith) {
-                    return
+                    continue
                     //subs << ['DEBUG:blockedSinceRevertedBy': selectedEntity._revertedBy]
                 }
 
-                List result = subhandler.revertWithSourcePosition(state, data, selectedEntity)
+                var result = subhandler.revertWithSourcePosition(state, data, selectedEntity)
 
-                def justAdded = null
+                Tuple2<String, Map> justAdded = null
                 String firstAddedValue = null
 
                 if (result != null) {
-                    result.each {
-                        def (vs, pos) = it
-                        if (!(vs instanceof List)) {
-                            vs = [vs]
-                        }
+                    for (def item : result) {
+                        // TODO: check revertWithSourcePosition better!
+                        List valueAndPos = (List) item
+
+                        def value = valueAndPos[0]
+                        List vs = value instanceof List ? value : [value]
+
+                        var pos = valueAndPos[1]
+
                         for (v in vs.flatten()) {
                             if (usedMatchRules?.any { !it.matchValue(code, v) }) {
                                 continue
@@ -2547,12 +2578,13 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                             }
 
                             subs << sub
-                            justAdded = [code, sub]
+                            justAdded = new Tuple2(code, sub)
                             if (firstAddedValue == null) {
                                 firstAddedValue = v
                             }
                         }
                     }
+
                     if (subhandler.required && !justAdded
                         && !(code in succeededCodes)) {
                         failedRequired = true
@@ -2569,10 +2601,10 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                     succeededCodes << code
 
                     if (prevAdded && justAdded && subhandler.leadingPunctuation) {
-                        def (prevCode, prevSub) = prevAdded
+                        var (prevCode, prevSub) = prevAdded
                         MarcSubFieldHandler prevSubHandler = subfields[prevCode]
                         if (!prevSubHandler.trailingPunctuation) {
-                            def prevValue = prevSub[prevCode]
+                            var prevValue = (String) prevSub[prevCode]
                             def nextLeading = subhandler.leadingPunctuation
                             boolean valueSkipsLeading = subhandler.skipLeadingPattern &&
                                     subhandler.skipLeadingPattern.matcher(firstAddedValue).matches()
@@ -2606,7 +2638,7 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
                     [relPos != null ? relPosStart : subs.indexOf(it), relPos]
                 }
             }
-            def field = [ind1: i1, ind2: i2, subfields: subs]
+            var field = [ind1: i1, ind2: i2, subfields: subs]
 
             if (usedMatchRules && !usedMatchRules.every { it.matches(field) }) {
                 //return [_notMatching: this.tag]
@@ -2921,32 +2953,41 @@ class MarcSubFieldHandler extends ConversionPart {
         return val
     }
 
-    @CompileStatic(SKIP)
     List revert(Map state, Map data, Map currentEntity) {
         List result = revertWithSourcePosition(state, data, currentEntity)
-        if (result == null)
+        if (result == null) {
             return null
-        return result.collect { it[0] }
+        }
+        return result.collect {
+            it instanceof String ? it[0] : it instanceof List ? it[0] : it
+        }
     }
 
-    @CompileStatic(SKIP)
     List revertWithSourcePosition(Map state, Map data, Map currentEntity) {
         currentEntity = aboutEntityName ? getEntity(state, data) : currentEntity
         if (currentEntity == null)
             return null
 
-        def entities = link ? currentEntity[link] : [currentEntity]
-        if (entities == null) {
-            return marcDefault ? [marcDefault] : null
-        }
-        if (entities instanceof Map) {
-            entities = [entities]
+        List<Map> entities = [currentEntity]
+        if (link) {
+            def linked = currentEntity[link]
+            if (linked == null) {
+                return marcDefault ? [marcDefault] : null
+            }
+
+            if (linked instanceof Map) {
+                entities = [linked]
+            } else if (linked instanceof List) {
+                entities = linked
+            } else {
+                return null
+            }
         }
 
         List values = []
 
         int i = 0
-        for (entity in entities) {
+        for (Map entity : entities) {
             i++
             if (i == 1) {
                 if (itemPos == "rest")
@@ -3048,20 +3089,23 @@ class MarcSubFieldHandler extends ConversionPart {
                 value = revertObject(obj)
             }
 
-            if (value instanceof String && value.size() > 0) {
+            if (value instanceof String && value.length() > 0) {
+                String strval = value
                 if (surroundingChars) {
-                    def (lead, tail) = surroundingChars
-                    if (value[0] != lead) {
-                        value = '' + lead + value
+                    char lead = surroundingChars[0]
+                    char tail = surroundingChars[1]
+                    if (strval[0] != lead) {
+                        strval = '' + lead + strval
                     }
-                    if (value[-1] != tail) {
-                        value += tail
+                    if (strval[-1] != tail) {
+                        strval += tail
                     }
                 }
                 if (trailingPunctuation &&
-                        !value.endsWith(trailingPunctuation)) {
-                    value += trailingPunctuation
+                        !strval.endsWith(trailingPunctuation)) {
+                    strval += trailingPunctuation
                 }
+                value = strval
             }
 
             if (value != null) {
@@ -3237,8 +3281,7 @@ class MatchRule {
         }
     }
 
-    @CompileStatic(SKIP)
-    static boolean objectContains(obj, pattern) {
+    static boolean objectContains(Object obj, Object pattern) {
         if (pattern instanceof List) {
             return pattern.every {
                 objectContains(obj, it)
@@ -3253,7 +3296,7 @@ class MatchRule {
             if (!(obj instanceof Map)) {
                 return false
             }
-            def map = (Map) obj
+            var map = (Map) obj
             for (Map.Entry entry : ((Map) pattern).entrySet()) {
                 if (!map.containsKey(entry.key)) {
                     return false

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFrameConverter.groovy
@@ -2302,8 +2302,11 @@ class MarcFieldHandler extends BaseMarcFieldHandler {
             // TODO: use @id (existing or added bnode-id) instead of duplicating newEnt
             var entRef = newEnt
             if (useLinks && linkRule.link) {
-                if (!newEnt['@id'])
-                    newEnt['@id'] = "_:b-${((int) state.bnodeCounter)++}" as String
+                if (!newEnt['@id']) {
+                    int c = (int) state.bnodeCounter
+                    newEnt['@id'] = "_:b-${c}" as String
+                    state.bnodeCounter = c + 1
+                }
                 entRef = ['@id': newEnt['@id']]
             }
             if (linkRule.link) {

--- a/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/MarcFramePostProcStep.groovy
@@ -1,5 +1,8 @@
 package whelk.converter.marc
 
+import groovy.transform.CompileStatic
+import groovy.transform.MapConstructor
+
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -7,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import whelk.JsonLd
 import whelk.ResourceCache
 
+@CompileStatic
 interface MarcFramePostProcStep {
     var ID = JsonLd.ID_KEY
     var TYPE = JsonLd.TYPE_KEY
@@ -20,6 +24,7 @@ interface MarcFramePostProcStep {
 }
 
 
+@CompileStatic
 abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
 
     String type
@@ -44,7 +49,7 @@ abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
 
         def key = path[0]
         def object
-        if (ld == null) {
+        if (ld == null && source instanceof Map) {
             object = source[key]
         } else {
             object = getValue(source, key)
@@ -58,15 +63,15 @@ abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
     def getValue(source, key) {
         if (source instanceof List) {
             if (key instanceof Integer) {
-                return source[key]
+                return ((List) source)[(Integer) key]
             }
-            return source.findResults { getValue(it, key) }
+            return source.findResults { getValue(it, (String) key) }
         }
 
         if (source instanceof Map) {
-            def value = ld.getPropertyValue(source, key)
+            def value = ld.getPropertyValue(source, (String) key)
             if (!value) {
-                value = ld.getSubProperties(key).findResult {
+                value = ld.getSubProperties((String) key).findResult {
                     ld.getPropertyValue(source, (String) it)
                 }
             }
@@ -82,9 +87,9 @@ abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
         int padded = 0
 
         for (prop in showProperties) {
-            def fmt = null
+            Map fmt = null
             if (prop instanceof Map) {
-                fmt = prop.useValueFormat
+                fmt = (Map) prop.useValueFormat
                 prop = prop.property
             }
             def value = prop instanceof List ? findValue(node, prop) : getValue(node, prop)
@@ -133,6 +138,7 @@ abstract class MarcFramePostProcStepBase implements MarcFramePostProcStep {
 }
 
 
+@CompileStatic
 class CopyOnRevertStep extends MarcFramePostProcStepBase {
 
     String sourceLink
@@ -163,7 +169,7 @@ class CopyOnRevertStep extends MarcFramePostProcStepBase {
 
     void unmodify(Map record, Map thing) {
         def source = sourceLink ? thing[sourceLink] : thing
-        def target = targetLink ? thing[targetLink] : thing
+        Map target = targetLink ? (Map) thing[targetLink] : thing
 
         if (source) {
             if (!(source instanceof List)) {
@@ -171,7 +177,8 @@ class CopyOnRevertStep extends MarcFramePostProcStepBase {
             }
             for (prop in copyIfMissing) {
                 for (item in source) {
-                    if (!target.containsKey(prop.to) && item.containsKey(prop.from)) {
+                    if (item instanceof Map &&
+                        !target.containsKey(prop.to) && item.containsKey(prop.from)) {
                         def src = item[prop.from]
                         def copy = cloneValue(src)
 
@@ -207,6 +214,7 @@ class CopyOnRevertStep extends MarcFramePostProcStepBase {
         }
     }
 
+    @MapConstructor
     class FromToProperty {
         String from
         String to
@@ -215,6 +223,7 @@ class CopyOnRevertStep extends MarcFramePostProcStepBase {
 }
 
 
+@CompileStatic
 class MappedPropertyStep implements MarcFramePostProcStep {
 
     String type
@@ -236,14 +245,14 @@ class MappedPropertyStep implements MarcFramePostProcStep {
      * Sets computed value if missing. Leaves any given value as is.
      */
     void modify(Map record, Map thing) {
-        def target = targetEntity == "?record"? record : thing
+        var target = targetEntity == "?record"? record : thing
         if (target[targetProperty]) {
             return
         }
 
-        def source = sourceEntity == "?record"? record : thing
+        Map source = sourceEntity == "?record"? record : thing
         if (sourceLink) {
-            source = source.get(sourceLink)
+            source = (Map) source.get(sourceLink)
         }
         def values = source?.get(sourceProperty)
         if (values instanceof String) {
@@ -269,6 +278,7 @@ class MappedPropertyStep implements MarcFramePostProcStep {
 }
 
 
+@CompileStatic
 class VerboseRevertDataStep extends MarcFramePostProcStepBase {
 
     String sourceProperty
@@ -315,6 +325,7 @@ class VerboseRevertDataStep extends MarcFramePostProcStepBase {
 }
 
 
+// TODO: @CompileStatic
 class RestructPropertyValuesAndFlagStep extends MarcFramePostProcStepBase {
 
     String sourceLink
@@ -521,6 +532,7 @@ class RestructPropertyValuesAndFlagStep extends MarcFramePostProcStepBase {
 }
 
 
+@CompileStatic
 class ProduceIfMissingStep extends MarcFramePostProcStepBase {
 
     String select
@@ -531,23 +543,23 @@ class ProduceIfMissingStep extends MarcFramePostProcStepBase {
 
     void unmodify(Map record, Map thing) {
         def source = thing[select]
-        def items = source instanceof List ? source : source ? [source] : []
-        if (items.any { produceMissing.produceProperty in it }) {
+        var items = source instanceof List ? source : source ? [source] : []
+        if (items.any { it instanceof Map && produceMissing.produceProperty in it }) {
             return
             // Only apply rules in *no* property is found (since if one is
             // found, we don't know if data is intentionally sparse).
         }
         items.each {
-            def value = findValue(it, produceMissing.sourcePath)
+            def value = findValue(it, (List) produceMissing.sourcePath)
             if (value) {
                 // IMPROVE: use produceMissing.multiple to build from all
                 if (value instanceof List) {
                     value = value[0]
                 }
-                if (produceMissing.showProperties) {
-                    value = buildString(value, produceMissing.showProperties)
+                if (produceMissing.showProperties && value instanceof Map) {
+                    value = buildString(value, (List) produceMissing.showProperties)
                 }
-                if (value) {
+                if (value && it instanceof Map) {
                     it[produceMissing.produceProperty] = value
                 }
             }
@@ -556,6 +568,7 @@ class ProduceIfMissingStep extends MarcFramePostProcStepBase {
 }
 
 
+@CompileStatic
 class InjectWhenMatchingOnRevertStep extends MarcFramePostProcStepBase {
 
     List<Map> rules
@@ -565,11 +578,11 @@ class InjectWhenMatchingOnRevertStep extends MarcFramePostProcStepBase {
     }
 
     void unmodify(Map record, Map thing) {
-        def item = thing
+        var item = thing
         for (rule in rules) {
-            def refs = [:]
-            if (deepMatches(item, rule.matches, refs)) {
-                Map injectData = jsonClone(rule.injectData)
+            var refs = [:]
+            if (deepMatches(item, (Map) rule.matches, refs)) {
+                Map injectData = jsonClone((Map) rule.injectData)
                 injectInto(item, injectData, refs)
                 break
             }
@@ -585,10 +598,10 @@ class InjectWhenMatchingOnRevertStep extends MarcFramePostProcStepBase {
             if (k == ID && v == ref) return true
             Util.asList(v).every {
                 return Util.asList(o[k]).any { ov ->
-                    boolean matches = (ov instanceof Map) ?
+                    boolean matches = (ov instanceof Map && it instanceof Map) ?
                         deepMatches(ov, it, refs) :
                         ov == it
-                    if (!matches && k == TYPE) {
+                    if (!matches && k == TYPE && ov instanceof String && it instanceof String) {
                         matches = ld?.isSubClassOf(ov, it)
                     }
                     if (matches) {
@@ -629,6 +642,7 @@ class InjectWhenMatchingOnRevertStep extends MarcFramePostProcStepBase {
 }
 
 
+@CompileStatic
 class SetFlagsByPatternsStep extends MarcFramePostProcStepBase {
 
     String select
@@ -642,16 +656,18 @@ class SetFlagsByPatternsStep extends MarcFramePostProcStepBase {
         def selected = thing[select]
         def items = selected instanceof List
                     ? selected : selected ? [selected] : []
-        items.each { item ->
-            for (rule in match) {
-                if (rule.exists.every { item.containsKey(it) }) {
-                    rule.setFlags.each { flag, flagValue ->
-                        if (!item.containsKey(flag) || force) {
-                            item[flag] = flagValue
-                        }
-                    }
-                    break
-                }
+        for (item in items) {
+            if (item instanceof Map) {
+              for (rule in match) {
+                  if (((List) rule.exists).every { item.containsKey((String) it) }) {
+                      ((Map) rule.setFlags).each { flag, flagValue ->
+                          if (!item.containsKey((String) flag) || force) {
+                              item[flag] = flagValue
+                          }
+                      }
+                      break
+                  }
+              }
             }
         }
     }


### PR DESCRIPTION
This removes most `CompileStatic`-skips, and adds `CompileStatic` to several/most pre-/post-processing steps; intending to make the code faster, stricter, and reasonably more robust.

Some very simple testing (using the (fixed) `perf` feature of `MarcFrameCli`) indicates that this speeds up revert-to-MARC by a factor of 2x to 3x (200k repeated revert-runs that previously was 11 ms on average is now down to 3.7 ms).

All marcframe integration tests pass, so behaviour _should_ be identical. However, there may be some intricate bug(s) left, since Groovy calls overloaded methods using the _actual_ type of the objects (dynamic dispatch), whereas Java selects method by (compile-time) variable type (static dispatch).

The tests smoked out a bunch of those, _possibly_ all, but we need to either analyze all call sites with intent, or run some rather large export tests to be sure enough.