### PR TITLE
Extend whelk to RDF dump feature with n-quads support

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -2,7 +2,6 @@ package whelk.importer
 
 import java.lang.annotation.*
 import java.util.concurrent.ExecutorService
-import java.util.zip.GZIPOutputStream
 import groovy.cli.picocli.CliBuilder
 import groovy.util.logging.Slf4j as Log
 import org.apache.commons.io.output.CountingOutputStream
@@ -11,8 +10,6 @@ import org.apache.commons.io.FilenameUtils
 import whelk.Document
 import whelk.Whelk
 import whelk.component.PostgreSQLComponent
-import whelk.converter.JsonLdToTrigSerializer
-import whelk.filter.LinkFinder
 import whelk.reindexer.CardRefresher
 import whelk.reindexer.ElasticReindexer
 import whelk.util.PropertyLoader
@@ -213,76 +210,16 @@ class ImporterMain {
     @Command(args='FILE [CHUNKSIZEINMB [--gzip]]')
     void lddbToTrig(String file, String chunkSizeInMB = null, String gzip = null, String collection = null) {
         def whelk = Whelk.createLoadedCoreWhelk(props)
-
-        boolean writingToFile = file && file != '-'
-        boolean shouldGzip = writingToFile && gzip && gzip == '--gzip'
-
-        String chunkedFormatString = FilenameUtils.getFullPath(file) + FilenameUtils.getBaseName(file) + "-%04d" +
-                (FilenameUtils.getExtension(file) ? "." + FilenameUtils.getExtension(file) : "") +
-                (shouldGzip ? ".gz" : "")
-
-        int partNumber = 1
-        long maxChunkSizeInBytes = 0 // 0 = no limit
-        if (chunkSizeInMB && chunkSizeInMB.toLong() > 0 && writingToFile) {
-            maxChunkSizeInBytes = chunkSizeInMB.toLong() * 1000000
-        }
-
-        def outputStream
-        if (writingToFile && maxChunkSizeInBytes > 0) {
-            System.err.println("Writing ${String.format(chunkedFormatString, partNumber)}")
-            outputStream = new FileOutputStream(String.format(chunkedFormatString, partNumber))
-        } else if (writingToFile) {
-            outputStream = new FileOutputStream(file)
-        } else {
-            outputStream = System.out
-        }
-
-        if (shouldGzip) {
-            outputStream = new GZIPOutputStream(outputStream)
-        }
-
-        CountingOutputStream cos = new CountingOutputStream(outputStream)
         def ctx = whelk.jsonld.context
-        def serializer = new JsonLdToTrigSerializer(ctx, cos)
-
-        serializer.prelude()
-        int i = 0
+        def trigDumper = new TrigFileDumper(ctx, file, chunkSizeInMB, gzip == '--gzip')
         for (Document doc : whelk.storage.loadAll(collection)) {
             if (doc.getShortId() in trigExcludeList) {
                 System.err.println("Excluding: ${doc.getShortId()}")
                 continue
             }
-
-            def id = doc.completeId
-            if (i % 500 == 0) {
-                System.err.println("$i records dumped.")
-            }
-            ++i
-            filterProblematicData(id, doc.data)
-            try {
-                serializer.writeGraph(id, doc.data['@graph'])
-            } catch (Throwable e) {
-                // Part of the record may still have been written to the stream, which is now corrupt.
-                System.err.println("${doc.getShortId()} conversion failed with ${e.toString()}")
-            }
-
-            if (writingToFile && maxChunkSizeInBytes > 0 && cos.getByteCount() > maxChunkSizeInBytes) {
-                ++partNumber
-                cos.close()
-                System.err.println("Writing ${String.format(chunkedFormatString, partNumber)}")
-                def fos = new FileOutputStream(String.format(chunkedFormatString, partNumber))
-                if (shouldGzip) {
-                    cos = new CountingOutputStream(new GZIPOutputStream(fos))
-                } else {
-                    cos = new CountingOutputStream(fos)
-                }
-
-                serializer.setOutputStream(cos)
-                // Make sure each chunk gets the prefixes
-                serializer.prelude()
-            }
+            trigDumper.dump(doc.completeId, doc.data)
         }
-        cos.close()
+        trigDumper.close()
     }
 
     @Command(args='[FROM]')

--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -203,23 +203,20 @@ class ImporterMain {
         copier.run()
     }
 
-    // Records that do not cleanly translate to trig/turtle (bad data).
-    // This obviously needs to be cleaned up!
-    def trigExcludeList = [] as Set
-
     @Command(args='FILE [CHUNKSIZEINMB [--gzip]]')
     void lddbToTrig(String file, String chunkSizeInMB = null, String gzip = null, String collection = null) {
-        def whelk = Whelk.createLoadedCoreWhelk(props)
-        def ctx = whelk.jsonld.context
-        def trigDumper = new TrigFileDumper(ctx, file, chunkSizeInMB, gzip == '--gzip')
-        for (Document doc : whelk.storage.loadAll(collection)) {
-            if (doc.getShortId() in trigExcludeList) {
-                System.err.println("Excluding: ${doc.getShortId()}")
-                continue
-            }
-            trigDumper.dump(doc.completeId, doc.data)
-        }
-        trigDumper.close()
+        var whelk = Whelk.createLoadedCoreWhelk(props)
+        var ctx = whelk.jsonld.context
+        var trigDumper = new RdfFileDumper(RdfFileDumper.TRIG, ctx, file, chunkSizeInMB, gzip == '--gzip')
+        trigDumper.dump(whelk, collection)
+    }
+
+    @Command(args='FILE [CHUNKSIZEINMB [--gzip]]')
+    void lddbToNquads(String file, String chunkSizeInMB = null, String gzip = null, String collection = null) {
+        var whelk = Whelk.createLoadedCoreWhelk(props)
+        var ctx = whelk.jsonld.context
+        var nquadsDumper = new RdfFileDumper(RdfFileDumper.NQUADS, ctx, file, chunkSizeInMB, gzip == '--gzip')
+        nquadsDumper.dump(whelk, collection)
     }
 
     @Command(args='[FROM]')

--- a/importers/src/main/groovy/whelk/importer/RdfFileDumper.groovy
+++ b/importers/src/main/groovy/whelk/importer/RdfFileDumper.groovy
@@ -6,18 +6,27 @@ import org.apache.commons.io.output.CountingOutputStream
 import org.apache.commons.io.FilenameUtils
 import groovy.transform.CompileStatic
 import static groovy.transform.TypeCheckingMode.SKIP
-import groovy.util.logging.Log4j2 as Log
+import groovy.util.logging.Slf4j as Log
 
 import whelk.JsonLd
-import whelk.converter.JsonLdToTrigSerializer
+import whelk.Whelk
 import whelk.util.Jackson
+
+import whelk.converter.JsonLdToNquadsSerializer
+import whelk.converter.JsonLdToRdfSerializer
+import whelk.converter.JsonLdToTrigSerializer
 
 @Log
 @CompileStatic
-class TrigFileDumper {
+class RdfFileDumper {
 
-    JsonLdToTrigSerializer serializer
+    static final String TRIG = "trig"
+    static final String NQUADS = "nquads"
+
+    JsonLdToRdfSerializer serializer
     CountingOutputStream cos
+
+    String format
 
     String chunkedFormatString
     boolean shouldGzip
@@ -26,7 +35,7 @@ class TrigFileDumper {
     int partNumber = 1
     long maxChunkSizeInBytes = 0 // 0 = no limit
 
-    TrigFileDumper(Map ctx, String file, String chunkSizeInMB, boolean shouldGzip) {
+    RdfFileDumper(String format, Map ctx, String file, String chunkSizeInMB, boolean shouldGzip) {
         writingToFile = file && file != '-'
         this.shouldGzip = shouldGzip && writingToFile
 
@@ -54,11 +63,19 @@ class TrigFileDumper {
 
         cos = new CountingOutputStream(outputStream)
 
-        serializer = new JsonLdToTrigSerializer(ctx, cos)
+        serializer = format == NQUADS ? new JsonLdToNquadsSerializer(ctx, cos) : new JsonLdToTrigSerializer(ctx, cos)
+
         serializer.prelude()
     }
 
-    void dump(String id, Map data) {
+    void dump(Whelk whelk, String collection = null) {
+        for (var doc : whelk.storage.loadAll(collection)) {
+            writeGraph(doc.completeId, doc.data)
+        }
+        close()
+    }
+
+    void writeGraph(String id, Map data) {
         if (i % 500 == 0) {
             System.err.println("$i records dumped.")
         }
@@ -131,7 +148,8 @@ class TrigFileDumper {
         String ctxFile = args[2]
         Map contextData = Jackson.mapper.readValue(new File(ctxFile), Map)
         var ctx = JsonLd.getNormalizedContext(contextData)
-        var trigDumper = new TrigFileDumper(ctx, outFile, "1000", true)
+        var ser
+        var trigDumper = new RdfFileDumper(TRIG, ctx, outFile, "1000", true)
         new File(inFile).withInputStream { ins ->
             if (inFile.endsWith('.gz')) {
                 ins = new GZIPInputStream(ins)
@@ -139,7 +157,7 @@ class TrigFileDumper {
             ins.eachLine { line ->
                 Map data = Jackson.mapper.readValue(line, Map)
                 String id = ((Map) ((List) data['@graph'])[0])['@id']
-                trigDumper.dump(id, data)
+                trigDumper.writeGraph(id, data)
             }
             trigDumper.close()
         }

--- a/importers/src/main/groovy/whelk/importer/TrigFileDumper.groovy
+++ b/importers/src/main/groovy/whelk/importer/TrigFileDumper.groovy
@@ -1,0 +1,147 @@
+package whelk.importer
+
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+import org.apache.commons.io.output.CountingOutputStream
+import org.apache.commons.io.FilenameUtils
+import groovy.transform.CompileStatic
+import static groovy.transform.TypeCheckingMode.SKIP
+import groovy.util.logging.Log4j2 as Log
+
+import whelk.JsonLd
+import whelk.converter.JsonLdToTrigSerializer
+import whelk.util.Jackson
+
+@Log
+@CompileStatic
+class TrigFileDumper {
+
+    JsonLdToTrigSerializer serializer
+    CountingOutputStream cos
+
+    String chunkedFormatString
+    boolean shouldGzip
+    boolean writingToFile
+    int i = 0
+    int partNumber = 1
+    long maxChunkSizeInBytes = 0 // 0 = no limit
+
+    TrigFileDumper(Map ctx, String file, String chunkSizeInMB, boolean shouldGzip) {
+        writingToFile = file && file != '-'
+        this.shouldGzip = shouldGzip && writingToFile
+
+        chunkedFormatString = FilenameUtils.getFullPath(file) + FilenameUtils.getBaseName(file) + "-%04d" +
+                (FilenameUtils.getExtension(file) ? "." + FilenameUtils.getExtension(file) : "") +
+                (shouldGzip ? ".gz" : "")
+
+        if (chunkSizeInMB && chunkSizeInMB.toLong() > 0 && writingToFile) {
+            maxChunkSizeInBytes = chunkSizeInMB.toLong() * 1000000
+        }
+
+        def outputStream
+        if (writingToFile && maxChunkSizeInBytes > 0) {
+            System.err.println("Writing ${String.format(chunkedFormatString, partNumber)}")
+            outputStream = new FileOutputStream(String.format(chunkedFormatString, partNumber))
+        } else if (writingToFile) {
+            outputStream = new FileOutputStream(file)
+        } else {
+            outputStream = System.out
+        }
+
+        if (shouldGzip) {
+            outputStream = new GZIPOutputStream(outputStream)
+        }
+
+        cos = new CountingOutputStream(outputStream)
+
+        serializer = new JsonLdToTrigSerializer(ctx, cos)
+        serializer.prelude()
+    }
+
+    void dump(String id, Map data) {
+        if (i % 500 == 0) {
+            System.err.println("$i records dumped.")
+        }
+
+        ++i
+        filterProblematicData(id, data)
+        try {
+            serializer.writeGraph(id, data['@graph'])
+        } catch (Throwable e) {
+            // Part of the record may still have been written to the stream, which is now corrupt.
+            System.err.println("${id} conversion failed with ${e.toString()}")
+        }
+
+        if (writingToFile && maxChunkSizeInBytes > 0 && cos.getByteCount() > maxChunkSizeInBytes) {
+            ++partNumber
+            cos.close()
+            System.err.println("Writing ${String.format(chunkedFormatString, partNumber)}")
+            def fos = new FileOutputStream(String.format(chunkedFormatString, partNumber))
+            if (shouldGzip) {
+                cos = new CountingOutputStream(new GZIPOutputStream(fos))
+            } else {
+                cos = new CountingOutputStream(fos)
+            }
+
+            serializer.setOutputStream(cos)
+            // Make sure each chunk gets the prefixes
+            serializer.prelude()
+        }
+    }
+
+    void close() {
+        cos.close()
+    }
+
+    @CompileStatic(SKIP)
+    private static void filterProblematicData(id, data) {
+        if (data instanceof Collection) {
+            data.eachWithIndex { it, index ->
+                if (it instanceof String) {
+                    // Virtuoso bulk load doesn't like some unusual characters, such as 0x02,
+                    // so remove invisible control characters and unused code points
+                    data[index] = it.replaceAll(/\p{C}/, "")
+                }
+            }
+        }
+
+        if (data instanceof Map) {
+            data.removeAll { entry ->
+                return entry.key.startsWith("generic") ||
+                        entry.key.equals("marc:hasGovernmentDocumentClassificationNumber") ||
+                        (entry.key.equals("encodingLevel") && entry.value instanceof String && entry.value.contains(" ")) ||
+                        !entry.value
+            }
+            data.keySet().each { property ->
+                filterProblematicData(id, data[property])
+            }
+        } else if (data instanceof List) {
+            if (data.removeAll([null])) {
+                log.warn("Removing null value from ${id}")
+            }
+            data.each {
+                filterProblematicData(id, it)
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        String inFile = args[0]
+        String outFile = args[1]
+        String ctxFile = args[2]
+        Map contextData = Jackson.mapper.readValue(new File(ctxFile), Map)
+        var ctx = JsonLd.getNormalizedContext(contextData)
+        var trigDumper = new TrigFileDumper(ctx, outFile, "1000", true)
+        new File(inFile).withInputStream { ins ->
+            if (inFile.endsWith('.gz')) {
+                ins = new GZIPInputStream(ins)
+            }
+            ins.eachLine { line ->
+                Map data = Jackson.mapper.readValue(line, Map)
+                String id = ((Map) ((List) data['@graph'])[0])['@id']
+                trigDumper.dump(id, data)
+            }
+            trigDumper.close()
+        }
+    }
+}

--- a/trld-java/src/main/java/trld/nq/Serializer.java
+++ b/trld-java/src/main/java/trld/nq/Serializer.java
@@ -15,6 +15,7 @@ import java.io.*;
 import trld.Builtins;
 import trld.KeyValue;
 
+import static trld.platform.Common.escapeCodepoints;
 import trld.platform.Output;
 import static trld.jsonld.Base.isBlank;
 import trld.jsonld.RdfDataset;
@@ -61,6 +62,12 @@ public class Serializer {
       String v = (String) ((RdfLiteral) t).value;
       v = v.replace("\\", "\\\\");
       v = v.replace("\"", "\\\"");
+      v = v.replace("", "\\b");
+      v = v.replace("\t", "\\t");
+      v = v.replace("\n", "\\n");
+      v = v.replace("\u000c", "\\f");
+      v = v.replace("\r", "\\r");
+      v = escapeCodepoints(v, (c) -> needsUnicodeEsc(c));
       v = "\"" + v + "\"";
       if (((RdfLiteral) t).language != null) {
         return v + "@" + ((RdfLiteral) t).language;
@@ -71,5 +78,8 @@ public class Serializer {
         return v;
       }
     }
+  }
+  protected static boolean needsUnicodeEsc(Integer cp) {
+    return ((0 <= cp && cp <= 7) || cp == 11 || (14 <= cp && cp <= 31) || cp == 127 || !(((1 <= cp && cp <= 55295) || (57344 <= cp && cp <= 65533) || (65536 <= cp && cp <= 1114111))));
   }
 }

--- a/trld-java/src/main/java/trld/platform/Common.java
+++ b/trld-java/src/main/java/trld/platform/Common.java
@@ -3,9 +3,24 @@ package trld.platform;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.function.IntPredicate;
+
 import com.fasterxml.jackson.jr.ob.JSON;
 
 public class Common {
+
+    public static String escapeCodepoints(String s, IntPredicate needsEsc) {
+        StringBuilder sb = new  StringBuilder();
+        s.codePoints().forEach(cp -> {
+            if (needsEsc.test(cp)) {
+                sb.append(String.format("\\u%04X", cp));
+            } else {
+                sb.appendCodePoint(cp);
+            }
+        });
+        return sb.toString();
+    }
+
 
     public static String resolveIri(String base, String relative) {
         try {

--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     api files('lib/isbntools-1.3.jar')
     implementation files('lib/oaij-0.1.jar')
 
-    implementation(project(':trld-java'))
+    api project(':trld-java')
 
     // Dependencies inherited from classic libris, due to profile handling
     implementation "com.ibm.icu:icu4j:71.1"

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToNquadsSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToNquadsSerializer.groovy
@@ -1,0 +1,36 @@
+package whelk.converter
+
+import groovy.transform.CompileStatic
+
+import trld.platform.Output
+import trld.jsonld.Context
+import static trld.jsonld.Expansion.expansion
+import static trld.jsonld.Flattening.flatten
+import static trld.jsonld.Rdf.toRdfDataset
+import static trld.nq.Serializer.serialize
+
+@CompileStatic
+class JsonLdToNquadsSerializer implements JsonLdToRdfSerializer {
+
+    Context context
+    Output out
+
+    JsonLdToNquadsSerializer(Map ctx, OutputStream ostream) {
+      this.context = new Context(null, null, null).getContext(ctx, null)
+      setOutputStream(ostream)
+    }
+
+    void setOutputStream(OutputStream ostream) {
+        out = new Output(new PrintStream(ostream))
+    }
+
+    void prelude() {
+    }
+
+    void writeGraph(String id, Object data) {
+        data = ['@id': id, '@graph': data]
+        var rdfDataset = toRdfDataset(flatten(expansion(context, null, data, id)))
+        serialize(rdfDataset, out)
+    }
+
+}

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToNquadsSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToNquadsSerializer.groovy
@@ -2,12 +2,15 @@ package whelk.converter
 
 import groovy.transform.CompileStatic
 
+import org.apache.commons.codec.digest.DigestUtils
+
 import trld.platform.Output
 import trld.jsonld.Context
-import static trld.jsonld.Expansion.expansion
-import static trld.jsonld.Flattening.flatten
-import static trld.jsonld.Rdf.toRdfDataset
-import static trld.nq.Serializer.serialize
+import trld.jsonld.Expansion
+import trld.jsonld.Flattening
+import trld.jsonld.BNodes
+import trld.jsonld.Rdf
+import trld.jsonld.RdfDataset
 
 @CompileStatic
 class JsonLdToNquadsSerializer implements JsonLdToRdfSerializer {
@@ -28,9 +31,24 @@ class JsonLdToNquadsSerializer implements JsonLdToRdfSerializer {
     }
 
     void writeGraph(String id, Object data) {
-        data = ['@id': id, '@graph': data]
-        var rdfDataset = toRdfDataset(flatten(expansion(context, null, data, id)))
-        serialize(rdfDataset, out)
+        // Note: not enough:
+        // var rdfDataset = toRdfDataset(flatten(expansion(context, null, data, id)))
+        // ; need to ensure unique part bnode IDs in resulting output dataset:
+        var hash = DigestUtils.sha256Hex(id)
+        var pfx = "_:${hash}-" as String
+        var bnodes = new BNodes() {
+           String makeBnodeId(String identifier) {
+            return pfx + super.makeBnodeId(identifier).substring(2)
+           }
+        }
+        data = ['@id': id, '@graph': data] // to named graph
+        var flatExpandedData = Flattening.flatten(Expansion.expansion(context, null, data, id))
+        Map<String, Map<String, Object>> nodeMap = ['@default': [:]]
+        Flattening.makeNodeMap(bnodes, flatExpandedData, nodeMap)
+        var rdfDataset = new RdfDataset()
+        Rdf.jsonldToRdfDataset(nodeMap, rdfDataset, bnodes, null)
+
+        trld.nq.Serializer.serialize(rdfDataset, out)
     }
 
 }

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToRdfSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToRdfSerializer.groovy
@@ -1,0 +1,14 @@
+package whelk.converter
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+interface JsonLdToRdfSerializer {
+
+    abstract void setOutputStream(OutputStream ostream)
+
+    abstract void prelude()
+
+    abstract void writeGraph(String id, Object data)
+
+}

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
@@ -1,5 +1,6 @@
 package whelk.converter
 
+import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j as Log
 
@@ -10,7 +11,8 @@ import trld.platform.Output
 import trld.trig.SerializerState
 import trld.trig.Settings
 
-class JsonLdToTrigSerializer {
+@CompileStatic
+class JsonLdToTrigSerializer implements JsonLdToRdfSerializer {
 
     private CleanedTrigSerializerState state
 
@@ -33,19 +35,19 @@ class JsonLdToTrigSerializer {
         state.writeGraph(id, data)
     }
 
-    static OutputStream toTrig(context, source, base=null, String iri=null) {
+    static OutputStream toTrig(Map context, Map source, String base=null, String iri=null) {
         return serialize(context, source, base, new Settings())
     }
 
-    static OutputStream toTurtle(context, source, base=null) {
+    static OutputStream toTurtle(Map context, Map source, String base=null) {
         boolean union = true
-        def settings = new Settings(true, !union)
+        var settings = new Settings(true, !union)
         return serialize(context, source, base, settings)
     }
 
-    static OutputStream serialize(context, source, base, settings) {
-        def out = new Output()
-        def state = new CleanedTrigSerializerState(out, settings, context, base)
+    static OutputStream serialize(Map context, Map source, String base, Settings settings) {
+        var out = new Output()
+        var state = new CleanedTrigSerializerState(out, settings, context, base)
         state.serialize(source)
         return out.getCaptured()
     }
@@ -81,7 +83,13 @@ class CleanedTrigSerializerState extends SerializerState {
         // "http://foo:", http://", etc.
         IRI iri = iriFactory.create(cleanedIriString)
         if (iri.hasViolation(false)) { // false = ignore warnings, care only about errors
-            cleanedIriString = "https://BROKEN-IRI/"
+            String encoded = ""
+            try {
+              encoded = URLEncoder.encode(cleanedIriString, 'UTF-8')
+            } catch (UnsupportedEncodingException e) {
+              encoded = "broken"
+            }
+            cleanedIriString = "http://iri.invalid/?iri=${encoded}".toString()
         }
 
         if (cleanedIriString != iriString) {

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
@@ -35,17 +35,17 @@ class JsonLdToTrigSerializer implements JsonLdToRdfSerializer {
         state.writeGraph(id, data)
     }
 
-    static OutputStream toTrig(Map context, Map source, String base=null, String iri=null) {
+    static OutputStream toTrig(Map context, Object source, String base=null, String iri=null) {
         return serialize(context, source, base, new Settings())
     }
 
-    static OutputStream toTurtle(Map context, Map source, String base=null) {
+    static OutputStream toTurtle(Map context, Object source, String base=null) {
         boolean union = true
         var settings = new Settings(true, !union)
         return serialize(context, source, base, settings)
     }
 
-    static OutputStream serialize(Map context, Map source, String base, Settings settings) {
+    static OutputStream serialize(Map context, Object source, String base, Settings settings) {
         var out = new Output()
         var state = new CleanedTrigSerializerState(out, settings, context, base)
         state.serialize(source)


### PR DESCRIPTION
Example usage:
```sh
cd importers
../gradlew jar
mkdir -p /tmp/libris-dumps
java -Dxl.secret.properties=../secret.properties.dev -jar build/libs/xlimporter.jar \
        lddbToNquads /tmp/libris-dumps/dev-bib-nq 4 --gzip bib
```

This is still WIP for various reasons:
- [ ] Compliation of importers failed on develop (possibly due to gradle bump). This is adressed in 5502f9e72f69d77193281a1f2beb6c047720ffc8 which we may want to cherry-pick if that's the way to go.
- [x] We _must_ to use a unique bnodes minter (e.g. doc-and-batch-count as prefix, or uuid:s) per conversion (a.k.a. "standardize apart"); the current nquads writer here will result in horrendous bnode smushing!
- [ ] I prefer to isolate trld-java API dependency a bit more (any may improve its public API further to do so).
- [x] TRLD 0.3.0 includes proper n-quads support (and c14n, though we don't need it here); so we should either just bump trld-java, or backport that part (crucially fixes newlines in strings).
- [ ] We do some intricate cleanup in `JsonLdToTrigSerializer` which we may want to go about differently to reuse here (ideally of course fix the data in XL to prevent e.g. broken IRIs from ever entering).