### PR TITLE
feat(oaipmh): avoid sending lots of empty pages

### DIFF
--- a/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/Helpers.java
@@ -289,7 +289,7 @@ public class Helpers
     private static PreparedStatement getIntervalStatement(Connection connection, ZonedDateTime fromDateTime,
                                                           ZonedDateTime untilDateTime, boolean includeSilentChanges,
                                                           Timestamp afterModified, String afterId,
-                                                          String explicitSet, String restrictToCollection, int limit)
+                                                          String explicitSet, List<String> scanCollections, int limit)
             throws SQLException
     {
         // By default we go by the modified date, but we support to option to include silent changes.
@@ -299,14 +299,14 @@ public class Helpers
                 ? "GREATEST(modified, totstz(data#>>'{@graph,0,generationDate}'))"
                 : "modified";
 
+        // Only scan the collections that can actually emit records for the requested set.
+        StringJoiner collectionPlaceholders = new StringJoiner(", ", "(", ")");
+        for (int i = 0; i < scanCollections.size(); i++)
+            collectionPlaceholders.add("?");
+
         StringBuilder sql = new StringBuilder(
                 "SELECT id, " + effectiveModified + " AS effective_modified, data" +
-                " FROM lddb WHERE collection in ('bib', 'auth', 'hold')");
-
-        // If a collection has been requested and dependency expansion is not needed, we only need to scan
-        // the requested collection
-        if (restrictToCollection != null)
-            sql.append(" AND collection = ? ");
+                " FROM lddb WHERE collection in " + collectionPlaceholders);
 
         String explicitSetColumn = explicitSetColumn(explicitSet);
         if (explicitSetColumn != null)
@@ -327,8 +327,8 @@ public class Helpers
         preparedStatement.setFetchSize(512);
 
         int parameterIndex = 1;
-        if (restrictToCollection != null)
-            preparedStatement.setString(parameterIndex++, restrictToCollection);
+        for (String collection : scanCollections)
+            preparedStatement.setString(parameterIndex++, collection);
         if (explicitSetColumn != null)
             preparedStatement.setString(parameterIndex++, explicitSetValue(explicitSet));
         if (fromDateTime != null)
@@ -342,6 +342,17 @@ public class Helpers
         }
 
         return preparedStatement;
+    }
+
+    private static List<String> collectionsToScan(String requestedCollection, boolean includeDependenciesInTimeInterval)
+    {
+        if (requestedCollection == null)
+            return List.of("bib", "auth", "hold");
+
+        if (includeDependenciesInTimeInterval && !requestedCollection.equals("auth"))
+            return List.of(requestedCollection, "auth");
+
+        return List.of(requestedCollection);
     }
 
     private static String explicitSetColumn(String explicitSet)
@@ -394,14 +405,15 @@ public class Helpers
             }
         }
 
-        // This is to avoid paging through non-matching rows
-        String restrictToCollection = includeDependenciesInTimeInterval ? null : requestedCollection;
+        // Only scan the collections that can actually emit records for the requested set, to avoid
+        // paging through non-matching rows.
+        List<String> scanCollections = collectionsToScan(requestedCollection, includeDependenciesInTimeInterval);
 
         PreparedStatement preparedStatement;
         if (id == null)
         {
             preparedStatement = getIntervalStatement(connection, fromDateTime, untilDateTime,
-                    includeSilentChanges, afterModified, afterId, explicitSet, restrictToCollection, limit);
+                    includeSilentChanges, afterModified, afterId, explicitSet, scanCollections, limit);
         }
         else
         {

--- a/oaipmh/src/main/java/whelk/export/servlet/ListRecords.java
+++ b/oaipmh/src/main/java/whelk/export/servlet/ListRecords.java
@@ -25,9 +25,14 @@ public class ListRecords
     private final static String DELETED_DATA_PARAM = "x-withDeletedData";
     private final static String INCLUDE_SILENT_PARAM = "x-withSilentUpdates";
 
-    // Number of source rows from lddb to scan per page. One page = one HTTP response,
-    // possibly with a resumptionToken for the next page.
+    // Number of source rows from lddb to scan per db page
     private final static int PAGE_SIZE = 1000;
+
+    // A single HTTP response may chain several db pages, to avoid returning empty pages (= resumptionToken
+    // and no records) while the scan goes past rows that don't emit anything. This caps how many db pages
+    // one HTTP request will scan before giving up and returning an empty page with a resumptionToken, so
+    // that a request never results in an unbounded scan of the database.
+    private final static int MAX_PAGES_PER_REQUEST = 100;
 
     private static final Counter failedRequests = Counter.build()
             .name("oaipmh_failed_listrecords_requests_total").help("Total failed ListRecords requests.")
@@ -149,13 +154,48 @@ public class ListRecords
             ResumptionToken baseToken = new ResumptionToken(from, until, set, metadataPrefix,
                     withDeletedData, withSilentChanges, null, null);
 
-            try (Helpers.ResultIterator resultIterator = Helpers.getMatchingDocuments(dbconn, fromDateTime,
-                    untilDateTime, setSpec, null, includeDependencies, withSilentChanges,
-                    afterModified, afterId, PAGE_SIZE))
+            try
             {
-                respond(request, response, metadataPrefix, onlyIdentifiers,
-                        includeDependencies, withDeletedData, resultIterator, baseToken,
-                        resumptionTokenParam != null);
+                // Chain db pages until we have at least one record to emit, or run out of data, or hit
+                // the per-request page cap. This is to avoid returning a whole lof of empty pages
+                // (with resumptionToken) when the scan goes through records that don't emit anything.
+                Helpers.ResultIterator resultIterator = Helpers.getMatchingDocuments(dbconn, fromDateTime,
+                        untilDateTime, setSpec, null, includeDependencies, withSilentChanges,
+                        afterModified, afterId, PAGE_SIZE);
+                try
+                {
+                    int pagesScanned = 1;
+                    while (!resultIterator.hasNext() && !resultIterator.isExhausted()
+                            && pagesScanned < MAX_PAGES_PER_REQUEST)
+                    {
+                        // A full db page with nothing to emit. Advance the cursor to the end of the
+                        // page we just scanned and scan the next one. If the page reported no
+                        // position, keep the cursor where it was.
+                        String lastSourceModified = resultIterator.getLastSourceModified();
+                        if (lastSourceModified != null)
+                        {
+                            afterModified = Timestamp.from(
+                                    ZonedDateTime.parse(lastSourceModified).toInstant());
+                        }
+                        String lastSourceId = resultIterator.getLastSourceId();
+                        if (lastSourceId != null)
+                        {
+                            afterId = lastSourceId;
+                        }
+
+                        resultIterator.close();
+                        resultIterator = Helpers.getMatchingDocuments(dbconn, fromDateTime,
+                                untilDateTime, setSpec, null, includeDependencies, withSilentChanges,
+                                afterModified, afterId, PAGE_SIZE);
+                        pagesScanned++;
+                    }
+
+                    respond(request, response, metadataPrefix, onlyIdentifiers,
+                            includeDependencies, withDeletedData, resultIterator, baseToken,
+                            resumptionTokenParam != null);
+                } finally {
+                    resultIterator.close();
+                }
             } finally {
                 dbconn.commit();
             }


### PR DESCRIPTION
Previously a request like `/oaipmh/?verb=ListRecords&metadataPrefix=marcxml_includehold&set=bib%3AS` in the dev environment would result in 30+ empty pages with just a resumptionToken before there were any actual records. This (basically) takes care of that, and also seems to improve the speed a little.