### PR TITLE
fix(whelk-core): add null guard to reindexAffectedReverseIntegral

### DIFF
--- a/whelk-core/src/main/groovy/whelk/Whelk.groovy
+++ b/whelk-core/src/main/groovy/whelk/Whelk.groovy
@@ -420,13 +420,15 @@ class Whelk {
             String p = link.property()
             if (jsonld.isIntegral(jsonld.getInverseProperty(p))) {
                 String id = storage.getSystemIdByIri(link.iri)
-                Document doc = storage.load(id)
-                def lenses = ['chips', 'cards', 'full']
-                def reverseRelations = lenses
-                        .collect { jsonld.getInverseProperties(doc.data, it) }
-                        .flatten()
-                if (reverseRelations.contains(p)) {
-                    indexDocAndVirtual(doc)
+                if (id) {
+                    Document doc = storage.load(id)
+                    def lenses = ['chips', 'cards', 'full']
+                    def reverseRelations = lenses
+                            .collect { jsonld.getInverseProperties(doc.data, it) }
+                            .flatten()
+                    if (reverseRelations.contains(p)) {
+                        indexDocAndVirtual(doc)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This has nothing to do with recent changes, I just noticed it while investigating an APIX issue. The error has probably been around for a long time (as far back as I can see in the dev logs -- May). When running a test that would create and immediatiely delete a hold this would happen:
```
2026-07-17T18:19:29,814 [Thread-511] ERROR whelk.Whelk - Error reindexing: java.lang.reflect.UndeclaredThrowableException
java.lang.reflect.UndeclaredThrowableException: null
        at jdk.proxy1/jdk.proxy1.$Proxy32.accept(Unknown Source) ~[?:?]
        at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at whelk.Whelk.reindexAffectedReverseIntegral(Whelk.groovy:419) ~[apix_server.jar:?]
        at whelk.Whelk.access$2(Whelk.groovy) ~[apix_server.jar:?]
        at whelk.Whelk$_reindexAffected_closure11.doCall(Whelk.groovy:403) ~[apix_server.jar:?]
        at whelk.Whelk$_reindexAffected_closure11.call(Whelk.groovy) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2432) ~[apix_server.jar:?]
        at whelk.Whelk.reindexAffected(Whelk.groovy:390) ~[apix_server.jar:?]
        at whelk.Whelk.access$1(Whelk.groovy) ~[apix_server.jar:?]
        at whelk.Whelk$_createDocument_closure15.doCall(Whelk.groovy:517) ~[apix_server.jar:?]
        at whelk.Whelk$_createDocument_closure15.call(Whelk.groovy) ~[apix_server.jar:?]
        at groovy.lang.Closure.run(Closure.java:505) ~[apix_server.jar:?]
        at whelk.Whelk$_indexAsyncOrSync_closure9.doCall(Whelk.groovy:356) [apix_server.jar:?]
        at whelk.Whelk$_indexAsyncOrSync_closure9.call(Whelk.groovy) [apix_server.jar:?]
        at groovy.lang.Closure.run(Closure.java:505) [apix_server.jar:?]
        at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]
Caused by: org.postgresql.util.PSQLException: No value specified for parameter 1.
        at org.postgresql.core.v3.SimpleParameterList.checkAllParametersSet(SimpleParameterList.java:407) ~[apix_server.jar:?]
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356) ~[apix_server.jar:?]
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:525) ~[apix_server.jar:?]
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:435) ~[apix_server.jar:?]
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:196) ~[apix_server.jar:?]
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:139) ~[apix_server.jar:?]
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52) ~[apix_server.jar:?]
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent$_loadFromSql_closure54.doCall(PostgreSQLComponent.groovy:2486) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent$_loadFromSql_closure54.call(PostgreSQLComponent.groovy) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent.withDbConnection(PostgreSQLComponent.groovy:3107) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent.loadFromSql(PostgreSQLComponent.groovy:2462) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent.load(PostgreSQLComponent.groovy:1992) ~[apix_server.jar:?]
        at whelk.component.PostgreSQLComponent.load(PostgreSQLComponent.groovy:1971) ~[apix_server.jar:?]
        at whelk.Whelk$_reindexAffectedReverseIntegral_closure12.doCall(Whelk.groovy:423) ~[apix_server.jar:?]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
        at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343) ~[apix_server.jar:?]
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:280) ~[apix_server.jar:?]
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007) ~[apix_server.jar:?]
        at groovy.lang.Closure.call(Closure.java:433) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.ConvertedClosure.invokeCustom(ConvertedClosure.java:52) ~[apix_server.jar:?]
        at org.codehaus.groovy.runtime.ConversionHandler.invoke(ConversionHandler.java:113) ~[apix_server.jar:?]
```
So let's just check that we actually get an id before trying to load it.