### PR TITLE
feat(importers): add copyRecords tool for importing individual records

### DIFF
--- a/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
+++ b/importers/src/main/groovy/whelk/importer/ImporterMain.groovy
@@ -172,6 +172,40 @@ class ImporterMain {
         copier.run()
     }
 
+    /**
+     * Copy one or a few records, specified by XL id (or IRI) on the command line, from
+     * another whelk, and index them. Like copywhelk, records that the specified records
+     * link to, and records that link to them, are copied as well.
+     *
+     * Unlike copywhelk's --copy-versions, this one is boolean: if set, all
+     * historical versions of the *specified records* (not of their deps) are copied.
+     *
+     * By default a specified record that already exists in the destination is skipped.
+     * With --overwrite-existing its contents are instead overwritten (via an atomic
+     * update) with the source version, and its dependencies/dependers are copied as normal.
+     * Note that overwriting does not reconstruct version history, so --copy-versions
+     * has no effect on records that were overwritten rather than freshly copied.
+     *
+     * E.g., copy two records including their holdings and full history:
+     * --include-items --copy-versions SOURCE_PROPERTIES_FILE s93zr6j40v97d0f 3mfj87vf5t3zg3w
+     */
+    @Command(args='SOURCE_PROPERTIES RECORD_ID...', flags='--copy-versions --include-items --overwrite-existing')
+    void copyRecords(Map flags, String sourcePropsFile, String... recordIds) {
+        if (!recordIds) {
+            throw new IllegalArgumentException("At least one record id must be given.")
+        }
+        def sourceProps = new Properties()
+        new File(sourcePropsFile).withInputStream {
+            sourceProps.load(it)
+        }
+        Whelk source = Whelk.createLoadedCoreWhelk(sourceProps)
+        Whelk dest = Whelk.createLoadedSearchWhelk(props)
+        def copier = new RecordCopier(source, dest, recordIds as List,
+                (boolean) flags['copy-versions'], (boolean) flags['include-items'],
+                (boolean) flags['overwrite-existing'])
+        copier.run()
+    }
+
     // Records that do not cleanly translate to trig/turtle (bad data).
     // This obviously needs to be cleaned up!
     def trigExcludeList = [] as Set

--- a/importers/src/main/java/whelk/importer/RecordCopier.java
+++ b/importers/src/main/java/whelk/importer/RecordCopier.java
@@ -1,0 +1,324 @@
+package whelk.importer;
+
+import whelk.Document;
+import whelk.Whelk;
+import whelk.component.PostgreSQLComponent;
+import whelk.history.DocumentVersion;
+import whelk.util.LegacyIntegrationTools;
+
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import static whelk.util.Jackson.mapper;
+
+/**
+ * Copies a small, explicitly named set of records (and their immediate link
+ * dependencies/dependers) from one whelk to another, and indexes them.
+ *
+ * Unlike {@link WhelkCopier}, which is built for bulk reloads driven by a file
+ * of ids, this is meant for pulling in one or a few records from the command
+ * line, so it indexes them directly instead of relying on a separate reindex.
+ */
+public class RecordCopier {
+
+    private static final int FETCH_SIZE = 100;
+    private static final int INDEX_BATCH_SIZE = 100;
+
+    private final Whelk source;
+    private final Whelk dest;
+    private final List<String> recordIds;
+    private final boolean copyVersions;
+    private final boolean includeItems;
+    private final boolean overwriteExisting;
+
+    private int copied = 0;
+    private int copiedVersions = 0;
+    private int overwritten = 0;
+    private int failed = 0;
+    private final TreeSet<String> seenIds = new TreeSet<>();
+    private final TreeSet<String> copiedIds = new TreeSet<>();
+    private final List<String> skippedRecordIds = new ArrayList<>();
+
+    public RecordCopier(Whelk source, Whelk dest, List<String> recordIds,
+                        boolean copyVersions, boolean includeItems, boolean overwriteExisting) {
+        this.source = source;
+        this.dest = dest;
+        this.recordIds = recordIds;
+        this.copyVersions = copyVersions;
+        this.includeItems = includeItems;
+        this.overwriteExisting = overwriteExisting;
+
+        dest.getStorage().setDoVerifyDocumentIdRetention(false);
+    }
+
+    public void run() {
+        for (String id : recordIds) {
+            Document doc = loadDocument(id);
+            if (doc == null) {
+                System.err.println("Could not load document with ID: " + id);
+                skippedRecordIds.add(id);
+                continue;
+            }
+            doc.setBaseUri(source.getBaseUri());
+
+            String shortId = doc.getShortId();
+
+            // If this record is already in the destination, either overwrite its contents
+            // with the source version and carry on copying deps, or (default)
+            // skip it and its deps entirely.
+            if (dest.getDocument(shortId) != null) {
+                if (!overwriteExisting) {
+                    System.err.println("Skipping " + id + ", already present in the destination.");
+                    skippedRecordIds.add(id);
+                    continue;
+                }
+                if (!overwrite(doc)) {
+                    skippedRecordIds.add(id);
+                    continue;
+                }
+                overwritten++;
+                // The record itself is now handled; copy() must not touch it again. Its link
+                // deps are still copied below (new deps get added as usual).
+                seenIds.add(shortId);
+            }
+
+            String dependenciesWhere =
+                    "id in (select dependsonid from lddb__dependencies where id = '" + shortId + "')";
+
+            String dependersWhere = includeItems
+                    ? "id in (select id from lddb__dependencies where dependsonid = '" + shortId + "')"
+                    : "id in (select id from lddb__dependencies where dependsonid = '" + shortId
+                            + "' and relation != 'itemOf')";
+
+            List<Document> dependencies = selectBySqlWhere(dependenciesWhere);
+            List<Document> dependers = selectBySqlWhere(dependersWhere);
+
+            System.err.println(shortId + ": " + dependencies.size() + " dependencies; "
+                + dependers.size() + " dependers");
+
+            for (Document relDoc : dependencies) {
+                copy(relDoc, false);
+            }
+
+            // The record itself. Copied after its dependencies so that links
+            // resolve, and always with versions if --copy-versions is set.
+            copy(doc, copyVersions);
+
+            for (Document revDoc : dependers) {
+                copy(revDoc, false);
+            }
+        }
+
+        reDenormalizeCopied();
+        index();
+
+        if (copyVersions) {
+            System.err.println("Copied " + copied + " documents (from " + recordIds.size() + " selected), "
+                    + "including " + copiedVersions + " historical versions.");
+        } else {
+            System.err.println("Copied " + copied + " documents (from " + recordIds.size() + " selected).");
+        }
+        if (overwritten > 0) {
+            System.err.println("Overwrote " + overwritten + " already-present records.");
+        }
+        if (!skippedRecordIds.isEmpty()) {
+            System.err.println("Skipped " + skippedRecordIds.size() + " of the selected records "
+                    + "(already present or not loadable): " + String.join(", ", skippedRecordIds));
+        }
+        if (failed > 0) {
+            System.err.println("Skipped " + failed + " linked documents that could not be written "
+                    + "(they most likely already exist in the destination).");
+        }
+    }
+
+    private Document loadDocument(String id) {
+        return id.contains("/")
+                ? source.getStorage().getDocumentByIri(id)
+                : source.getDocument(id);
+    }
+
+    /**
+     * Copy a document, unless it is deleted or has already been copied.
+     * Versions are only copied for the explicitly named records.
+     */
+    private void copy(Document doc, boolean withVersions) {
+        if (doc.getDeleted()) {
+            return;
+        }
+        doc.setBaseUri(source.getBaseUri());
+        if (!seenIds.add(doc.getShortId())) {
+            return;
+        }
+
+        if (!save(doc)) {
+            failed++;
+            return;
+        }
+        copiedIds.add(doc.getShortId());
+        copied++;
+
+        if (withVersions) {
+            copyVersionsOf(doc.getShortId());
+        }
+    }
+
+    /**
+     * Replace an already-existing destination record's contents with the source version,
+     * via an atomic update. Unlike copy(), this does not reconstruct the record's version
+     * history (the update writes a single new version entry), so --copy-versions has no
+     * effect on records that are overwritten.
+     *
+     * @return true if the record was updated.
+     */
+    private boolean overwrite(Document doc) {
+        Document newDoc = rewriteToDest(doc);
+        if (newDoc == null) {
+            return false;
+        }
+        String shortId = newDoc.getShortId();
+        try {
+            // writeIdenticalVersions=true so that overwriting an identical record still
+            // applies (and reindexes) rather than being cancelled as a no-op.
+            boolean updated = dest.storeAtomicUpdate(shortId, false, true, true, "xl", "RecordCopier",
+                    (Document existing) -> existing.data = newDoc.data);
+            if (!updated) {
+                System.err.println("Could not overwrite " + shortId + " (no update was applied).");
+                return false;
+            }
+        } catch (Exception e) {
+            System.err.println("Could not overwrite " + shortId + " due to: " + e);
+            return false;
+        }
+        // storeAtomicUpdate already reindexed this record; no need to add it to copiedIds.
+        return true;
+    }
+
+    private void copyVersionsOf(String shortId) {
+        List<DocumentVersion> history = source.getStorage().loadDocumentHistory(shortId);
+        for (int i = 0; i < history.size(); i++) {
+            // Skip the first (latest) version, it was added by quickCreateDocument above.
+            if (i == 0) {
+                continue;
+            }
+            DocumentVersion docVersion = history.get(i);
+            docVersion.doc.setBaseUri(source.getBaseUri());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = docVersion.doc.data;
+            data.put("_isVersion", true);
+            data.put("_changedBy", docVersion.changedBy);
+            data.put("_changedIn", docVersion.changedIn);
+            save(docVersion.doc);
+            copiedVersions++;
+        }
+    }
+
+    private List<Document> selectBySqlWhere(String whereClause) {
+        String query = """
+                SELECT id, data, created, modified, deleted
+                FROM lddb
+                WHERE %s
+                """.formatted(whereClause);
+
+        List<Document> docs = new ArrayList<>();
+        try (Connection conn = source.getStorage().getOuterConnection()) {
+            conn.setAutoCommit(false);
+            PreparedStatement stmt = conn.prepareStatement(query);
+            stmt.setFetchSize(FETCH_SIZE);
+            ResultSet rs = stmt.executeQuery();
+            for (Document doc : PostgreSQLComponent.iterateDocuments(rs)) {
+                docs.add(doc);
+            }
+        } catch (java.sql.SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return docs;
+    }
+
+    private Document rewriteToDest(Document doc) {
+        String libUriPlaceholder = "___TEMP_HARDCODED_LIB_BASEURI";
+        URI sourceBase = source.getBaseUri();
+        String libBase = sourceBase.resolve("library/").toString();
+
+        String newDataRepr = doc.getDataAsString().replaceAll( // Move all lib uris, to a temporary placeholder.
+                "\"\\Q" + libBase + "\\E",
+                "\"" + libUriPlaceholder);
+        newDataRepr = newDataRepr.replaceAll( // Replace all other baseURIs
+                "\"\\Q" + sourceBase + "\\E",
+                "\"" + dest.getBaseUri());
+        newDataRepr = newDataRepr.replaceAll( // Move the hardcoded lib uris back
+                "\"\\Q" + libUriPlaceholder + "\\E",
+                "\"" + libBase);
+
+        Document newDoc;
+        try {
+            newDoc = new Document(mapper.readValue(newDataRepr, Map.class));
+        } catch (Exception e) {
+            System.err.println("Could not parse " + doc.getShortId() + " due to: " + e);
+            return null;
+        }
+        newDoc.setId(dest.getBaseUri().resolve(doc.getShortId()).toString());
+        return newDoc;
+    }
+
+    private boolean save(Document doc) {
+        Document newDoc = rewriteToDest(doc);
+        if (newDoc == null) {
+            return false;
+        }
+
+        String collection = LegacyIntegrationTools.determineLegacyCollection(newDoc, dest.getJsonld());
+        if ("definitions".equals(collection)) {
+            System.err.println("Collection could not be determined for id " + newDoc.getShortId()
+                    + ", document will not be copied.");
+            return false;
+        }
+
+        try {
+            if (Boolean.TRUE.equals(doc.data.get("_isVersion"))) {
+                Date created = Date.from((Instant) doc.getCreatedTimestamp());
+                Date modified = Date.from((Instant) doc.getModifiedTimestamp());
+                String changedIn = (String) doc.data.get("_changedIn");
+                String changedBy = (String) doc.data.get("_changedBy");
+                return dest.quickCreateDocumentVersion(newDoc, created, modified, changedIn, changedBy, collection);
+            }
+            return dest.quickCreateDocument(newDoc, "xl", "RecordCopier", collection);
+        } catch (Exception e) {
+            System.err.println("Could not save " + doc.getShortId() + " due to: " + e);
+            return false;
+        }
+    }
+
+    /**
+     * Refresh the derivative tables for the copied. WhelkCopier() does storage.reDenormalize()
+     * but we don't want to do that for the *entire* database here.
+     */
+    private void reDenormalizeCopied() {
+        System.err.println("Re-denormalizing " + copiedIds.size() + " copied documents.");
+        for (Document doc : dest.bulkLoad(copiedIds).values()) {
+            dest.getStorage().refreshDerivativeTables(doc, true);
+        }
+    }
+
+    private void index() {
+        System.err.println("Indexing " + copiedIds.size() + " documents.");
+        List<String> batch = new ArrayList<>(INDEX_BATCH_SIZE);
+        for (String id : copiedIds) {
+            batch.add(id);
+            if (batch.size() == INDEX_BATCH_SIZE) {
+                dest.elastic.bulkIndexWithRetry(batch, dest);
+                batch = new ArrayList<>(INDEX_BATCH_SIZE);
+            }
+        }
+        if (!batch.isEmpty()) {
+            dest.elastic.bulkIndexWithRetry(batch, dest);
+        }
+    }
+}


### PR DESCRIPTION
Something I've wanted for a _long_ time but couldn't be bothered with until now.

To import sample records to a dev db we've only had the importer tool's `copywhelk` command, which takes a file with a list of IDs (and optionally a list of types to copy). This is mainly intended for the initial run when (re)creating a dev db. `copywhelk` redenormalizes the entire db and doesn't reindex on its own.

The use case this PR solves is: "I have an existing dev database and I just want to quickly import one or a few specific records and their dependencies/dependers from the prod db (and redenormalize+index only what's necessary)". Et voilà:

```bash
cd importers/
../gradlew jar
```
To import a couple of records by short ID, including their version history and holdings (if any):
`java -Dxl.secret.properties=../secret.properties -jar build/libs/xlimporter.jar copyRecords --copy-versions --include-items ../temp_source_secret.properties 4ngh2qhg49jhnp4 vhsxx8rks82lgtn5`

By IRI:
`java -Dxl.secret.properties=../secret.properties -jar build/libs/xlimporter.jar copyRecords --copy-versions --include-items ../temp_source_secret.properties https://libris.kb.se/4ngh2qhg49jhnp4`

Where `temp_source_secret.properties` contains the details for the source database (e.g. qa/stg/prod readonly...). Just like with `copywhelk`.

`--overwrite-existing` can also be specified. In that case the specified record will be _updated_ with the contents of the source version (but then version history is not copied).