### PR TITLE
fix(search2): Fix NPE in PostFilterTree

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
+++ b/whelk-core/src/main/groovy/whelk/search2/querytree/EsQueryTree.java
@@ -191,7 +191,11 @@ public class EsQueryTree {
             List<List<Node>> multiSelectGroups = selectedFacets.getAllMultiOrRadioSelected()
                     .values()
                     .stream()
-                    .map(origSelected -> origSelected.stream().map(eqt.nodeMap()::get).toList())
+                    .map(origSelected -> origSelected.stream()
+                            .map(eqt.nodeMap()::get)
+                            .filter(Objects::nonNull)
+                            .toList())
+                    .filter(Predicate.not(List::isEmpty))
                     .toList();
 
             if (multiSelectGroups.isEmpty()) {


### PR DESCRIPTION
I noticed that some search2 requests would NPE:
```
java.lang.NullPointerException: Cannot invoke "whelk.search2.querytree.Node.allDescendants()" because "node" is null
  at whelk.search2.querytree.EsQueryTree.flattenedConditions(EsQueryTree.java:231) ~[rest.jar:?]
  at whelk.search2.querytree.EsQueryTree$PostFilterTree.from(EsQueryTree.java:208) ~[rest.jar:?]
  at whelk.search2.querytree.EsQueryTree.<init>(EsQueryTree.java:36) ~[rest.jar:?]
  at whelk.search2.Query.doGetEsQuery(Query.java:148) ~[rest.jar:?]
  at whelk.search2.Query.getEsQuery(Query.java:344) ~[rest.jar:?]
  at whelk.search2.Query.getQueryResult(Query.java:176) ~[rest.jar:?]
  at whelk.search2.Query.getPartialCollectionView(Query.java:219) ~[rest.jar:?]
  at whelk.search2.Query.collectResults(Query.java:119) ~[rest.jar:?]
  at whelk.rest.api.SearchUtils2.doSearch(SearchUtils2.java:41) ~[rest.jar:?]
  at whelk.rest.api.SiteSearch.findData(SiteSearch.java:146) ~[rest.jar:?]
  at whelk.rest.api.Crud.handleQuery(Crud.java:155) ~[rest.jar:?]
  at whelk.rest.api.Crud.doGet2(Crud.java:133) ~[rest.jar:?]
  at whelk.rest.api.Crud.doGet(Crud.java:113) ~[rest.jar:?]
```
e.g. `https://libris.kb.se/find.jsonld?_q=contributor%3A%22libris%3Ahftwxkx10q8ndd8%23it%22+contributor%3A%22libris%3A1zcff5tk4xvtrpw%23it%22+yearPublished%3A1937+bibliography%3A%22libris%3Alibrary%2FNB%22+bibliography%3A%22libris%3Alibrary%2FSHB%22+bibliography%3A%22libris%3Alibrary%2FNLT%22+language%3A%22lang%3Aswe%22+(library%3A%22libris%3Alibrary%2Forg%2FCTHB%22+OR+library%3A%22libris%3Alibrary%2Forg%2FBTH%22+OR+library%3A%22libris%3Alibrary%2Forg%2F3P%22+OR+library%3A%22libris%3Alibrary%2Forg%2F2K%22+OR+library%3A%22libris%3Alibrary%2Forg%2FARKM%22)&_r=itemHeldByOrg%3AARKM&_stats=true&_limit=0`

It took a moment to debug because it was dependent on what ended up being `activeSite`, i.e., what `getAndIndexDescription` would load.

Adding `&_site=https://id.kb.se/` makes it use the minimal configuration and then it works:

`https://libris.kb.se/find.jsonld?_q=contributor%3A%22libris%3Ahftwxkx10q8ndd8%23it%22+contributor%3A%22libris%3A1zcff5tk4xvtrpw%23it%22+yearPublished%3A1937+bibliography%3A%22libris%3Alibrary%2FNB%22+bibliography%3A%22libris%3Alibrary%2FSHB%22+bibliography%3A%22libris%3Alibrary%2FNLT%22+language%3A%22lang%3Aswe%22+(library%3A%22libris%3Alibrary%2Forg%2FCTHB%22+OR+library%3A%22libris%3Alibrary%2Forg%2FBTH%22+OR+library%3A%22libris%3Alibrary%2Forg%2F3P%22+OR+library%3A%22libris%3Alibrary%2Forg%2F2K%22+OR+library%3A%22libris%3Alibrary%2Forg%2FARKM%22)&_r=itemHeldByOrg%3AARKM&_stats=true&_limit=0&_site=https://id.kb.se/`

The error appears to happen when there's a multi-select library `OR` group _and_ an `_r` filter _and_ having `_r` equal to one of the values in the `OR` group (in this case ARKM). `getFullQueryTree` collapses the equal nodes but in `PostFilterTree` it's assumed that both are still around.