### PR TITLE
fix(rest): SearchUtils: don't NPE on unknown field in chained matches query

### DIFF
--- a/rest/src/main/groovy/whelk/rest/api/SearchUtils.java
+++ b/rest/src/main/groovy/whelk/rest/api/SearchUtils.java
@@ -670,13 +670,15 @@ public class SearchUtils {
                 }
                 String label = String.join(" ", parts);
 
-                if (matchesTerm) {
+                if (matchesTerm && !chain.isEmpty()) {
                     Object proptype = chain.getLast().get(JsonLd.TYPE_KEY);
                     List<String> proptypes;
                     if (proptype instanceof String) {
                         proptypes = List.of((String) proptype);
-                    } else {
+                    } else if (proptype instanceof List) {
                         proptypes = (List<String>) proptype;
+                    } else {
+                        proptypes = List.of();
                     }
                     boolean anyObjectProperty = proptypes.stream().anyMatch(pt -> ld.isSubClassOf(pt, "ObjectProperty"));
                     if (anyObjectProperty) {


### PR DESCRIPTION
Currently:
https://libris.kb.se/find.jsonld?matches-nonexistent=dfsdf => 200
https://libris.kb.se/find.jsonld?matches-nonexistent.foo=dfsdf => 500:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "proptypes" is null
	at whelk.rest.api.SearchUtils$Lookup.chip(SearchUtils.java:681) ~[rest.jar:?]
	at whelk.rest.api.SearchUtils.mapParams(SearchUtils.java:957) ~[rest.jar:?]
	at whelk.rest.api.SearchUtils.queryElasticSearch(SearchUtils.java:165) ~[rest.jar:?]
	at whelk.rest.api.SearchUtils.doSearch(SearchUtils.java:114) ~[rest.jar:?]
	at whelk.rest.api.SiteSearch.findData(SiteSearch.java:151) ~[rest.jar:?]
	at whelk.rest.api.Crud.handleQuery(Crud.java:155) ~[rest.jar:?]
	at whelk.rest.api.Crud.doGet2(Crud.java:133) ~[rest.jar:?]
	at whelk.rest.api.Crud.doGet(Crud.java:113) ~[rest.jar:?]
	at whelk.util.http.WhelkHttpServlet.service(WhelkHttpServlet.java:42) ~[rest.jar:?]
```
So let's guard against that.