### PR TITLE
Use just Instance type for versionOfResource

### DIFF
--- a/whelk-core/src/main/resources/ext/marcframe.json
+++ b/whelk-core/src/main/resources/ext/marcframe.json
@@ -20583,7 +20583,7 @@
       },
       "match": [
         {"when": "i2=0", "addLink": "associatedMedia", "resourceType": "MediaObject"},
-        {"when": "i2=1", "addLink": "marc:versionOfResource", "resourceType": "Electronic"},
+        {"when": "i2=1", "addLink": "marc:versionOfResource", "resourceType": "Instance"},
         {"when": "i2=2", "addLink": "isPrimaryTopicOf", "resourceType": "Document"},
         {"when": "i2=8", "addLink": "relatedTo", "resourceType": "Document"}
       ],
@@ -20684,7 +20684,7 @@
             ]}},
           "result": {"mainEntity": {
             "marc:versionOfResource": [{
-              "@type": "Electronic",
+              "@type": "Instance",
               "marc:publicNote": ["Tidskriftens webbplats"],
               "uri": ["http://www.vr.se/tvarsnitt"]
             }]


### PR DESCRIPTION
These are reasonably all DigitalResource, but 856 is also used in holdings (where no type-denormalization is currently done).

In practise, need to revise the model to what is actually intended, update records, and *then* handle the outcome to get/send required MARC21 (as minimal as possible; ideally with less variation of 856 i2).

So this change simply ensures that the current data (which varies in precision) is properly reverted. It could be followed by a global change (in all bib and hold records where this relation is used), setting the proper relationship along with a more precise type (DigitalResource), and *then* mapped to that in marcframe.