### PR TITLE
chore: upgrade apache-jena from 3.0.1 to 6.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ systemProp.https.protocols=TLSv1.1,TLSv1.2
 guavaVersion=33.6.0-jre
 jacocoVersion=0.8.13
 jacksonVersion=2.21.5
+jenaVersion=6.2.0

--- a/housekeeping/src/main/resources/wikidatalinking.groovy
+++ b/housekeeping/src/main/resources/wikidatalinking.groovy
@@ -5,7 +5,6 @@
 import org.apache.jena.query.ARQ
 import org.apache.jena.query.ParameterizedSparqlString
 import org.apache.jena.query.QueryExecution
-import org.apache.jena.query.QueryExecutionFactory
 import org.apache.jena.query.QuerySolution
 import org.apache.jena.query.ResultSet
 import org.apache.jena.query.ResultSetFactory
@@ -213,7 +212,7 @@ ResultSet runQuery(String command, List values = null) {
         paramString.setParam(i, v)
     }
 
-    QueryExecution qExec = QueryExecutionFactory.sparqlService("https://query.wikidata.org/sparql", paramString.asQuery())
+    QueryExecution qExec = QueryExecution.service("https://query.wikidata.org/sparql", paramString.asQuery())
 
     ResultSet resultSet
 

--- a/whelk-core/build.gradle
+++ b/whelk-core/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     api 'commons-io:commons-io:2.20.0'
     implementation "org.apache.httpcomponents.client5:httpclient5:${httpComponentsClientVersion}"
     implementation "org.apache.httpcomponents.core5:httpcore5:${httpComponentsCoreVersion}"
-    api 'org.apache.jena:apache-jena-libs:3.0.1'
+    api "org.apache.jena:apache-jena-libs:${jenaVersion}"
     api "org.apache.groovy:groovy-json:${groovyVersion}"
     api "org.apache.groovy:groovy-xml:${groovyVersion}"
     api "org.apache.groovy:groovy-yaml:${groovyVersion}"

--- a/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
+++ b/whelk-core/src/main/groovy/whelk/JsonLdValidator.groovy
@@ -1,9 +1,8 @@
 package whelk
 
-import org.apache.jena.iri.IRI
-import org.apache.jena.iri.IRIFactory
 import com.google.common.base.Preconditions
 import whelk.util.DocumentUtil
+import whelk.util.Iris
 
 class JsonLdValidator {
     private static JsonLd jsonLd
@@ -15,8 +14,6 @@ class JsonLdValidator {
             'hold': Validation.Scope.HOLD,
     ]
     private Set langAliases
-    
-    static IRIFactory iriFactory = IRIFactory.iriImplementation()
     
     private JsonLdValidator(JsonLd jsonLd) {
         this.jsonLd = jsonLd
@@ -232,8 +229,7 @@ class JsonLdValidator {
 
     private void validateId(String key, value, Validation validation) {
         if (key == jsonLd.ID_KEY) {
-            IRI iri = iriFactory.create(value)
-            if (iri.hasViolation(false)) {
+            if (Iris.isBroken(value as String)) {
                 handleError(new Error(Error.Type.INVALID_IRI, key, value), validation)
             }
         }

--- a/whelk-core/src/main/groovy/whelk/component/SparqlQueryClient.groovy
+++ b/whelk-core/src/main/groovy/whelk/component/SparqlQueryClient.groovy
@@ -3,7 +3,6 @@ package whelk.component
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j as Log
 import org.apache.jena.query.QueryExecution
-import org.apache.jena.query.QueryExecutionFactory
 import org.apache.jena.query.ResultSet
 import whelk.Document
 import whelk.JsonLd
@@ -48,9 +47,11 @@ class SparqlQueryClient {
 
         log.info(queryString)
 
-        QueryExecution qe = QueryExecutionFactory.sparqlService(sparqlEndpoint, queryString)
-        ResultSet res = qe.execSelect()
-        var ids = res.collect { it.get(GRAPH_VAR).toString() }
+        List<String> ids
+        try (QueryExecution qe = QueryExecution.service(sparqlEndpoint, queryString)) {
+            ResultSet res = qe.execSelect()
+            ids = res.collect { it.get(GRAPH_VAR).toString() }
+        }
 
         // for experimenting without a local Virtuoso installation
         if ("true" == System.getProperty("xl.test.rewriteSparqlResultIds")) {

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLD2N3Converter.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLD2N3Converter.groovy
@@ -3,7 +3,7 @@ package whelk.converter
 import org.apache.commons.io.IOUtils
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.rdf.model.RDFWriter
+import org.apache.jena.rdf.model.RDFWriterI
 import whelk.Document
 import whelk.JsonLd
 import whelk.Whelk
@@ -34,7 +34,7 @@ class JsonLD2N3Converter implements FormatConverter {
         Model model = ModelFactory.createDefaultModel()
         ByteArrayOutputStream baos = new ByteArrayOutputStream()
         model = model.read(input, Document.BASE_URI.toString(), "JSONLD")
-        RDFWriter writer = model.getWriter("N3")
+        RDFWriterI writer = model.getWriter("N3")
         writer.setProperty("allowBadURIs","true")
         writer.write(model, baos, "")
 

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTrigSerializer.groovy
@@ -2,9 +2,7 @@ package whelk.converter
 
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j as Log
-
-import org.apache.jena.iri.IRI
-import org.apache.jena.iri.IRIFactory
+import whelk.util.Iris
 
 import trld.platform.Output
 import trld.trig.SerializerState
@@ -56,8 +54,6 @@ class JsonLdToTrigSerializer {
 @InheritConstructors
 class CleanedTrigSerializerState extends SerializerState {
 
-    static IRIFactory iriFactory = IRIFactory.iriImplementation()
-
     // TODO: We need to fix these when ENTERING the system (Validation/Normalization)!
     String refRepr(Object refobj) {
         if (refobj !instanceof String) {
@@ -79,13 +75,12 @@ class CleanedTrigSerializerState extends SerializerState {
 
         // Now catch things that are too broken to sensibly do anything about, e.g.,
         // "http://foo:", http://", etc.
-        IRI iri = iriFactory.create(cleanedIriString)
-        if (iri.hasViolation(false)) { // false = ignore warnings, care only about errors
+        if (Iris.isBroken(cleanedIriString)) {
             cleanedIriString = "https://BROKEN-IRI/"
         }
 
         if (cleanedIriString != iriString) {
-            log.warn("Broken IRI ${iri}, changing to ${cleanedIriString}")
+            log.warn("Broken IRI ${iriString}, changing to ${cleanedIriString}")
         }
         return super.refRepr(cleanedIriString)
     }

--- a/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/JsonLdToTurtle.groovy
@@ -1,8 +1,7 @@
 package whelk.converter
 
 import groovy.util.logging.Slf4j as Log
-import org.apache.jena.iri.IRI
-import org.apache.jena.iri.IRIFactory
+import whelk.util.Iris
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeJava
 import static whelk.util.Jackson.mapper
@@ -37,7 +36,6 @@ class JsonLdToTurtle {
     boolean useGraphKeyword
     boolean markEmptyBnode
     String emptyMarker = '_:Nothing'
-    static IRIFactory iriFactory = IRIFactory.iriImplementation()
 
     JsonLdToTurtle(Map context, OutputStream outStream, Map opts = null) {
         this(context, outStream, opts?.base, opts)
@@ -156,13 +154,12 @@ class JsonLdToTurtle {
 
         // Now catch things that are too broken to sensibly do anything about, e.g.,
         // "http://foo:", http://", etc.
-        IRI iri = iriFactory.create(cleanedIriString)
-        if (iri.hasViolation(false)) { // false = ignore warnings, care only about errors
+        if (Iris.isBroken(cleanedIriString)) {
             cleanedIriString = "https://BROKEN-IRI/"
         }
 
         if (cleanedIriString != iriString) {
-            log.warn("Broken IRI ${iri}, changing to ${cleanedIriString}")
+            log.warn("Broken IRI ${iriString}, changing to ${cleanedIriString}")
         }
         return cleanedIriString
     }

--- a/whelk-core/src/main/java/whelk/util/Iris.java
+++ b/whelk-core/src/main/java/whelk/util/Iris.java
@@ -1,0 +1,16 @@
+package whelk.util;
+
+import org.apache.jena.irix.IRIException;
+import org.apache.jena.irix.IRIx;
+
+public class Iris {
+    private Iris() {}
+
+    public static boolean isBroken(String iriString) {
+        try {
+            return IRIx.create(iriString).hasViolations();
+        } catch (IRIException e) {
+            return true;
+        }
+    }
+}

--- a/whelk-core/src/test/groovy/whelk/util/IrisSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/util/IrisSpec.groovy
@@ -1,0 +1,47 @@
+package whelk.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IrisSpec extends Specification {
+
+    @Unroll
+    def "usable IRI is not broken: #iri"() {
+        expect:
+        !Iris.isBroken(iri)
+
+        where:
+        iri << [
+                "https://libris.kb.se/abc123",
+                "https://id.kb.se/term/sao/Marsvin%20som%20s%C3%A4llskapsdjur",
+                "https://ja.wikipedia.org/wiki/モルモット",
+                "https://libris.kb.se/hold/123#it",
+                "urn:isbn:0451450523",
+                "mailto:foo@bar.com",
+                // relative IRIs are not rejected
+                "//foo",
+                "relative/path",
+        ]
+    }
+
+    @Unroll
+    def "broken IRI is detected: #iri"() {
+        expect:
+        Iris.isBroken(iri)
+
+        where:
+        iri << [
+                // IRIx.create() reports these as violations
+                "http://foo:",
+                "http://",
+                "HTTP://EXAMPLE.COM/Path",
+                "http://example.com:80/x",
+                "http://example.com/%7euser",
+                // ...and throws on these
+                "not a uri at all",
+                "https://example.com/ bar",
+                "[sfsdfsdf]",
+                "\"https://libris.kb.se/library/DIGI\"",
+        ]
+    }
+}


### PR DESCRIPTION
Noticed a warning in the logs:
```
java[287887]: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
java[287887]: WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.apache.jena.ext.com.google.common.cache.Striped64 (file:/srv/housekeeping.jar)
java[287887]: WARNING: Please consider reporting this to the maintainers of class org.apache.jena.ext.com.google.common.cache.Striped64
java[287887]: WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```
The version of Jena we used was more than a decade behind.

This upgrades to the latest. Just some small changes as things were removed or reshuffled in Jena over the years (https://github.com/apache/jena/blob/main/CHANGES.txt).