### PR TITLE
fix: newlines in lddb__profiles library_id

### DIFF
--- a/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
+++ b/importers/src/main/groovy/whelk/importer/DatasetImporter.groovy
@@ -101,6 +101,7 @@ class DatasetImporter {
                     sourceUrl = sourceRef[ID]
                 } else {
                     String sourcePath = asList(sourceRef['uri'])[0]
+                    log.info("loading {} {} {}", item, sourceBaseDir, sourcePath)
                     sourceUrl = new File(new File(sourceBaseDir), sourcePath).toString()
                 }
                 assert sourceUrl

--- a/librisxl-tools/scripts/update_export_profiles.sh
+++ b/librisxl-tools/scripts/update_export_profiles.sh
@@ -32,18 +32,22 @@ do
 
     for var in $sigel_list
     do
-        profile_no_ext=$(echo $var | cut -d'.' -f 1)
-        if [[ ${used_sigels[$profile_no_ext]} != used ]]; then
-            used_sigels[$profile_no_ext]="used"
-	    profile_uri="https://libris.kb.se/library/$profile_no_ext"
-            # This used to be the below line, but it is vulnerable to injection:
-	    # query="$query INSERT INTO lddb__profiles (library_id, profile) VALUES ('https://libris.kb.se/library/$profile_no_ext', '$data');"
-	    IFS=""
-	    query="$query INSERT INTO lddb__profiles (library_id, profile) VALUES (convert_from(decode( '$(echo $profile_uri | base64)', 'base64'), 'UTF8'), convert_from(decode( '$(echo $data | base64)', 'base64'), 'UTF8'));"
-	    IFS=$'\n'
-        fi
-    done
+      profile_no_ext=$(echo $var | cut -d'.' -f 1)
+      if [[ ${used_sigels[$profile_no_ext]} != used ]]; then
+        used_sigels[$profile_no_ext]="used"
 
+        profile_uri="https://libris.kb.se/library/$profile_no_ext"
+
+        IFS=""
+        # base64 to guard against injections. decode in postgres makes strings safe.
+        profile_uri_b64="$(echo $profile_uri | tr -d '\n' | base64)"
+        profile_b64="$(echo $data | base64)" # preserve newlines. additional newline at the end is ok
+
+        # shellcheck disable=SC2089
+        query="$query INSERT INTO lddb__profiles (library_id, profile) VALUES (convert_from(decode( '$profile_uri_b64', 'base64'), 'UTF8'), convert_from(decode( '$profile_b64', 'base64'), 'UTF8'));"
+        IFS=$'\n'
+      fi
+    done
 done
 
 popd

--- a/librisxl-tools/scripts/update_export_profiles.sh
+++ b/librisxl-tools/scripts/update_export_profiles.sh
@@ -44,7 +44,7 @@ do
         profile_b64="$(echo $data | base64)" # preserve newlines. additional newline at the end is ok
 
         # shellcheck disable=SC2089
-        query="$query INSERT INTO lddb__profiles (library_id, profile) VALUES (convert_from(decode( '$profile_uri_b64', 'base64'), 'UTF8'), convert_from(decode( '$profile_b64', 'base64'), 'UTF8'));"
+        query="$query INSERT INTO lddb__profiles (library_id, profile) VALUES (convert_from(decode('$profile_uri_b64', 'base64'), 'UTF8'), convert_from(decode('$profile_b64', 'base64'), 'UTF8'));"
         IFS=$'\n'
       fi
     done


### PR DESCRIPTION
lddb__profiles.library_id contained newlines which made _compilemarc always select the default export profile