### PR TITLE
fix(search2/lex): treat non-breaking space as whitespace

### DIFF
--- a/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
+++ b/whelk-core/src/main/groovy/whelk/search2/parse/Lex.java
@@ -42,10 +42,18 @@ public class Lex {
     }
 
     private static void consumeWhiteSpace(StringBuilder query, MutableInteger offset) {
-        while (!query.isEmpty() && Character.isWhitespace(query.charAt(0))) {
+        while (!query.isEmpty() && isWhitespace(query.charAt(0))) {
             query.deleteCharAt(0);
             offset.increase(1);
         }
+    }
+
+    private static boolean isWhitespace(char c) {
+        return Character.isWhitespace(c) || isNonBreakingSpace(c);
+    }
+
+    private static boolean isNonBreakingSpace(char c) {
+        return c == '\u00A0' || c == '\u2007' || c == '\u202F';
     }
 
     public static final List<Character> reservedCharsInString = Arrays.asList('<', '>', '=', '(', ')', ':', '~');
@@ -141,7 +149,7 @@ public class Lex {
                 } else {
                     query.deleteCharAt(0);
                     offset.increase(1);
-                    if (Character.isWhitespace(c))
+                    if (isWhitespace(c))
                         break;
                     symbolValue.append(c);
                     if (query.isEmpty())

--- a/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/search2/parse/LexSpec.groovy
@@ -227,4 +227,16 @@ class LexSpec extends Specification {
         ]
     }
 
+    def "nbsp is space"() {
+        given:
+        def input = "\u00A0AAA\u2007NOT\u202FBBB\u00A0"
+        def lexedSymbols = Lex.lexQuery(input)
+
+        expect:
+        lexedSymbols as List == [
+                new Lex.Symbol(Lex.TokenName.STRING, "AAA", 1),
+                new Lex.Symbol(Lex.TokenName.KEYWORD, "not", 5),
+                new Lex.Symbol(Lex.TokenName.STRING, "BBB", 9),
+        ]
+    }
 }


### PR DESCRIPTION
lxl-web / codemirror sometimes inserts U+00A0 in queries.
Breaks for example: " +\U+00A0NOT" becoming the string " NOT" instead of the keyword NOT.
It makes sense treating nbsp as whitespace anyway.