### PR TITLE
fix(converter/marc): denormalize: handle case where instanceOf is a list

### DIFF
--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -82,10 +82,11 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     }
 
     void denormalize(Map instance) {
-        def work = instance.get('instanceOf', [:]) // NOTE: *sets* default value
+        // NOTE: instanceOf may be a list of works; *sets* default value
+        var works = (List<Map>) asList(instance.get('instanceOf', [:]))
 
         // Pick out the categories:
-        var workCategories = getDescriptions(work.category)
+        var workCategories = (List<Map<String, Object>>) works.collectMany { getDescriptions(it.category) }
         var instanceCategories = getDescriptions(instance.category)
 
         // Stop processing if we already seem to have a legacy shape:
@@ -95,14 +96,14 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
 
         // Then remove from shape (*might* hurt to keep, since these are to be used in legacy form):
-        work.remove('category')
+        works.each { it.remove('category') }
         instance.remove('category')
 
         // Mutate into legacy form:
-        var wtype = (String) work[TYPE]
+        var wtypes = works.collect { it[TYPE] }
         var itype = (String) instance[TYPE]
-        def issuanceType = getIssuanceType(wtype, itype, workCategories, instanceCategories)
-        reshapeToLegacyWork(work, workCategories)
+        def issuanceType = getIssuanceType(wtypes, itype, workCategories, instanceCategories)
+        works.each { reshapeToLegacyWork(it, workCategories) }
         reshapeToLegacyInstance(instance, workCategories, instanceCategories)
         instance.issuanceType = issuanceType ?: 'Monograph'
 
@@ -114,10 +115,12 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
             }
         }
 
-        DocumentUtil.traverse(work) { value, path ->
-            if (!path.isEmpty()) {
-                if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
-                    reshapeToLegacyWork(value, getDescriptions(value.remove('category')))
+        works.each { w ->
+            DocumentUtil.traverse(w) { value, path ->
+                if (!path.isEmpty()) {
+                    if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
+                        reshapeToLegacyWork(value, getDescriptions(value.remove('category')))
+                    }
                 }
             }
         }
@@ -179,7 +182,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
     }
 
-    String getIssuanceType(String workType, String instanceType, List<Map> workCategories, List<Map> instanceCategories) {
+    String getIssuanceType(Object workType, String instanceType, List<Map> workCategories, List<Map> instanceCategories) {
         if (instanceCategories.any { it[ID] == componentPartCategory}) {
           return 'ComponentPart'
         }

--- a/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
+++ b/whelk-core/src/main/groovy/whelk/converter/marc/BibTypeNormalizationStep.groovy
@@ -82,11 +82,13 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
     }
 
     void denormalize(Map instance) {
-        // NOTE: instanceOf may be a list of works; *sets* default value
+        // NOTE: *sets* default value. instanceOf should be a single work, but
+        // malformed data may hold a list; use the first and ignore the rest.
         var works = (List<Map>) asList(instance.get('instanceOf', [:]))
+        Map work = works.isEmpty() ? [:] : works.first()
 
         // Pick out the categories:
-        var workCategories = (List<Map<String, Object>>) works.collectMany { getDescriptions(it.category) }
+        var workCategories = getDescriptions(work.category)
         var instanceCategories = getDescriptions(instance.category)
 
         // Stop processing if we already seem to have a legacy shape:
@@ -96,14 +98,14 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
 
         // Then remove from shape (*might* hurt to keep, since these are to be used in legacy form):
-        works.each { it.remove('category') }
+        work.remove('category')
         instance.remove('category')
 
         // Mutate into legacy form:
-        var wtypes = works.collect { it[TYPE] }
+        var wtype = (String) work[TYPE]
         var itype = (String) instance[TYPE]
-        def issuanceType = getIssuanceType(wtypes, itype, workCategories, instanceCategories)
-        works.each { reshapeToLegacyWork(it, workCategories) }
+        def issuanceType = getIssuanceType(wtype, itype, workCategories, instanceCategories)
+        reshapeToLegacyWork(work, workCategories)
         reshapeToLegacyInstance(instance, workCategories, instanceCategories)
         instance.issuanceType = issuanceType ?: 'Monograph'
 
@@ -115,12 +117,10 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
             }
         }
 
-        works.each { w ->
-            DocumentUtil.traverse(w) { value, path ->
-                if (!path.isEmpty()) {
-                    if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
-                        reshapeToLegacyWork(value, getDescriptions(value.remove('category')))
-                    }
+        DocumentUtil.traverse(work) { value, path ->
+            if (!path.isEmpty()) {
+                if (value instanceof Map && resourceCache.jsonld.isSubClassOf(getType(value), 'Work')) {
+                    reshapeToLegacyWork(value, getDescriptions(value.remove('category')))
                 }
             }
         }
@@ -182,7 +182,7 @@ class BibTypeNormalizationStep extends MarcFramePostProcStepBase {
         }
     }
 
-    String getIssuanceType(Object workType, String instanceType, List<Map> workCategories, List<Map> instanceCategories) {
+    String getIssuanceType(String workType, String instanceType, List<Map> workCategories, List<Map> instanceCategories) {
         if (instanceCategories.any { it[ID] == componentPartCategory}) {
           return 'ComponentPart'
         }

--- a/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
@@ -74,11 +74,17 @@ class BibTypeNormalizationStepSpec extends Specification {
       bibTypeNormalizationStep.denormalize(instance)
       then:
       noExceptionThrown()
-      and: 'both works are reshaped to legacy form'
-      instance.instanceOf.every { it.containsKey('contentType') && it.containsKey('genreForm') }
-      instance.instanceOf*.'@type' == ['Text', 'Text']
-      and: 'categories are removed and issuanceType set'
-      instance.instanceOf.every { !it.containsKey('category') }
+      and: 'only the first work is reshaped to legacy form; the rest are ignored'
+      instance.instanceOf[0].'@type' == 'Text'
+      instance.instanceOf[0].containsKey('contentType')
+      instance.instanceOf[0].containsKey('genreForm')
+      !instance.instanceOf[0].containsKey('category')
+      and: 'the second work is left untouched'
+      instance.instanceOf[1] == [
+        '@type': 'Work',
+        'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']],
+      ]
+      and: 'the instance itself is denormalized'
       !instance.containsKey('category')
       instance.issuanceType == 'Monograph'
   }

--- a/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
@@ -2,6 +2,9 @@ package whelk.converter.marc
 
 import spock.lang.Specification
 
+import whelk.JsonLd
+import whelk.ResourceCache
+
 class BibTypeNormalizationStepSpec extends Specification {
 
   static Map testCategories = [
@@ -11,6 +14,15 @@ class BibTypeNormalizationStepSpec extends Specification {
     '_:gf4': ['@id': '_:gf4', '@type': 'GenreForm', 'closeMatch': [['@id': '_:gf3']]],  // cycle!
     '_:gf5': ['@id': '_:gf5', '@type': 'GenreForm'],
   ]
+
+  // minimal vocab so the traversals in denormalize() can resolve Work/Instance
+  static Map VOCAB = ['@graph': [
+    ['@id': 'https://id.kb.se/vocab/Work', '@type': 'Class'],
+    ['@id': 'https://id.kb.se/vocab/Instance', '@type': 'Class'],
+    ['@id': 'https://id.kb.se/vocab/Monograph', '@type': 'Class',
+     'subClassOf': [['@id': 'https://id.kb.se/vocab/Work']]],
+  ]]
+  static Map CONTEXT = ['@context': ['@vocab': 'https://id.kb.se/vocab/']]
 
   // subclass to overcome too coupled components (JsonLd and ResourceCache)
   static var bibTypeNormalizationStep = new BibTypeNormalizationStep() {
@@ -23,6 +35,7 @@ class BibTypeNormalizationStepSpec extends Specification {
   }
 
   static {
+    bibTypeNormalizationStep.resourceCache = new ResourceCache(new JsonLd(CONTEXT, [:], VOCAB))
     bibTypeNormalizationStep.matchRelations = ['broader', 'closeMatch']
     bibTypeNormalizationStep.prioritizedWorkLegacyTypes = ['Multimedia', 'Text']
     bibTypeNormalizationStep.marcTypeMappings = [:]
@@ -42,5 +55,65 @@ class BibTypeNormalizationStepSpec extends Specification {
       impliedTypes == ['Text', 'Image'] as Set
       and:
       bibTypeNormalizationStep.getWorkType(workCategories) == 'Text'
+  }
+
+  def "should denormalize an instance with a list of works"() {
+      given:
+      def instance = [
+        '@type': 'Instance',
+        'category': [['@id': '_:gf5']],
+        'instanceOf': [
+          ['@type': 'Work',
+           'category': [['@id': '_:gf3']],
+           'hasTitle': [['@type': 'Title', 'mainTitle': 'Darth Bane series']]],
+          ['@type': 'Work',
+           'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']]],
+        ],
+      ]
+      when:
+      bibTypeNormalizationStep.denormalize(instance)
+      then:
+      noExceptionThrown()
+      and: 'both works are reshaped to legacy form'
+      instance.instanceOf.every { it.containsKey('contentType') && it.containsKey('genreForm') }
+      instance.instanceOf*.'@type' == ['Text', 'Text']
+      and: 'categories are removed and issuanceType set'
+      instance.instanceOf.every { !it.containsKey('category') }
+      !instance.containsKey('category')
+      instance.issuanceType == 'Monograph'
+  }
+
+  def "should denormalize a nested series instance whose works are a list"() {
+      given: 'the shape of libris.kb.se/n6jv280rl5s01mj6, where seriesMembership.inSeries has two works'
+      def inSeries = [
+        '@type': 'Instance',
+        'instanceOf': [
+          ['@type': 'Work',
+           'hasTitle': [['@type': 'Title', 'mainTitle': 'Darth Bane series']],
+           'contribution': [['@type': 'PrimaryContribution',
+                             'agent': ['@type': 'Person',
+                                       'givenName': 'Drew.',
+                                       'familyName': 'Karpyshyn']]]],
+          ['@type': 'Work',
+           'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']]],
+        ],
+      ]
+      def instance = [
+        '@type': 'Instance',
+        'category': [['@id': '_:gf5']],
+        'instanceOf': ['@type': 'Work', 'category': [['@id': '_:gf3']]],
+        'seriesMembership': [
+          ['@type': 'SeriesMembership', 'inSeries': inSeries, 'seriesEnumeration': '1.'],
+        ],
+      ]
+      when:
+      bibTypeNormalizationStep.denormalize(instance)
+      then:
+      noExceptionThrown()
+      and: 'the nested instance has no categories, so it is left as it was'
+      inSeries['@type'] == 'Instance'
+      inSeries.instanceOf.size() == 2
+      inSeries.instanceOf*.'@type' == ['Work', 'Work']
+      !inSeries.containsKey('issuanceType')
   }
 }

--- a/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
+++ b/whelk-core/src/test/groovy/whelk/converter/marc/BibTypeNormalizationStepSpec.groovy
@@ -2,9 +2,6 @@ package whelk.converter.marc
 
 import spock.lang.Specification
 
-import whelk.JsonLd
-import whelk.ResourceCache
-
 class BibTypeNormalizationStepSpec extends Specification {
 
   static Map testCategories = [
@@ -14,15 +11,6 @@ class BibTypeNormalizationStepSpec extends Specification {
     '_:gf4': ['@id': '_:gf4', '@type': 'GenreForm', 'closeMatch': [['@id': '_:gf3']]],  // cycle!
     '_:gf5': ['@id': '_:gf5', '@type': 'GenreForm'],
   ]
-
-  // minimal vocab so the traversals in denormalize() can resolve Work/Instance
-  static Map VOCAB = ['@graph': [
-    ['@id': 'https://id.kb.se/vocab/Work', '@type': 'Class'],
-    ['@id': 'https://id.kb.se/vocab/Instance', '@type': 'Class'],
-    ['@id': 'https://id.kb.se/vocab/Monograph', '@type': 'Class',
-     'subClassOf': [['@id': 'https://id.kb.se/vocab/Work']]],
-  ]]
-  static Map CONTEXT = ['@context': ['@vocab': 'https://id.kb.se/vocab/']]
 
   // subclass to overcome too coupled components (JsonLd and ResourceCache)
   static var bibTypeNormalizationStep = new BibTypeNormalizationStep() {
@@ -35,7 +23,6 @@ class BibTypeNormalizationStepSpec extends Specification {
   }
 
   static {
-    bibTypeNormalizationStep.resourceCache = new ResourceCache(new JsonLd(CONTEXT, [:], VOCAB))
     bibTypeNormalizationStep.matchRelations = ['broader', 'closeMatch']
     bibTypeNormalizationStep.prioritizedWorkLegacyTypes = ['Multimedia', 'Text']
     bibTypeNormalizationStep.marcTypeMappings = [:]
@@ -55,71 +42,5 @@ class BibTypeNormalizationStepSpec extends Specification {
       impliedTypes == ['Text', 'Image'] as Set
       and:
       bibTypeNormalizationStep.getWorkType(workCategories) == 'Text'
-  }
-
-  def "should denormalize an instance with a list of works"() {
-      given:
-      def instance = [
-        '@type': 'Instance',
-        'category': [['@id': '_:gf5']],
-        'instanceOf': [
-          ['@type': 'Work',
-           'category': [['@id': '_:gf3']],
-           'hasTitle': [['@type': 'Title', 'mainTitle': 'Darth Bane series']]],
-          ['@type': 'Work',
-           'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']]],
-        ],
-      ]
-      when:
-      bibTypeNormalizationStep.denormalize(instance)
-      then:
-      noExceptionThrown()
-      and: 'only the first work is reshaped to legacy form; the rest are ignored'
-      instance.instanceOf[0].'@type' == 'Text'
-      instance.instanceOf[0].containsKey('contentType')
-      instance.instanceOf[0].containsKey('genreForm')
-      !instance.instanceOf[0].containsKey('category')
-      and: 'the second work is left untouched'
-      instance.instanceOf[1] == [
-        '@type': 'Work',
-        'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']],
-      ]
-      and: 'the instance itself is denormalized'
-      !instance.containsKey('category')
-      instance.issuanceType == 'Monograph'
-  }
-
-  def "should denormalize a nested series instance whose works are a list"() {
-      given: 'the shape of libris.kb.se/n6jv280rl5s01mj6, where seriesMembership.inSeries has two works'
-      def inSeries = [
-        '@type': 'Instance',
-        'instanceOf': [
-          ['@type': 'Work',
-           'hasTitle': [['@type': 'Title', 'mainTitle': 'Darth Bane series']],
-           'contribution': [['@type': 'PrimaryContribution',
-                             'agent': ['@type': 'Person',
-                                       'givenName': 'Drew.',
-                                       'familyName': 'Karpyshyn']]]],
-          ['@type': 'Work',
-           'hasTitle': [['@type': 'Title', 'mainTitle': 'Star wars']]],
-        ],
-      ]
-      def instance = [
-        '@type': 'Instance',
-        'category': [['@id': '_:gf5']],
-        'instanceOf': ['@type': 'Work', 'category': [['@id': '_:gf3']]],
-        'seriesMembership': [
-          ['@type': 'SeriesMembership', 'inSeries': inSeries, 'seriesEnumeration': '1.'],
-        ],
-      ]
-      when:
-      bibTypeNormalizationStep.denormalize(instance)
-      then:
-      noExceptionThrown()
-      and: 'the nested instance has no categories, so it is left as it was'
-      inSeries['@type'] == 'Instance'
-      inSeries.instanceOf.size() == 2
-      inSeries.instanceOf*.'@type' == ['Work', 'Work']
-      !inSeries.containsKey('issuanceType')
   }
 }


### PR DESCRIPTION
https://libris-qa.kb.se/xsearch?query=ISXN:9781529150391 => 500
```
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '[{@type=Work, hasTitle=[{@type=Title, mainTitle=Darth Bane series}], contribution=[{@type=PrimaryContribution, agent={@type=Person, givenName=Drew., familyName=Karpyshyn}}]}, {@type=Work, hasTitle=[{@type=Title, mainTitle=Star wars}]}]' with class 'java.util.ArrayList' to class 'java.util.LinkedHashMap' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.util.LinkedHashMap(LinkedHashMap, LinkedHashMap)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:413)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:326)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:244)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at whelk.converter.marc.BibTypeNormalizationStep.denormalize(BibTypeNormalizationStep.groovy:85)
```
because instanceOf is assumed to be a Map, but in some (b0rked) records this is not always so: in https://libris-qa.kb.se/n6jv280rl5s01mj6/data.jsonld `seriesMembership[2].inSeries.instanceOf` is a list.

So in the presumably few broken cases where instanceOf is a list, just get the first element.